### PR TITLE
[#5] Public-data connector protocols and fixture clients

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
@@ -1,0 +1,33 @@
+from .base import ConnectorRow, SourceMetadata
+from .data_portal import DataPortalConnector, DataPortalSampleRow
+from .ecos import EcosBaseRateRow, EcosBondYieldRow, EcosConnector, EcosUsdKrwRow
+from .fixture import (
+    FixtureDataPortalConnector,
+    FixtureEcosConnector,
+    FixtureKosisConnector,
+    FixtureKrxConnector,
+)
+from .kosis import KosisConnector, KosisMacroIndicatorRow, PerPbrPercentileRow
+from .krx import InvestorFlowRow, KospiIndexRow, KrxConnector, MarketValuationRow
+
+__all__ = [
+    "ConnectorRow",
+    "DataPortalConnector",
+    "DataPortalSampleRow",
+    "EcosBaseRateRow",
+    "EcosBondYieldRow",
+    "EcosConnector",
+    "EcosUsdKrwRow",
+    "FixtureDataPortalConnector",
+    "FixtureEcosConnector",
+    "FixtureKosisConnector",
+    "FixtureKrxConnector",
+    "InvestorFlowRow",
+    "KospiIndexRow",
+    "KosisConnector",
+    "KosisMacroIndicatorRow",
+    "KrxConnector",
+    "MarketValuationRow",
+    "PerPbrPercentileRow",
+    "SourceMetadata",
+]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/base.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/base.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True, slots=True)
+class SourceMetadata:
+    source_name: str
+    source_series_id: str
+    fetched_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorRow:
+    metadata: SourceMetadata
+
+
+@runtime_checkable
+class Connector(Protocol):
+    pass

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/data_portal.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/data_portal.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from .base import ConnectorRow
+
+
+@dataclass(frozen=True, slots=True)
+class DataPortalSampleRow(ConnectorRow):
+    value_date: date
+    metric_name: str
+    metric_value: Decimal
+
+
+@runtime_checkable
+class DataPortalConnector(Protocol):
+    def fetch_sample_dataset(self, start: date, end: date) -> tuple[DataPortalSampleRow, ...]: ...

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from .base import ConnectorRow
+
+
+@dataclass(frozen=True, slots=True)
+class EcosBaseRateRow(ConnectorRow):
+    value_date: date
+    base_rate: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class EcosUsdKrwRow(ConnectorRow):
+    value_date: date
+    exchange_rate: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class EcosBondYieldRow(ConnectorRow):
+    value_date: date
+    maturity_code: str
+    yield_rate: Decimal
+
+
+@runtime_checkable
+class EcosConnector(Protocol):
+    def fetch_base_rate_series(self, start: date, end: date) -> tuple[EcosBaseRateRow, ...]: ...
+
+    def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]: ...
+
+    def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]: ...

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+import json
+from pathlib import Path
+from typing import Callable, TypeVar, cast
+
+from .base import SourceMetadata
+from .data_portal import DataPortalSampleRow
+from .ecos import EcosBaseRateRow, EcosBondYieldRow, EcosUsdKrwRow
+from .kosis import KosisMacroIndicatorRow, PerPbrPercentileRow
+from .krx import InvestorFlowRow, KospiIndexRow, MarketValuationRow
+
+
+@dataclass(frozen=True, slots=True)
+class _FixturePayload:
+    metadata: SourceMetadata
+    rows: tuple[dict[str, object], ...]
+
+
+RowT = TypeVar("RowT")
+
+
+class _FixtureLoader:
+    def __init__(self, fixtures_root: Path) -> None:
+        self._fixtures_root = fixtures_root
+
+    def load(self, source_name: str, dataset_name: str) -> _FixturePayload:
+        fixture_path = self._fixtures_root / source_name / f"{dataset_name}.json"
+        payload: dict[str, object] = json.loads(fixture_path.read_text(encoding="utf-8"))
+        metadata = SourceMetadata(
+            source_name=str(payload["source_name"]),
+            source_series_id=str(payload["source_series_id"]),
+            fetched_at=datetime.fromisoformat(str(payload["fetched_at"])),
+        )
+        raw_rows = cast(list[dict[str, object]], payload["rows"])
+        return _FixturePayload(metadata=metadata, rows=tuple(raw_rows))
+
+
+def _parse_date(value: object) -> date:
+    return date.fromisoformat(str(value))
+
+
+def _parse_decimal(value: object) -> Decimal:
+    return Decimal(str(value))
+
+
+def _parse_int(value: object) -> int:
+    return int(str(value))
+
+
+def _filter_by_date_range(
+    rows: tuple[RowT, ...],
+    date_getter: Callable[[RowT], date],
+    start: date,
+    end: date,
+) -> tuple[RowT, ...]:
+    return tuple(row for row in rows if start <= date_getter(row) <= end)
+
+
+class FixtureKrxConnector:
+    def __init__(self, fixtures_root: Path) -> None:
+        self._loader = _FixtureLoader(fixtures_root)
+
+    def fetch_kospi_index(self, start: date, end: date) -> tuple[KospiIndexRow, ...]:
+        payload = self._loader.load("krx", "kospi_index")
+        rows = tuple(
+            KospiIndexRow(
+                metadata=payload.metadata,
+                trade_date=_parse_date(row["trade_date"]),
+                open_price=_parse_decimal(row["open_price"]),
+                high_price=_parse_decimal(row["high_price"]),
+                low_price=_parse_decimal(row["low_price"]),
+                close_price=_parse_decimal(row["close_price"]),
+                volume=_parse_int(row["volume"]),
+                turnover=_parse_decimal(row["turnover"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
+
+    def fetch_investor_flow(self, start: date, end: date) -> tuple[InvestorFlowRow, ...]:
+        payload = self._loader.load("krx", "investor_flow")
+        rows = tuple(
+            InvestorFlowRow(
+                metadata=payload.metadata,
+                trade_date=_parse_date(row["trade_date"]),
+                individual_net_buy=_parse_decimal(row["individual_net_buy"]),
+                foreign_net_buy=_parse_decimal(row["foreign_net_buy"]),
+                institution_net_buy=_parse_decimal(row["institution_net_buy"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
+
+    def fetch_market_valuation(self, start: date, end: date) -> tuple[MarketValuationRow, ...]:
+        payload = self._loader.load("krx", "market_valuation")
+        rows = tuple(
+            MarketValuationRow(
+                metadata=payload.metadata,
+                trade_date=_parse_date(row["trade_date"]),
+                market_capitalization=_parse_decimal(row["market_capitalization"]),
+                trailing_per=_parse_decimal(row["trailing_per"]),
+                trailing_pbr=_parse_decimal(row["trailing_pbr"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
+
+
+class FixtureEcosConnector:
+    def __init__(self, fixtures_root: Path) -> None:
+        self._loader = _FixtureLoader(fixtures_root)
+
+    def fetch_base_rate_series(self, start: date, end: date) -> tuple[EcosBaseRateRow, ...]:
+        payload = self._loader.load("ecos", "base_rate")
+        rows = tuple(
+            EcosBaseRateRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                base_rate=_parse_decimal(row["base_rate"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+    def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]:
+        payload = self._loader.load("ecos", "usd_krw")
+        rows = tuple(
+            EcosUsdKrwRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                exchange_rate=_parse_decimal(row["exchange_rate"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+    def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]:
+        payload = self._loader.load("ecos", "bond_yield")
+        rows = tuple(
+            EcosBondYieldRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                maturity_code=str(row["maturity_code"]),
+                yield_rate=_parse_decimal(row["yield_rate"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+
+class FixtureKosisConnector:
+    def __init__(self, fixtures_root: Path) -> None:
+        self._loader = _FixtureLoader(fixtures_root)
+
+    def fetch_per_pbr_percentiles(self, start: date, end: date) -> tuple[PerPbrPercentileRow, ...]:
+        payload = self._loader.load("kosis", "per_pbr_percentiles")
+        rows = tuple(
+            PerPbrPercentileRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                per_percentile=_parse_decimal(row["per_percentile"]),
+                pbr_percentile=_parse_decimal(row["pbr_percentile"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+    def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
+        payload = self._loader.load("kosis", "macro_indicators")
+        rows = tuple(
+            KosisMacroIndicatorRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                indicator_name=str(row["indicator_name"]),
+                indicator_value=_parse_decimal(row["indicator_value"]),
+                unit=str(row["unit"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+
+class FixtureDataPortalConnector:
+    def __init__(self, fixtures_root: Path) -> None:
+        self._loader = _FixtureLoader(fixtures_root)
+
+    def fetch_sample_dataset(self, start: date, end: date) -> tuple[DataPortalSampleRow, ...]:
+        payload = self._loader.load("data_portal", "sample_dataset")
+        rows = tuple(
+            DataPortalSampleRow(
+                metadata=payload.metadata,
+                value_date=_parse_date(row["value_date"]),
+                metric_name=str(row["metric_name"]),
+                metric_value=_parse_decimal(row["metric_value"]),
+            )
+            for row in payload.rows
+        )
+        return _filter_by_date_range(rows, lambda row: row.value_date, start, end)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
@@ -5,7 +5,7 @@ from datetime import date, datetime
 from decimal import Decimal
 import json
 from pathlib import Path
-from typing import Callable, TypeVar, cast
+from typing import Callable, TypeVar, cast, final
 
 from .base import SourceMetadata
 from .data_portal import DataPortalSampleRow
@@ -23,13 +23,16 @@ class _FixturePayload:
 RowT = TypeVar("RowT")
 
 
+@final
 class _FixtureLoader:
+    _fixtures_root: Path
+
     def __init__(self, fixtures_root: Path) -> None:
         self._fixtures_root = fixtures_root
 
     def load(self, source_name: str, dataset_name: str) -> _FixturePayload:
         fixture_path = self._fixtures_root / source_name / f"{dataset_name}.json"
-        payload: dict[str, object] = json.loads(fixture_path.read_text(encoding="utf-8"))
+        payload = cast(dict[str, object], json.loads(fixture_path.read_text(encoding="utf-8")))
         metadata = SourceMetadata(
             source_name=str(payload["source_name"]),
             source_series_id=str(payload["source_series_id"]),
@@ -60,7 +63,10 @@ def _filter_by_date_range(
     return tuple(row for row in rows if start <= date_getter(row) <= end)
 
 
+@final
 class FixtureKrxConnector:
+    _loader: _FixtureLoader
+
     def __init__(self, fixtures_root: Path) -> None:
         self._loader = _FixtureLoader(fixtures_root)
 
@@ -110,7 +116,10 @@ class FixtureKrxConnector:
         return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
 
 
+@final
 class FixtureEcosConnector:
+    _loader: _FixtureLoader
+
     def __init__(self, fixtures_root: Path) -> None:
         self._loader = _FixtureLoader(fixtures_root)
 
@@ -152,7 +161,10 @@ class FixtureEcosConnector:
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
 
 
+@final
 class FixtureKosisConnector:
+    _loader: _FixtureLoader
+
     def __init__(self, fixtures_root: Path) -> None:
         self._loader = _FixtureLoader(fixtures_root)
 
@@ -184,7 +196,10 @@ class FixtureKosisConnector:
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
 
 
+@final
 class FixtureDataPortalConnector:
+    _loader: _FixtureLoader
+
     def __init__(self, fixtures_root: Path) -> None:
         self._loader = _FixtureLoader(fixtures_root)
 

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from .base import ConnectorRow
+
+
+@dataclass(frozen=True, slots=True)
+class PerPbrPercentileRow(ConnectorRow):
+    value_date: date
+    per_percentile: Decimal
+    pbr_percentile: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class KosisMacroIndicatorRow(ConnectorRow):
+    value_date: date
+    indicator_name: str
+    indicator_value: Decimal
+    unit: str
+
+
+@runtime_checkable
+class KosisConnector(Protocol):
+    def fetch_per_pbr_percentiles(
+        self, start: date, end: date
+    ) -> tuple[PerPbrPercentileRow, ...]: ...
+
+    def fetch_macro_indicators(
+        self, start: date, end: date
+    ) -> tuple[KosisMacroIndicatorRow, ...]: ...

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Protocol, runtime_checkable
+
+from .base import ConnectorRow
+
+
+@dataclass(frozen=True, slots=True)
+class KospiIndexRow(ConnectorRow):
+    trade_date: date
+    open_price: Decimal
+    high_price: Decimal
+    low_price: Decimal
+    close_price: Decimal
+    volume: int
+    turnover: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class InvestorFlowRow(ConnectorRow):
+    trade_date: date
+    individual_net_buy: Decimal
+    foreign_net_buy: Decimal
+    institution_net_buy: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class MarketValuationRow(ConnectorRow):
+    trade_date: date
+    market_capitalization: Decimal
+    trailing_per: Decimal
+    trailing_pbr: Decimal
+
+
+@runtime_checkable
+class KrxConnector(Protocol):
+    def fetch_kospi_index(self, start: date, end: date) -> tuple[KospiIndexRow, ...]: ...
+
+    def fetch_investor_flow(self, start: date, end: date) -> tuple[InvestorFlowRow, ...]: ...
+
+    def fetch_market_valuation(self, start: date, end: date) -> tuple[MarketValuationRow, ...]: ...

--- a/apps/kr-kospi/tests/conftest.py
+++ b/apps/kr-kospi/tests/conftest.py
@@ -1,1 +1,30 @@
 from __future__ import annotations
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "requires_network: mark test as requiring live network access and skip by default in CI",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: list[pytest.Item],
+) -> None:
+    if not config.getoption("--run-network", default=False):
+        skip_network = pytest.mark.skip(reason="requires network; pass --run-network to enable")
+        for item in items:
+            if "requires_network" in item.keywords:
+                item.add_marker(skip_network)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests marked with requires_network",
+    )

--- a/apps/kr-kospi/tests/conftest.py
+++ b/apps/kr-kospi/tests/conftest.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import socket
+
 import pytest
 
 
@@ -28,3 +30,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default=False,
         help="run tests marked with requires_network",
     )
+
+
+@pytest.fixture(autouse=True)
+def block_network_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+) -> None:
+    if request.node.get_closest_marker("requires_network") is not None:
+        return
+
+    def fail_create_connection(*args: object, **kwargs: object) -> None:
+        raise AssertionError(
+            f"unexpected network access via create_connection: {args!r} {kwargs!r}"
+        )
+
+    def fail_connect(_self: socket.socket, address: object) -> None:
+        raise AssertionError(f"unexpected network access via connect: {address!r}")
+
+    def fail_connect_ex(_self: socket.socket, address: object) -> int:
+        raise AssertionError(f"unexpected network access via connect_ex: {address!r}")
+
+    monkeypatch.setattr(socket, "create_connection", fail_create_connection)
+    monkeypatch.setattr(socket.socket, "connect", fail_connect)
+    monkeypatch.setattr(socket.socket, "connect_ex", fail_connect_ex)

--- a/apps/kr-kospi/tests/contract/test_connector_fixtures.py
+++ b/apps/kr-kospi/tests/contract/test_connector_fixtures.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import date
+import importlib
 from pathlib import Path
-import socket
-from typing import TypeVar
+import sys
+from typing import Protocol, TypeVar
 
 import pytest
 
 from kospi_decision_pipeline_app_kr_kospi import connectors
+from kospi_decision_pipeline_app_kr_kospi.connectors.base import SourceMetadata
 from kospi_decision_pipeline_app_kr_kospi.connectors.data_portal import (
     DataPortalConnector,
     DataPortalSampleRow,
@@ -44,13 +46,18 @@ START_DATE = date(2024, 1, 2)
 END_DATE = date(2024, 1, 4)
 
 
-def assert_metadata(rows: tuple[object, ...], source_name: str, source_series_id: str) -> None:
+class HasMetadata(Protocol):
+    @property
+    def metadata(self) -> SourceMetadata: ...
+
+
+def assert_metadata(rows: tuple[HasMetadata, ...], source_name: str, source_series_id: str) -> None:
     assert rows
-    first_row = rows[0]
-    metadata = getattr(first_row, "metadata")
-    assert metadata.source_name == source_name
-    assert metadata.source_series_id == source_series_id
-    assert metadata.fetched_at.isoformat() == "2024-01-10T09:00:00+00:00"
+    for row in rows:
+        metadata = row.metadata
+        assert metadata.source_name == source_name
+        assert metadata.source_series_id == source_series_id
+        assert metadata.fetched_at.isoformat() == "2024-01-10T09:00:00+00:00"
 
 
 def assert_deterministic(fetcher: Callable[[], tuple[RowT, ...]]) -> tuple[RowT, ...]:
@@ -135,12 +142,7 @@ def test_fixture_data_portal_connector_satisfies_protocol_and_returns_metadata()
     assert_metadata(rows, source_name="data_portal", source_series_id="sample_dataset")
 
 
-def test_fixture_connectors_do_not_require_network(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fail_connect(self: socket.socket, address: object) -> None:
-        raise AssertionError(f"unexpected network access: {address!r}")
-
-    monkeypatch.setattr(socket.socket, "connect", fail_connect)
-
+def test_fixture_connectors_do_not_require_network() -> None:
     krx_connector = FixtureKrxConnector(FIXTURES_ROOT)
     ecos_connector = FixtureEcosConnector(FIXTURES_ROOT)
     kosis_connector = FixtureKosisConnector(FIXTURES_ROOT)
@@ -162,3 +164,25 @@ def test_connectors_package_exports_fixture_connectors() -> None:
     assert connectors.FixtureEcosConnector is FixtureEcosConnector
     assert connectors.FixtureKosisConnector is FixtureKosisConnector
     assert connectors.FixtureDataPortalConnector is FixtureDataPortalConnector
+
+
+def test_connector_modules_do_not_read_fixtures_at_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    imported_modules = (
+        "kospi_decision_pipeline_app_kr_kospi.connectors.base",
+        "kospi_decision_pipeline_app_kr_kospi.connectors.krx",
+        "kospi_decision_pipeline_app_kr_kospi.connectors.ecos",
+        "kospi_decision_pipeline_app_kr_kospi.connectors.kosis",
+        "kospi_decision_pipeline_app_kr_kospi.connectors.data_portal",
+        "kospi_decision_pipeline_app_kr_kospi.connectors.fixture",
+    )
+
+    def fail_read_text(self: Path, encoding: str = "utf-8") -> str:
+        raise AssertionError(f"fixture file should not be read at import time: {self} ({encoding})")
+
+    monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+    for module_name in imported_modules:
+        sys.modules.pop(module_name, None)
+        importlib.import_module(module_name)

--- a/apps/kr-kospi/tests/contract/test_connector_fixtures.py
+++ b/apps/kr-kospi/tests/contract/test_connector_fixtures.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+import socket
+from typing import TypeVar
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.data_portal import (
+    DataPortalConnector,
+    DataPortalSampleRow,
+)
+from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import EcosConnector, EcosBaseRateRow
+from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import (
+    FixtureDataPortalConnector,
+    FixtureEcosConnector,
+    FixtureKosisConnector,
+    FixtureKrxConnector,
+)
+from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
+    KosisConnector,
+    PerPbrPercentileRow,
+)
+from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
+    InvestorFlowRow,
+    KospiIndexRow,
+    KrxConnector,
+)
+
+
+FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
+RowT = TypeVar("RowT")
+
+
+def assert_metadata(rows: tuple[object, ...], source_name: str, source_series_id: str) -> None:
+    assert rows
+    first_row = rows[0]
+    metadata = getattr(first_row, "metadata")
+    assert metadata.source_name == source_name
+    assert metadata.source_series_id == source_series_id
+    assert metadata.fetched_at.isoformat() == "2024-01-10T09:00:00+00:00"
+
+
+def assert_deterministic(fetcher: Callable[[], tuple[RowT, ...]]) -> tuple[RowT, ...]:
+    first_result = fetcher()
+    second_result = fetcher()
+    assert first_result == second_result
+    return first_result
+
+
+def test_fixture_krx_connector_satisfies_protocols_and_returns_typed_rows() -> None:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+
+    assert isinstance(connector, KrxConnector)
+
+    kospi_rows = assert_deterministic(lambda: connector.fetch_kospi_index())
+    investor_rows = assert_deterministic(lambda: connector.fetch_investor_flow())
+
+    assert kospi_rows == tuple(kospi_rows)
+    assert investor_rows == tuple(investor_rows)
+    assert all(isinstance(row, KospiIndexRow) for row in kospi_rows)
+    assert all(isinstance(row, InvestorFlowRow) for row in investor_rows)
+    assert_metadata(kospi_rows, source_name="krx", source_series_id="kospi_index")
+    assert_metadata(investor_rows, source_name="krx", source_series_id="investor_flow")
+
+
+def test_fixture_ecos_connector_satisfies_protocol_and_returns_metadata() -> None:
+    connector = FixtureEcosConnector(FIXTURES_ROOT)
+
+    assert isinstance(connector, EcosConnector)
+
+    rows = assert_deterministic(lambda: connector.fetch_base_rate_series())
+
+    assert all(isinstance(row, EcosBaseRateRow) for row in rows)
+    assert_metadata(rows, source_name="ecos", source_series_id="base_rate")
+
+
+def test_fixture_kosis_connector_satisfies_protocol_and_returns_metadata() -> None:
+    connector = FixtureKosisConnector(FIXTURES_ROOT)
+
+    assert isinstance(connector, KosisConnector)
+
+    rows = assert_deterministic(lambda: connector.fetch_per_pbr_percentiles())
+
+    assert all(isinstance(row, PerPbrPercentileRow) for row in rows)
+    assert_metadata(rows, source_name="kosis", source_series_id="per_pbr_percentiles")
+
+
+def test_fixture_data_portal_connector_satisfies_protocol_and_returns_metadata() -> None:
+    connector = FixtureDataPortalConnector(FIXTURES_ROOT)
+
+    assert isinstance(connector, DataPortalConnector)
+
+    rows = assert_deterministic(lambda: connector.fetch_sample_dataset())
+
+    assert all(isinstance(row, DataPortalSampleRow) for row in rows)
+    assert_metadata(rows, source_name="data_portal", source_series_id="sample_dataset")
+
+
+def test_fixture_connectors_do_not_require_network(monkeypatch) -> None:
+    def fail_connect(self: socket.socket, address: object) -> None:
+        raise AssertionError(f"unexpected network access: {address!r}")
+
+    monkeypatch.setattr(socket.socket, "connect", fail_connect)
+
+    krx_connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ecos_connector = FixtureEcosConnector(FIXTURES_ROOT)
+    kosis_connector = FixtureKosisConnector(FIXTURES_ROOT)
+    data_portal_connector = FixtureDataPortalConnector(FIXTURES_ROOT)
+
+    assert krx_connector.fetch_kospi_index()
+    assert krx_connector.fetch_investor_flow()
+    assert ecos_connector.fetch_base_rate_series()
+    assert kosis_connector.fetch_per_pbr_percentiles()
+    assert data_portal_connector.fetch_sample_dataset()

--- a/apps/kr-kospi/tests/contract/test_connector_fixtures.py
+++ b/apps/kr-kospi/tests/contract/test_connector_fixtures.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import date
 from pathlib import Path
 import socket
 from typing import TypeVar
 
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi import connectors
 from kospi_decision_pipeline_app_kr_kospi.connectors.data_portal import (
     DataPortalConnector,
     DataPortalSampleRow,
 )
-from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import EcosConnector, EcosBaseRateRow
+from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
+    EcosBaseRateRow,
+    EcosBondYieldRow,
+    EcosConnector,
+    EcosUsdKrwRow,
+)
 from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import (
     FixtureDataPortalConnector,
     FixtureEcosConnector,
@@ -17,6 +26,7 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import (
     FixtureKrxConnector,
 )
 from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
+    KosisMacroIndicatorRow,
     KosisConnector,
     PerPbrPercentileRow,
 )
@@ -24,11 +34,14 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
     InvestorFlowRow,
     KospiIndexRow,
     KrxConnector,
+    MarketValuationRow,
 )
 
 
 FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
 RowT = TypeVar("RowT")
+START_DATE = date(2024, 1, 2)
+END_DATE = date(2024, 1, 4)
 
 
 def assert_metadata(rows: tuple[object, ...], source_name: str, source_series_id: str) -> None:
@@ -52,15 +65,26 @@ def test_fixture_krx_connector_satisfies_protocols_and_returns_typed_rows() -> N
 
     assert isinstance(connector, KrxConnector)
 
-    kospi_rows = assert_deterministic(lambda: connector.fetch_kospi_index())
-    investor_rows = assert_deterministic(lambda: connector.fetch_investor_flow())
+    kospi_rows = assert_deterministic(lambda: connector.fetch_kospi_index(START_DATE, END_DATE))
+    investor_rows = assert_deterministic(
+        lambda: connector.fetch_investor_flow(START_DATE, END_DATE)
+    )
+    valuation_rows = assert_deterministic(
+        lambda: connector.fetch_market_valuation(START_DATE, END_DATE)
+    )
 
     assert kospi_rows == tuple(kospi_rows)
     assert investor_rows == tuple(investor_rows)
+    assert valuation_rows == tuple(valuation_rows)
+    assert len(kospi_rows) == 3
+    assert kospi_rows[0].trade_date == START_DATE
+    assert kospi_rows[-1].trade_date == END_DATE
     assert all(isinstance(row, KospiIndexRow) for row in kospi_rows)
     assert all(isinstance(row, InvestorFlowRow) for row in investor_rows)
+    assert all(isinstance(row, MarketValuationRow) for row in valuation_rows)
     assert_metadata(kospi_rows, source_name="krx", source_series_id="kospi_index")
     assert_metadata(investor_rows, source_name="krx", source_series_id="investor_flow")
+    assert_metadata(valuation_rows, source_name="krx", source_series_id="market_valuation")
 
 
 def test_fixture_ecos_connector_satisfies_protocol_and_returns_metadata() -> None:
@@ -68,10 +92,20 @@ def test_fixture_ecos_connector_satisfies_protocol_and_returns_metadata() -> Non
 
     assert isinstance(connector, EcosConnector)
 
-    rows = assert_deterministic(lambda: connector.fetch_base_rate_series())
+    rows = assert_deterministic(lambda: connector.fetch_base_rate_series(START_DATE, END_DATE))
+    usd_krw_rows = assert_deterministic(
+        lambda: connector.fetch_usd_krw_series(START_DATE, END_DATE)
+    )
+    bond_rows = assert_deterministic(
+        lambda: connector.fetch_bond_yield_series(START_DATE, END_DATE)
+    )
 
     assert all(isinstance(row, EcosBaseRateRow) for row in rows)
+    assert all(isinstance(row, EcosUsdKrwRow) for row in usd_krw_rows)
+    assert all(isinstance(row, EcosBondYieldRow) for row in bond_rows)
     assert_metadata(rows, source_name="ecos", source_series_id="base_rate")
+    assert_metadata(usd_krw_rows, source_name="ecos", source_series_id="usd_krw")
+    assert_metadata(bond_rows, source_name="ecos", source_series_id="bond_yield")
 
 
 def test_fixture_kosis_connector_satisfies_protocol_and_returns_metadata() -> None:
@@ -79,10 +113,15 @@ def test_fixture_kosis_connector_satisfies_protocol_and_returns_metadata() -> No
 
     assert isinstance(connector, KosisConnector)
 
-    rows = assert_deterministic(lambda: connector.fetch_per_pbr_percentiles())
+    rows = assert_deterministic(lambda: connector.fetch_per_pbr_percentiles(START_DATE, END_DATE))
+    macro_rows = assert_deterministic(
+        lambda: connector.fetch_macro_indicators(START_DATE, END_DATE)
+    )
 
     assert all(isinstance(row, PerPbrPercentileRow) for row in rows)
+    assert all(isinstance(row, KosisMacroIndicatorRow) for row in macro_rows)
     assert_metadata(rows, source_name="kosis", source_series_id="per_pbr_percentiles")
+    assert_metadata(macro_rows, source_name="kosis", source_series_id="macro_indicators")
 
 
 def test_fixture_data_portal_connector_satisfies_protocol_and_returns_metadata() -> None:
@@ -90,13 +129,13 @@ def test_fixture_data_portal_connector_satisfies_protocol_and_returns_metadata()
 
     assert isinstance(connector, DataPortalConnector)
 
-    rows = assert_deterministic(lambda: connector.fetch_sample_dataset())
+    rows = assert_deterministic(lambda: connector.fetch_sample_dataset(START_DATE, END_DATE))
 
     assert all(isinstance(row, DataPortalSampleRow) for row in rows)
     assert_metadata(rows, source_name="data_portal", source_series_id="sample_dataset")
 
 
-def test_fixture_connectors_do_not_require_network(monkeypatch) -> None:
+def test_fixture_connectors_do_not_require_network(monkeypatch: pytest.MonkeyPatch) -> None:
     def fail_connect(self: socket.socket, address: object) -> None:
         raise AssertionError(f"unexpected network access: {address!r}")
 
@@ -107,8 +146,19 @@ def test_fixture_connectors_do_not_require_network(monkeypatch) -> None:
     kosis_connector = FixtureKosisConnector(FIXTURES_ROOT)
     data_portal_connector = FixtureDataPortalConnector(FIXTURES_ROOT)
 
-    assert krx_connector.fetch_kospi_index()
-    assert krx_connector.fetch_investor_flow()
-    assert ecos_connector.fetch_base_rate_series()
-    assert kosis_connector.fetch_per_pbr_percentiles()
-    assert data_portal_connector.fetch_sample_dataset()
+    assert krx_connector.fetch_kospi_index(START_DATE, END_DATE)
+    assert krx_connector.fetch_investor_flow(START_DATE, END_DATE)
+    assert krx_connector.fetch_market_valuation(START_DATE, END_DATE)
+    assert ecos_connector.fetch_base_rate_series(START_DATE, END_DATE)
+    assert ecos_connector.fetch_usd_krw_series(START_DATE, END_DATE)
+    assert ecos_connector.fetch_bond_yield_series(START_DATE, END_DATE)
+    assert kosis_connector.fetch_per_pbr_percentiles(START_DATE, END_DATE)
+    assert kosis_connector.fetch_macro_indicators(START_DATE, END_DATE)
+    assert data_portal_connector.fetch_sample_dataset(START_DATE, END_DATE)
+
+
+def test_connectors_package_exports_fixture_connectors() -> None:
+    assert connectors.FixtureKrxConnector is FixtureKrxConnector
+    assert connectors.FixtureEcosConnector is FixtureEcosConnector
+    assert connectors.FixtureKosisConnector is FixtureKosisConnector
+    assert connectors.FixtureDataPortalConnector is FixtureDataPortalConnector

--- a/apps/kr-kospi/tests/fixtures/data_portal/sample_dataset.json
+++ b/apps/kr-kospi/tests/fixtures/data_portal/sample_dataset.json
@@ -1,0 +1,10 @@
+{
+  "source_name": "data_portal",
+  "source_series_id": "sample_dataset",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-03", "metric_name": "public_signal", "metric_value": "101.5"},
+    {"value_date": "2024-01-04", "metric_name": "public_signal", "metric_value": "102.0"},
+    {"value_date": "2024-01-05", "metric_name": "public_signal", "metric_value": "103.2"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/ecos/base_rate.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/base_rate.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "ecos",
+  "source_series_id": "base_rate",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-01", "base_rate": "3.50"},
+    {"value_date": "2024-01-02", "base_rate": "3.50"},
+    {"value_date": "2024-01-03", "base_rate": "3.50"},
+    {"value_date": "2024-01-04", "base_rate": "3.50"},
+    {"value_date": "2024-01-05", "base_rate": "3.50"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/ecos/bond_yield.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/bond_yield.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "ecos",
+  "source_series_id": "bond_yield",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-01", "maturity_code": "3Y", "yield_rate": "3.21"},
+    {"value_date": "2024-01-02", "maturity_code": "3Y", "yield_rate": "3.23"},
+    {"value_date": "2024-01-03", "maturity_code": "3Y", "yield_rate": "3.20"},
+    {"value_date": "2024-01-04", "maturity_code": "3Y", "yield_rate": "3.18"},
+    {"value_date": "2024-01-05", "maturity_code": "3Y", "yield_rate": "3.19"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/ecos/usd_krw.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/usd_krw.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "ecos",
+  "source_series_id": "usd_krw",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-01", "exchange_rate": "1291.20"},
+    {"value_date": "2024-01-02", "exchange_rate": "1293.10"},
+    {"value_date": "2024-01-03", "exchange_rate": "1288.40"},
+    {"value_date": "2024-01-04", "exchange_rate": "1290.00"},
+    {"value_date": "2024-01-05", "exchange_rate": "1287.70"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/kosis/macro_indicators.json
+++ b/apps/kr-kospi/tests/fixtures/kosis/macro_indicators.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "kosis",
+  "source_series_id": "macro_indicators",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-01", "indicator_name": "cpi_yoy", "indicator_value": "2.8", "unit": "percent"},
+    {"value_date": "2024-01-02", "indicator_name": "cpi_yoy", "indicator_value": "2.8", "unit": "percent"},
+    {"value_date": "2024-01-03", "indicator_name": "cpi_yoy", "indicator_value": "2.7", "unit": "percent"},
+    {"value_date": "2024-01-04", "indicator_name": "cpi_yoy", "indicator_value": "2.7", "unit": "percent"},
+    {"value_date": "2024-01-05", "indicator_name": "cpi_yoy", "indicator_value": "2.6", "unit": "percent"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/kosis/per_pbr_percentiles.json
+++ b/apps/kr-kospi/tests/fixtures/kosis/per_pbr_percentiles.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "kosis",
+  "source_series_id": "per_pbr_percentiles",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"value_date": "2024-01-01", "per_percentile": "41.0", "pbr_percentile": "38.5"},
+    {"value_date": "2024-01-02", "per_percentile": "42.1", "pbr_percentile": "39.2"},
+    {"value_date": "2024-01-03", "per_percentile": "40.8", "pbr_percentile": "38.9"},
+    {"value_date": "2024-01-04", "per_percentile": "39.7", "pbr_percentile": "38.0"},
+    {"value_date": "2024-01-05", "per_percentile": "43.5", "pbr_percentile": "40.1"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/krx/investor_flow.json
+++ b/apps/kr-kospi/tests/fixtures/krx/investor_flow.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "krx",
+  "source_series_id": "investor_flow",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"trade_date": "2024-01-01", "individual_net_buy": "1200000000", "foreign_net_buy": "-800000000", "institution_net_buy": "-400000000"},
+    {"trade_date": "2024-01-02", "individual_net_buy": "-400000000", "foreign_net_buy": "700000000", "institution_net_buy": "-300000000"},
+    {"trade_date": "2024-01-03", "individual_net_buy": "300000000", "foreign_net_buy": "-100000000", "institution_net_buy": "-200000000"},
+    {"trade_date": "2024-01-04", "individual_net_buy": "-900000000", "foreign_net_buy": "500000000", "institution_net_buy": "400000000"},
+    {"trade_date": "2024-01-05", "individual_net_buy": "150000000", "foreign_net_buy": "-250000000", "institution_net_buy": "100000000"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/krx/kospi_index.json
+++ b/apps/kr-kospi/tests/fixtures/krx/kospi_index.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "krx",
+  "source_series_id": "kospi_index",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"trade_date": "2024-01-01", "open_price": "2640.10", "high_price": "2650.20", "low_price": "2630.00", "close_price": "2645.50", "volume": 1001000, "turnover": "845000000000.00"},
+    {"trade_date": "2024-01-02", "open_price": "2645.50", "high_price": "2660.00", "low_price": "2642.20", "close_price": "2658.10", "volume": 1020000, "turnover": "852500000000.00"},
+    {"trade_date": "2024-01-03", "open_price": "2658.10", "high_price": "2661.40", "low_price": "2648.20", "close_price": "2651.00", "volume": 990000, "turnover": "830200000000.00"},
+    {"trade_date": "2024-01-04", "open_price": "2651.00", "high_price": "2659.70", "low_price": "2640.50", "close_price": "2644.20", "volume": 978000, "turnover": "818300000000.00"},
+    {"trade_date": "2024-01-05", "open_price": "2644.20", "high_price": "2665.00", "low_price": "2641.90", "close_price": "2661.80", "volume": 1042000, "turnover": "867700000000.00"}
+  ]
+}

--- a/apps/kr-kospi/tests/fixtures/krx/market_valuation.json
+++ b/apps/kr-kospi/tests/fixtures/krx/market_valuation.json
@@ -1,0 +1,12 @@
+{
+  "source_name": "krx",
+  "source_series_id": "market_valuation",
+  "fetched_at": "2024-01-10T09:00:00+00:00",
+  "rows": [
+    {"trade_date": "2024-01-01", "market_capitalization": "2100000000000000", "trailing_per": "10.2", "trailing_pbr": "0.92"},
+    {"trade_date": "2024-01-02", "market_capitalization": "2105000000000000", "trailing_per": "10.3", "trailing_pbr": "0.93"},
+    {"trade_date": "2024-01-03", "market_capitalization": "2102000000000000", "trailing_per": "10.25", "trailing_pbr": "0.93"},
+    {"trade_date": "2024-01-04", "market_capitalization": "2098000000000000", "trailing_per": "10.18", "trailing_pbr": "0.92"},
+    {"trade_date": "2024-01-05", "market_capitalization": "2111000000000000", "trailing_per": "10.35", "trailing_pbr": "0.94"}
+  ]
+}


### PR DESCRIPTION
## Summary
- add frozen connector row dataclasses and runtime-checkable Protocol interfaces for KRX, ECOS, KOSIS, and public data portal sources
- add deterministic fixture connector implementations plus JSON fixture datasets with lazy file reads and date-range filtering
- add contract tests and a `requires_network` pytest marker so connector tests stay fixture-only and 100% covered in CI