### PR TITLE
[#1] Draft ADR-001: project foundation and v0.1 scope

### DIFF
--- a/docs/adr/001-project-foundation.md
+++ b/docs/adr/001-project-foundation.md
@@ -59,6 +59,11 @@ We adopt the following project foundation for v0.1:
 - v0.1 will be intentionally narrow and may skip many days.
 - Some potentially predictive signals are deferred to later versions.
 
+## Disclaimer
+> 본 프로젝트는 연구 및 교육 목적의 실험 도구이며, 투자 권유 또는 금융 자문이 아닙니다.
+>
+> This project is an experimental research and educational tool. It is not investment advice or financial advisory.
+
 ## Related
 - `docs/spec.md`
 - `apps/kr-kospi/config/agents.yaml`

--- a/docs/adr/001-project-foundation.md
+++ b/docs/adr/001-project-foundation.md
@@ -1,0 +1,65 @@
+# ADR-001: Project Foundation and v0.1 Scope
+
+## Status
+Accepted
+
+## Date
+2026-04-26
+
+## Context
+`kospi-decision-pipeline` is a public, deterministic decision pipeline for next-day KOSPI direction built only from Korean public data. The project must remain auditable, reproducible, and explicit about its scope boundaries because financial-domain tools are especially vulnerable to hidden leakage, undocumented heuristics, and accidental scope creep.
+
+The repository is being created as a new public Apache-2.0 project under `kpubdata-lab`. It should follow the organization's public-data-first convention and reuse established packaging/CI patterns where they reduce maintenance cost.
+
+## Decision
+We adopt the following project foundation for v0.1:
+
+1. **Purpose**
+   - Produce a deterministic next-day KOSPI directional decision from domestic public data.
+   - The model output label set is **`up | down | skip` only**.
+
+2. **Ground truth**
+   - Ground-truth labels may use **`up | down | flat`** for backtesting only.
+   - `flat` is not a model output in v0.1.
+
+3. **Data principle**
+   - The project is **public-data-first**.
+   - v0.1 uses only domestic public data sources such as KRX, ECOS, KOSIS, and 공공데이터포털-derived inputs.
+
+4. **Architecture**
+   - Bronze → Silver → Gold deterministic data plane.
+   - Rule-based multi-agent decision plane executed through ABDP `ScenarioRunner`.
+   - Reporting and backtesting are downstream of the deterministic decision path.
+
+5. **Future-leakage prevention**
+   - Agent inputs must never include `target_*` columns.
+   - No future-incorporating moving averages.
+   - No full-period normalization.
+   - No full-period threshold tuning.
+
+6. **v0.1 exclusions**
+   - No S&P 500
+   - No Nasdaq
+   - No Dow
+   - No VIX
+   - No US futures
+   - No real-time FX
+   - No news sentiment
+   - No broker reports
+   - No individual stocks
+
+## Consequences
+
+### Positive
+- Clear public scope and low ambiguity for contributors.
+- Easier auditability and reproducibility.
+- Lower risk of accidental dependence on non-domestic or non-public signals.
+
+### Negative
+- v0.1 will be intentionally narrow and may skip many days.
+- Some potentially predictive signals are deferred to later versions.
+
+## Related
+- `docs/spec.md`
+- `apps/kr-kospi/config/agents.yaml`
+- `apps/kr-kospi/config/scenario.kospi.next_day.yaml`


### PR DESCRIPTION
## Summary
- add ADR-001 documenting the deterministic, public-data-first v0.1 foundation
- capture model labels, backtest-only ground truth labels, leakage guards, and explicit exclusions

## Checklist
- [x] `docs/adr/001-project-foundation.md` added
- [x] v0.1 exclusions listed verbatim
- [x] model labels documented as `up | down | skip`
- [x] ground-truth labels documented as `up | down | flat` for backtesting only
- [x] future-leakage rules summarized
- [x] disclaimer requirement reviewed against provided ADR draft

Closes #1