### PR TITLE
[#3] Add CI workflows and policy gates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,35 @@
-name: Placeholder CodeQL
+name: CodeQL
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
 
 jobs:
-  noop:
+  analyze:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python]
     steps:
-      - run: true
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,24 @@
-name: Placeholder Lint
+name: Lint
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  noop:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Ruff check
+        run: ruff check .
+      - name: Ruff format check
+        run: ruff format --check .
+      - name: Typing policy
+        run: python scripts/check_typing_policy.py

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,10 +1,20 @@
-name: Placeholder Mypy
+name: Mypy
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  noop:
+  mypy:
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Run mypy
+        run: mypy --strict core/src apps/kr-kospi/src

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,25 @@
-name: Placeholder Test
+name: Test
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
-  noop:
+  test:
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Run tests with coverage
+        run: pytest --cov=core/src --cov=apps/kr-kospi/src --cov-branch --cov-report=xml --cov-fail-under=100
+      - name: Upload coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .coverage
+coverage.xml
 .mypy_cache/
 .pytest_cache/
 .ruff_cache/

--- a/apps/kr-kospi/tests/contract/test_cli_stub.py
+++ b/apps/kr-kospi/tests/contract/test_cli_stub.py
@@ -7,7 +7,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 ENV = {
-    "PYTHONPATH": str(REPO_ROOT / "core" / "src") + ":" + str(REPO_ROOT / "apps" / "kr-kospi" / "src"),
+    "PYTHONPATH": str(REPO_ROOT / "core" / "src")
+    + ":"
+    + str(REPO_ROOT / "apps" / "kr-kospi" / "src"),
 }
 
 

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+import runpy
+
+from kospi_decision_pipeline_app_kr_kospi import __version__
+from kospi_decision_pipeline_app_kr_kospi.cli import main
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+ENV = {
+    "PYTHONPATH": str(REPO_ROOT / "core" / "src")
+    + ":"
+    + str(REPO_ROOT / "apps" / "kr-kospi" / "src"),
+}
+
+
+def test_cli_stub_subcommand_output() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "kospi_decision_pipeline_app_kr_kospi", "run"],
+        cwd=REPO_ROOT,
+        env=ENV,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "run: not yet implemented"
+
+
+def test_cli_main_returns_zero_for_run(capsys) -> None:
+    assert main(["run"]) == 0
+    assert capsys.readouterr().out.strip() == "run: not yet implemented"
+
+
+def test_cli_main_prints_help_without_command(capsys) -> None:
+    assert main([]) == 0
+    assert "build-features" in capsys.readouterr().out
+
+
+def test_cli_main_prints_version_and_exits(capsys) -> None:
+    try:
+        main(["--version"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert capsys.readouterr().out.strip() == __version__
+
+
+def test_module_main_raises_system_exit(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["kospi_decision_pipeline_app_kr_kospi", "run"])
+
+    try:
+        runpy.run_module("kospi_decision_pipeline_app_kr_kospi", run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 0

--- a/core/tests/unit/test_core_modules.py
+++ b/core/tests/unit/test_core_modules.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from kospi_decision_pipeline_core import __version__
+from kospi_decision_pipeline_core.ids import dataset_id
+from kospi_decision_pipeline_core.io import ensure_directory
+from kospi_decision_pipeline_core.schemas import DecisionRecord, FeatureRecord, ScenarioConfig
+from kospi_decision_pipeline_core.types import Decision
+
+
+def test_core_version() -> None:
+    assert __version__ == "0.0.1"
+
+
+def test_dataset_id() -> None:
+    assert dataset_id("gold") == "dataset:gold"
+
+
+def test_ensure_directory_creates_path(tmp_path) -> None:
+    target = tmp_path / "nested"
+
+    assert ensure_directory(target) == target
+    assert target.is_dir()
+
+
+def test_decision_dataclass() -> None:
+    decision = Decision(label="up", score=0.5)
+
+    assert decision.label == "up"
+    assert decision.score == 0.5
+
+
+def test_schema_stubs_are_instantiable() -> None:
+    assert isinstance(DecisionRecord(), DecisionRecord)
+    assert isinstance(FeatureRecord(), FeatureRecord)
+    assert isinstance(ScenarioConfig(), ScenarioConfig)

--- a/core/tests/unit/test_typing_policy.py
+++ b/core/tests/unit/test_typing_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_typing_policy_script_fails_on_fixture_violations() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "check_typing_policy.py"),
+            str(REPO_ROOT / "tests" / "fixtures" / "typing_violations"),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+    assert result.returncode == 1

--- a/scripts/check_typing_policy.py
+++ b/scripts/check_typing_policy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import argparse
+import io
+import tokenize
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from typing import cast
+
+
+DEFAULT_TARGETS = (
+    Path("core/src"),
+    Path("apps/kr-kospi/src"),
+)
+
+
+def iter_python_files(targets: Sequence[Path]) -> Iterable[Path]:
+    for target in targets:
+        if target.is_file() and target.suffix == ".py":
+            yield target
+            continue
+        if target.is_dir():
+            yield from sorted(target.rglob("*.py"))
+
+
+def has_allow_any_marker(line: str) -> bool:
+    return "# allow-any:" in line
+
+
+def find_violations(path: Path) -> list[str]:
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    violations: list[str] = []
+
+    for line_number, line in enumerate(lines, start=1):
+        if "# type: ignore" in line:
+            violations.append(f"{path}:{line_number}: disallowed # type: ignore")
+
+    tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+    seen_any_lines: set[int] = set()
+    for token in tokens:
+        if token.type != tokenize.NAME or token.string != "Any":
+            continue
+        if token.start[0] in seen_any_lines:
+            continue
+        seen_any_lines.add(token.start[0])
+        line = lines[token.start[0] - 1]
+        if has_allow_any_marker(line):
+            continue
+        violations.append(f"{path}:{token.start[0]}: bare Any requires inline allow-any marker")
+
+    return violations
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument("targets", nargs="*", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    targets = tuple(cast(list[Path], args.targets)) or DEFAULT_TARGETS
+
+    violations: list[str] = []
+    checked_files = 0
+    for path in iter_python_files(targets):
+        checked_files += 1
+        violations.extend(find_violations(path))
+
+    if violations:
+        print("typing policy violations found:")
+        for violation in violations:
+            print(violation)
+        return 1
+
+    print(f"typing policy clean: checked {checked_files} Python files")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/typing_violations/any_example.py
+++ b/tests/fixtures/typing_violations/any_example.py
@@ -1,0 +1,5 @@
+from typing import Any
+
+
+def identity(value: Any) -> Any:
+    return value

--- a/tests/fixtures/typing_violations/type_ignore_example.py
+++ b/tests/fixtures/typing_violations/type_ignore_example.py
@@ -1,0 +1,1 @@
+value = 1  # type: ignore


### PR DESCRIPTION
## Summary
- add lint, test, mypy, and CodeQL workflows for the bootstrap Python scaffold
- add a typing policy script that blocks `# type: ignore` and bare `Any` without inline justification
- cover the source tree to 100% under the workflow coverage command and add fixtures proving the policy script fails on violations

## Checklist
- [x] `lint.yml` runs `ruff check`, `ruff format --check`, and `scripts/check_typing_policy.py`
- [x] `test.yml` runs `pytest --cov-fail-under=100 --cov-branch`
- [x] `mypy.yml` runs `mypy --strict` over `core/src` and `apps/kr-kospi/src`
- [x] `codeql.yml` runs Python CodeQL with `security-extended`
- [x] `scripts/check_typing_policy.py` fails on `# type: ignore` and bare `Any` without `# allow-any:`
- [x] local verification passes: typing policy, ruff, mypy, and 100% coverage pytest command

Closes #3