### PR TITLE
[#4] Typed config loaders for scenario.yaml and agents.yaml

### DIFF
--- a/core/src/kospi_decision_pipeline_core/schemas/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/__init__.py
@@ -1,5 +1,12 @@
-from .config import ScenarioConfig
+from .config import AgentWeightConfig, AgentsConfig, ScenarioConfig, ThresholdsConfig
 from .decisions import DecisionRecord
 from .features import FeatureRecord
 
-__all__ = ["DecisionRecord", "FeatureRecord", "ScenarioConfig"]
+__all__ = [
+    "AgentWeightConfig",
+    "AgentsConfig",
+    "DecisionRecord",
+    "FeatureRecord",
+    "ScenarioConfig",
+    "ThresholdsConfig",
+]

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -1,2 +1,244 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import isclose
+from pathlib import Path
+from types import MappingProxyType
+from typing import Final, Literal, Mapping, Sequence, TypedDict, cast
+
+import yaml
+
+
+AgentId = Literal[
+    "technical",
+    "domestic_macro",
+    "flow",
+    "valuation",
+    "volatility",
+    "decision",
+]
+KNOWN_AGENT_IDS: Final[frozenset[str]] = frozenset(
+    {
+        "technical",
+        "domestic_macro",
+        "flow",
+        "valuation",
+        "volatility",
+        "decision",
+    }
+)
+WEIGHT_TOLERANCE: Final[float] = 1e-9
+
+
+class ThresholdsConfigDict(TypedDict):
+    up: float
+    down: float
+
+
+class ScenarioConfigDict(TypedDict):
+    scenario_id: str
+    horizon: Literal["next_day"]
+    agents: list[str]
+
+
+class _AgentsConfigRequiredDict(TypedDict):
+    weights: dict[str, float]
+    thresholds: ThresholdsConfigDict
+
+
+class AgentsConfigDict(_AgentsConfigRequiredDict, total=False):
+    rule_versions: dict[str, str]
+
+
+@dataclass(frozen=True, slots=True)
+class AgentWeightConfig:
+    values: Mapping[str, float]
+
+    def __post_init__(self) -> None:
+        weights = _normalize_float_mapping(self.values, context="weights")
+        _validate_known_agent_ids(weights.keys(), context="weights")
+        total = sum(weights.values())
+        if not isclose(total, 1.0, rel_tol=0.0, abs_tol=WEIGHT_TOLERANCE):
+            raise ValueError("weights must sum to 1.0 ± 1e-9")
+        object.__setattr__(self, "values", MappingProxyType(dict(weights)))
+
+    def to_dict(self) -> dict[str, float]:
+        return dict(self.values)
+
+
+@dataclass(frozen=True, slots=True)
+class ThresholdsConfig:
+    up: float
+    down: float
+
+    def __post_init__(self) -> None:
+        if self.up <= self.down:
+            raise ValueError("threshold up must be greater than threshold down")
+
+    def to_dict(self) -> ThresholdsConfigDict:
+        return {"up": self.up, "down": self.down}
+
+
+@dataclass(frozen=True, slots=True)
+class AgentsConfig:
+    weights: AgentWeightConfig
+    thresholds: ThresholdsConfig
+    rule_versions: Mapping[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "rule_versions",
+            MappingProxyType(
+                dict(_normalize_string_mapping(self.rule_versions, context="rule_versions"))
+            ),
+        )
+
+    def to_dict(self) -> AgentsConfigDict:
+        result: AgentsConfigDict = {
+            "weights": self.weights.to_dict(),
+            "thresholds": self.thresholds.to_dict(),
+        }
+        if self.rule_versions:
+            result["rule_versions"] = dict(self.rule_versions)
+        return result
+
+
+@dataclass(frozen=True, slots=True)
 class ScenarioConfig:
-    pass
+    scenario_id: str
+    horizon: Literal["next_day"]
+    agents: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.horizon != "next_day":
+            raise ValueError("horizon must be 'next_day'")
+        agent_ids = tuple(_normalize_string_sequence(self.agents, context="agents"))
+        _validate_known_agent_ids(agent_ids, context="agents")
+        object.__setattr__(self, "agents", agent_ids)
+
+    def to_dict(self) -> ScenarioConfigDict:
+        return {
+            "scenario_id": self.scenario_id,
+            "horizon": self.horizon,
+            "agents": list(self.agents),
+        }
+
+
+def load_agents_config(path: Path) -> AgentsConfig:
+    payload = _load_yaml_mapping(path)
+    weights_payload = _require_mapping(payload, "weights")
+    thresholds_payload = _require_mapping(payload, "thresholds")
+    rule_versions_payload = payload.get("rule_versions", {})
+
+    thresholds = ThresholdsConfig(
+        up=_require_float(thresholds_payload, "up"),
+        down=_require_float(thresholds_payload, "down"),
+    )
+    return AgentsConfig(
+        weights=AgentWeightConfig(_normalize_float_mapping(weights_payload, context="weights")),
+        thresholds=thresholds,
+        rule_versions=_normalize_string_mapping(rule_versions_payload, context="rule_versions"),
+    )
+
+
+def load_scenario_config(path: Path) -> ScenarioConfig:
+    payload = _load_yaml_mapping(path)
+    agents_payload = _require_sequence(payload, "agents")
+
+    return ScenarioConfig(
+        scenario_id=_require_string(payload, "scenario_id"),
+        horizon=_require_horizon(payload),
+        agents=tuple(_normalize_string_sequence(agents_payload, context="agents")),
+    )
+
+
+def _load_yaml_mapping(path: Path) -> Mapping[str, object]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return _ensure_mapping(loaded, context=str(path))
+
+
+def _require_mapping(payload: Mapping[str, object], key: str) -> Mapping[str, object]:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    return _ensure_mapping(payload[key], context=key)
+
+
+def _require_sequence(payload: Mapping[str, object], key: str) -> Sequence[object]:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    return _ensure_sequence(payload[key], context=key)
+
+
+def _require_string(payload: Mapping[str, object], key: str) -> str:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    return _ensure_string(payload[key], context=key)
+
+
+def _require_float(payload: Mapping[str, object], key: str) -> float:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    return _ensure_float(payload[key], context=key)
+
+
+def _require_horizon(payload: Mapping[str, object]) -> Literal["next_day"]:
+    horizon = _require_string(payload, "horizon")
+    if horizon != "next_day":
+        raise ValueError("horizon must be 'next_day'")
+    return cast(Literal["next_day"], horizon)
+
+
+def _ensure_mapping(value: object, context: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{context} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise ValueError(f"{context} keys must be strings")
+    return cast(Mapping[str, object], value)
+
+
+def _ensure_sequence(value: object, context: str) -> Sequence[object]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{context} must be a sequence")
+    return value
+
+
+def _ensure_string(value: object, context: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{context} must be a string")
+    return value
+
+
+def _ensure_float(value: object, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{context} must be a float")
+    return float(value)
+
+
+def _normalize_float_mapping(value: object, context: str) -> dict[str, float]:
+    payload = _ensure_mapping(value, context=context)
+    return {
+        key: _ensure_float(raw_value, context=f"{context}.{key}")
+        for key, raw_value in payload.items()
+    }
+
+
+def _normalize_string_mapping(value: object, context: str) -> dict[str, str]:
+    payload = _ensure_mapping(value, context=context)
+    return {
+        key: _ensure_string(raw_value, context=f"{context}.{key}")
+        for key, raw_value in payload.items()
+    }
+
+
+def _normalize_string_sequence(value: object, context: str) -> tuple[str, ...]:
+    sequence = _ensure_sequence(value, context=context)
+    return tuple(_ensure_string(item, context=f"{context}[]") for item in sequence)
+
+
+def _validate_known_agent_ids(agent_ids: Sequence[str], context: str) -> None:
+    unknown_agent_ids = sorted(
+        agent_id for agent_id in agent_ids if agent_id not in KNOWN_AGENT_IDS
+    )
+    if unknown_agent_ids:
+        raise ValueError(f"unknown agent ids in {context}: {', '.join(unknown_agent_ids)}")

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import isclose
 from pathlib import Path
 from types import MappingProxyType
-from typing import Final, Literal, Mapping, Sequence, TypedDict, cast
+from typing import Final, Literal, TypedDict, cast
 
 import yaml
 
@@ -50,6 +51,10 @@ class AgentsConfigDict(_AgentsConfigRequiredDict, total=False):
     rule_versions: dict[str, str]
 
 
+def _empty_rule_versions() -> Mapping[str, str]:
+    return {}
+
+
 @dataclass(frozen=True, slots=True)
 class AgentWeightConfig:
     values: Mapping[str, float]
@@ -72,8 +77,12 @@ class ThresholdsConfig:
     down: float
 
     def __post_init__(self) -> None:
-        if self.up <= self.down:
+        up = _ensure_float(self.up, context="up")
+        down = _ensure_float(self.down, context="down")
+        if up <= down:
             raise ValueError("threshold up must be greater than threshold down")
+        object.__setattr__(self, "up", up)
+        object.__setattr__(self, "down", down)
 
     def to_dict(self) -> ThresholdsConfigDict:
         return {"up": self.up, "down": self.down}
@@ -83,7 +92,7 @@ class ThresholdsConfig:
 class AgentsConfig:
     weights: AgentWeightConfig
     thresholds: ThresholdsConfig
-    rule_versions: Mapping[str, str] = field(default_factory=dict)
+    rule_versions: Mapping[str, str] = field(default_factory=_empty_rule_versions)
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -111,10 +120,12 @@ class ScenarioConfig:
     agents: tuple[str, ...]
 
     def __post_init__(self) -> None:
+        scenario_id = _ensure_string(self.scenario_id, context="scenario_id")
         if self.horizon != "next_day":
             raise ValueError("horizon must be 'next_day'")
         agent_ids = tuple(_normalize_string_sequence(self.agents, context="agents"))
         _validate_known_agent_ids(agent_ids, context="agents")
+        object.__setattr__(self, "scenario_id", scenario_id)
         object.__setattr__(self, "agents", agent_ids)
 
     def to_dict(self) -> ScenarioConfigDict:
@@ -129,7 +140,7 @@ def load_agents_config(path: Path) -> AgentsConfig:
     payload = _load_yaml_mapping(path)
     weights_payload = _require_mapping(payload, "weights")
     thresholds_payload = _require_mapping(payload, "thresholds")
-    rule_versions_payload = payload.get("rule_versions", {})
+    rule_versions_payload: object = payload["rule_versions"] if "rule_versions" in payload else {}
 
     thresholds = ThresholdsConfig(
         up=_require_float(thresholds_payload, "up"),
@@ -154,7 +165,7 @@ def load_scenario_config(path: Path) -> ScenarioConfig:
 
 
 def _load_yaml_mapping(path: Path) -> Mapping[str, object]:
-    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    loaded = cast(object, yaml.safe_load(path.read_text(encoding="utf-8")))
     return _ensure_mapping(loaded, context=str(path))
 
 
@@ -186,14 +197,15 @@ def _require_horizon(payload: Mapping[str, object]) -> Literal["next_day"]:
     horizon = _require_string(payload, "horizon")
     if horizon != "next_day":
         raise ValueError("horizon must be 'next_day'")
-    return cast(Literal["next_day"], horizon)
+    return "next_day"
 
 
 def _ensure_mapping(value: object, context: str) -> Mapping[str, object]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{context} must be a mapping")
-    if not all(isinstance(key, str) for key in value):
-        raise ValueError(f"{context} keys must be strings")
+    for raw_key in cast(Iterable[object], value.keys()):
+        if not isinstance(raw_key, str):
+            raise ValueError(f"{context} keys must be strings")
     return cast(Mapping[str, object], value)
 
 
@@ -236,7 +248,7 @@ def _normalize_string_sequence(value: object, context: str) -> tuple[str, ...]:
     return tuple(_ensure_string(item, context=f"{context}[]") for item in sequence)
 
 
-def _validate_known_agent_ids(agent_ids: Sequence[str], context: str) -> None:
+def _validate_known_agent_ids(agent_ids: Iterable[str], context: str) -> None:
     unknown_agent_ids = sorted(
         agent_id for agent_id in agent_ids if agent_id not in KNOWN_AGENT_IDS
     )

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
+from typing import Literal, cast
 
 import pytest
 import yaml
@@ -21,7 +23,7 @@ SCENARIO_CONFIG_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "scenario.ko
 
 
 def write_yaml(path: Path, content: object) -> Path:
-    path.write_text(yaml.safe_dump(content, sort_keys=False), encoding="utf-8")
+    _ = path.write_text(yaml.safe_dump(content, sort_keys=False), encoding="utf-8")
     return path
 
 
@@ -79,14 +81,64 @@ def test_config_dataclasses_construct_and_serialize() -> None:
     }
 
 
+def test_agents_config_defaults_rule_versions_to_empty_mapping() -> None:
+    config = AgentsConfig(
+        weights=AgentWeightConfig(
+            {
+                "technical": 0.30,
+                "domestic_macro": 0.20,
+                "flow": 0.25,
+                "valuation": 0.10,
+                "volatility": 0.15,
+            }
+        ),
+        thresholds=ThresholdsConfig(up=0.25, down=-0.25),
+    )
+
+    assert config.rule_versions == {}
+    assert config.to_dict() == {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+    }
+
+
 def test_agent_weight_config_rejects_sum_not_equal_to_one() -> None:
     with pytest.raises(ValueError, match="sum to 1.0"):
-        AgentWeightConfig({"technical": 0.6, "flow": 0.3})
+        _ = AgentWeightConfig({"technical": 0.6, "flow": 0.3})
 
 
 def test_thresholds_config_rejects_invalid_ordering() -> None:
     with pytest.raises(ValueError, match="up.*greater than.*down"):
-        ThresholdsConfig(up=0.10, down=0.10)
+        _ = ThresholdsConfig(up=0.10, down=0.10)
+
+
+def test_thresholds_config_rejects_non_float_values_when_constructed_directly() -> None:
+    with pytest.raises(ValueError, match="up must be a float"):
+        _ = ThresholdsConfig(up=True, down=-0.25)
+
+
+def test_scenario_config_rejects_invalid_horizon_when_constructed_directly() -> None:
+    with pytest.raises(ValueError, match="next_day"):
+        _ = ScenarioConfig(
+            scenario_id="kospi.weekly",
+            horizon=cast(Literal["next_day"], cast(object, "weekly")),
+            agents=("technical", "decision"),
+        )
+
+
+def test_scenario_config_rejects_non_string_scenario_id_when_constructed_directly() -> None:
+    with pytest.raises(ValueError, match="scenario_id must be a string"):
+        _ = ScenarioConfig(
+            scenario_id=cast(str, cast(object, 1)),
+            horizon="next_day",
+            agents=("technical", "decision"),
+        )
 
 
 def test_load_agents_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
@@ -103,7 +155,7 @@ def test_load_agents_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="unknown agent"):
-        load_agents_config(config_path)
+        _ = load_agents_config(config_path)
 
 
 def test_load_scenario_config_rejects_invalid_horizon(tmp_path: Path) -> None:
@@ -117,7 +169,7 @@ def test_load_scenario_config_rejects_invalid_horizon(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="next_day"):
-        load_scenario_config(config_path)
+        _ = load_scenario_config(config_path)
 
 
 def test_load_scenario_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
@@ -131,7 +183,94 @@ def test_load_scenario_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="unknown agent"):
-        load_scenario_config(config_path)
+        _ = load_scenario_config(config_path)
+
+
+def test_load_agents_config_rejects_non_mapping_root(tmp_path: Path) -> None:
+    config_path = write_yaml(tmp_path / "agents.yaml", ["not", "a", "mapping"])
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_non_string_weight_keys(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "agents.yaml",
+        {
+            "weights": {1: 0.50, "flow": 0.50},
+            "thresholds": {"up": 0.25, "down": -0.25},
+        },
+    )
+
+    with pytest.raises(ValueError, match="keys must be strings"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_missing_threshold_value(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "agents.yaml",
+        {
+            "weights": {"technical": 0.50, "flow": 0.50},
+            "thresholds": {"down": -0.25},
+        },
+    )
+
+    with pytest.raises(ValueError, match="up"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_non_float_threshold_value(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "agents.yaml",
+        {
+            "weights": {"technical": 0.50, "flow": 0.50},
+            "thresholds": {"up": "high", "down": -0.25},
+        },
+    )
+
+    with pytest.raises(ValueError, match="up must be a float"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_scenario_config_rejects_non_string_scenario_id(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": 1,
+            "horizon": "next_day",
+            "agents": ["technical", "decision"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="scenario_id must be a string"):
+        _ = load_scenario_config(config_path)
+
+
+def test_load_scenario_config_rejects_missing_scenario_id(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "horizon": "next_day",
+            "agents": ["technical", "decision"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="scenario_id"):
+        _ = load_scenario_config(config_path)
+
+
+def test_load_scenario_config_rejects_non_sequence_agents(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": "kospi.next_day",
+            "horizon": "next_day",
+            "agents": "technical",
+        },
+    )
+
+    with pytest.raises(ValueError, match="agents must be a sequence"):
+        _ = load_scenario_config(config_path)
 
 
 @pytest.mark.parametrize(
@@ -155,13 +294,13 @@ def test_loaders_reject_missing_required_keys(
     tmp_path: Path,
     filename: str,
     content: object,
-    loader: object,
+    loader: Callable[[Path], object],
     missing_key: str,
 ) -> None:
     config_path = write_yaml(tmp_path / filename, content)
 
     with pytest.raises(ValueError, match=missing_key):
-        loader(config_path)
+        _ = loader(config_path)
 
 
 def test_agents_config_round_trip(tmp_path: Path) -> None:

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kospi_decision_pipeline_core.schemas.config import (
+    AgentWeightConfig,
+    AgentsConfig,
+    ScenarioConfig,
+    ThresholdsConfig,
+    load_agents_config,
+    load_scenario_config,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGENTS_CONFIG_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "agents.yaml"
+SCENARIO_CONFIG_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "scenario.kospi.next_day.yaml"
+
+
+def write_yaml(path: Path, content: object) -> Path:
+    path.write_text(yaml.safe_dump(content, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_config_dataclasses_construct_and_serialize() -> None:
+    weights = AgentWeightConfig(
+        {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        }
+    )
+    thresholds = ThresholdsConfig(up=0.25, down=-0.25)
+    config = AgentsConfig(
+        weights=weights,
+        thresholds=thresholds,
+        rule_versions={"decision": "v1"},
+    )
+    scenario = ScenarioConfig(
+        scenario_id="kospi.next_day",
+        horizon="next_day",
+        agents=(
+            "technical",
+            "domestic_macro",
+            "flow",
+            "valuation",
+            "volatility",
+            "decision",
+        ),
+    )
+
+    assert config.to_dict() == {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+        "rule_versions": {"decision": "v1"},
+    }
+    assert scenario.to_dict() == {
+        "scenario_id": "kospi.next_day",
+        "horizon": "next_day",
+        "agents": [
+            "technical",
+            "domestic_macro",
+            "flow",
+            "valuation",
+            "volatility",
+            "decision",
+        ],
+    }
+
+
+def test_agent_weight_config_rejects_sum_not_equal_to_one() -> None:
+    with pytest.raises(ValueError, match="sum to 1.0"):
+        AgentWeightConfig({"technical": 0.6, "flow": 0.3})
+
+
+def test_thresholds_config_rejects_invalid_ordering() -> None:
+    with pytest.raises(ValueError, match="up.*greater than.*down"):
+        ThresholdsConfig(up=0.10, down=0.10)
+
+
+def test_load_agents_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "agents.yaml",
+        {
+            "weights": {
+                "technical": 0.50,
+                "flow": 0.25,
+                "mystery": 0.25,
+            },
+            "thresholds": {"up": 0.25, "down": -0.25},
+        },
+    )
+
+    with pytest.raises(ValueError, match="unknown agent"):
+        load_agents_config(config_path)
+
+
+def test_load_scenario_config_rejects_invalid_horizon(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": "kospi.weekly",
+            "horizon": "weekly",
+            "agents": ["technical", "decision"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="next_day"):
+        load_scenario_config(config_path)
+
+
+def test_load_scenario_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": "kospi.next_day",
+            "horizon": "next_day",
+            "agents": ["technical", "mystery"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="unknown agent"):
+        load_scenario_config(config_path)
+
+
+@pytest.mark.parametrize(
+    ("filename", "content", "loader", "missing_key"),
+    [
+        (
+            "agents.yaml",
+            {"thresholds": {"up": 0.25, "down": -0.25}},
+            load_agents_config,
+            "weights",
+        ),
+        (
+            "scenario.yaml",
+            {"scenario_id": "kospi.next_day", "horizon": "next_day"},
+            load_scenario_config,
+            "agents",
+        ),
+    ],
+)
+def test_loaders_reject_missing_required_keys(
+    tmp_path: Path,
+    filename: str,
+    content: object,
+    loader: object,
+    missing_key: str,
+) -> None:
+    config_path = write_yaml(tmp_path / filename, content)
+
+    with pytest.raises(ValueError, match=missing_key):
+        loader(config_path)
+
+
+def test_agents_config_round_trip(tmp_path: Path) -> None:
+    loaded = load_agents_config(AGENTS_CONFIG_PATH)
+    round_trip_path = write_yaml(tmp_path / "agents.roundtrip.yaml", loaded.to_dict())
+
+    assert load_agents_config(round_trip_path) == loaded
+
+
+def test_scenario_config_round_trip(tmp_path: Path) -> None:
+    loaded = load_scenario_config(SCENARIO_CONFIG_PATH)
+    round_trip_path = write_yaml(tmp_path / "scenario.roundtrip.yaml", loaded.to_dict())
+
+    assert load_scenario_config(round_trip_path) == loaded
+
+
+def test_default_config_files_load_successfully() -> None:
+    agents_config = load_agents_config(AGENTS_CONFIG_PATH)
+    scenario_config = load_scenario_config(SCENARIO_CONFIG_PATH)
+
+    assert agents_config.to_dict() == {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+    }
+    assert scenario_config.to_dict() == {
+        "scenario_id": "kospi.next_day",
+        "horizon": "next_day",
+        "agents": [
+            "technical",
+            "domestic_macro",
+            "flow",
+            "valuation",
+            "volatility",
+            "decision",
+        ],
+    }

--- a/core/tests/unit/test_core_modules.py
+++ b/core/tests/unit/test_core_modules.py
@@ -32,4 +32,11 @@ def test_decision_dataclass() -> None:
 def test_schema_stubs_are_instantiable() -> None:
     assert isinstance(DecisionRecord(), DecisionRecord)
     assert isinstance(FeatureRecord(), FeatureRecord)
-    assert isinstance(ScenarioConfig(), ScenarioConfig)
+    assert isinstance(
+        ScenarioConfig(
+            scenario_id="kospi.next_day",
+            horizon="next_day",
+            agents=("technical", "decision"),
+        ),
+        ScenarioConfig,
+    )


### PR DESCRIPTION
## Summary
- add frozen typed config schemas and YAML loaders for `agents.yaml` and `scenario.kospi.next_day.yaml`
- validate weight sums, threshold ordering, required keys, agent IDs, and round-trip serialization through exhaustive tests
- keep source lint/type-clean with 100% coverage for the new config loader code