### PR TITLE
[#6] Bronze ingest pipeline and ingest CLI command

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -1,19 +1,91 @@
 from __future__ import annotations
 
 import argparse
-from typing import cast
+from datetime import date
+import os
+from pathlib import Path
+
+from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry, LiveConnectorRegistry
+
+
+def _parse_date(value: str) -> date:
+    return date.fromisoformat(value)
+
+
+def _fixtures_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "tests" / "fixtures"
+
+
+def _is_live_mode_requested(live_flag: bool) -> bool:
+    return live_flag or os.getenv("KOSPI_LIVE") == "1"
+
+
+def run_ingest_command(
+    *,
+    source: str,
+    dataset: str,
+    start: str,
+    end: str,
+    output_dir: str,
+    live: bool,
+) -> int:
+    registry = (
+        LiveConnectorRegistry()
+        if _is_live_mode_requested(live)
+        else FixtureConnectorRegistry(_fixtures_root())
+    )
+    connector = registry.get_connector(source)
+    ingestor = BronzeIngestor(output_root=Path(output_dir))
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id=dataset,
+        start=_parse_date(start),
+        end=_parse_date(end),
+    )
+    for entry in result.entries:
+        print(f"wrote {entry.path.as_posix()} sha256={entry.sha256}")
+    return 0
+
+
+class _CliArgs(argparse.Namespace):
+    cmd: str | None = None
+    source: str = ""
+    dataset: str = ""
+    start: str = ""
+    end: str = ""
+    output_dir: str = "data/bronze"
+    live: bool = False
 
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="kospi-pipeline")
     _ = parser.add_argument("--version", action="version", version="0.0.1")
     sub = parser.add_subparsers(dest="cmd", required=False)
-    for name in ("ingest", "build-features", "run", "backtest", "report"):
+    ingest_parser = sub.add_parser("ingest", help="ingest Bronze data")
+    _ = ingest_parser.add_argument(
+        "--source", choices=("krx", "ecos", "kosis", "data_portal"), required=True
+    )
+    _ = ingest_parser.add_argument("--dataset", required=True)
+    _ = ingest_parser.add_argument("--from", dest="start", required=True)
+    _ = ingest_parser.add_argument("--to", dest="end", required=True)
+    _ = ingest_parser.add_argument("--out", dest="output_dir", default="data/bronze")
+    _ = ingest_parser.add_argument("--live", action="store_true")
+    for name in ("build-features", "run", "backtest", "report"):
         _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
-    args = parser.parse_args(argv)
-    cmd = cast(str | None, args.cmd)
+    args = parser.parse_args(argv, namespace=_CliArgs())
+    cmd = args.cmd
     if cmd is None:
         parser.print_help()
         return 0
+    if cmd == "ingest":
+        live_mode = _is_live_mode_requested(bool(args.live))
+        return run_ingest_command(
+            source=str(args.source),
+            dataset=str(args.dataset),
+            start=str(args.start),
+            end=str(args.end),
+            output_dir=str(args.output_dir),
+            live=live_mode,
+        )
     print(f"{cmd}: not yet implemented")
     return 0

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, fields
+from datetime import date, datetime, timezone
+from decimal import Decimal
+import hashlib
+from pathlib import Path
+from typing import Protocol, cast, final
+
+import pyarrow as _pa
+import pyarrow.parquet as _pq
+
+from ..connectors import (
+    DataPortalConnector,
+    EcosConnector,
+    FixtureDataPortalConnector,
+    FixtureEcosConnector,
+    FixtureKosisConnector,
+    FixtureKrxConnector,
+    KosisConnector,
+    KrxConnector,
+)
+from ..connectors.base import ConnectorRow
+from .manifests import BronzeManifest, ManifestEntry, write_manifest
+
+
+SourceName = str
+DatasetId = str
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, str | int]]) -> object: ...
+
+
+class _ParquetWriter(Protocol):
+    def write_table(self, table: object, where: Path, *, compression: str) -> None: ...
+
+
+ARROW_TABLE = cast(_ArrowTableFactory, _pa.Table)
+PARQUET_WRITER: _ParquetWriter = _pq
+
+
+@dataclass(frozen=True, slots=True)
+class BronzeIngestResult:
+    entries: tuple[ManifestEntry, ...]
+    manifest_path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class _DatasetDefinition:
+    source_name: str
+    date_field_name: str
+    fetch_rows: _FetchRows
+
+
+class _FetchRows(Protocol):
+    def __call__(self, connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]: ...
+
+
+def _fetch_krx_kospi_index(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(KrxConnector, connector)
+    return tuple(typed_connector.fetch_kospi_index(start, end))
+
+
+def _fetch_krx_investor_flow(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(KrxConnector, connector)
+    return tuple(typed_connector.fetch_investor_flow(start, end))
+
+
+def _fetch_krx_market_valuation(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(KrxConnector, connector)
+    return tuple(typed_connector.fetch_market_valuation(start, end))
+
+
+def _fetch_ecos_base_rate(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(EcosConnector, connector)
+    return tuple(typed_connector.fetch_base_rate_series(start, end))
+
+
+def _fetch_ecos_usd_krw(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(EcosConnector, connector)
+    return tuple(typed_connector.fetch_usd_krw_series(start, end))
+
+
+def _fetch_ecos_bond_yield(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(EcosConnector, connector)
+    return tuple(typed_connector.fetch_bond_yield_series(start, end))
+
+
+def _fetch_kosis_per_pbr(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(KosisConnector, connector)
+    return tuple(typed_connector.fetch_per_pbr_percentiles(start, end))
+
+
+def _fetch_kosis_macro(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(KosisConnector, connector)
+    return tuple(typed_connector.fetch_macro_indicators(start, end))
+
+
+def _fetch_data_portal_sample(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRow, ...]:
+    typed_connector = cast(DataPortalConnector, connector)
+    return tuple(typed_connector.fetch_sample_dataset(start, end))
+
+
+DATASET_DEFINITIONS: dict[str, _DatasetDefinition] = {
+    "kospi_index": _DatasetDefinition(
+        source_name="krx",
+        date_field_name="trade_date",
+        fetch_rows=_fetch_krx_kospi_index,
+    ),
+    "investor_flow": _DatasetDefinition(
+        source_name="krx",
+        date_field_name="trade_date",
+        fetch_rows=_fetch_krx_investor_flow,
+    ),
+    "market_valuation": _DatasetDefinition(
+        source_name="krx",
+        date_field_name="trade_date",
+        fetch_rows=_fetch_krx_market_valuation,
+    ),
+    "base_rate": _DatasetDefinition(
+        source_name="ecos",
+        date_field_name="value_date",
+        fetch_rows=_fetch_ecos_base_rate,
+    ),
+    "usd_krw": _DatasetDefinition(
+        source_name="ecos",
+        date_field_name="value_date",
+        fetch_rows=_fetch_ecos_usd_krw,
+    ),
+    "bond_yield": _DatasetDefinition(
+        source_name="ecos",
+        date_field_name="value_date",
+        fetch_rows=_fetch_ecos_bond_yield,
+    ),
+    "per_pbr_percentiles": _DatasetDefinition(
+        source_name="kosis",
+        date_field_name="value_date",
+        fetch_rows=_fetch_kosis_per_pbr,
+    ),
+    "macro_indicators": _DatasetDefinition(
+        source_name="kosis",
+        date_field_name="value_date",
+        fetch_rows=_fetch_kosis_macro,
+    ),
+    "sample_dataset": _DatasetDefinition(
+        source_name="data_portal",
+        date_field_name="value_date",
+        fetch_rows=_fetch_data_portal_sample,
+    ),
+}
+
+
+@final
+class BronzeIngestor:
+    _output_root: Path
+    _deterministic_run_timestamp: datetime | None
+
+    def __init__(
+        self, output_root: Path, deterministic_run_timestamp: datetime | None = None
+    ) -> None:
+        self._output_root = output_root
+        self._deterministic_run_timestamp = deterministic_run_timestamp
+
+    def ingest(
+        self,
+        connector: object,
+        dataset_id: str,
+        start: date,
+        end: date,
+    ) -> BronzeIngestResult:
+        definition = DATASET_DEFINITIONS.get(dataset_id)
+        if definition is None:
+            raise ValueError(f"unsupported dataset: {dataset_id}")
+
+        rows = definition.fetch_rows(connector, start, end)
+        grouped_rows = _group_rows_by_date(rows, definition.date_field_name)
+        entries = tuple(
+            self._write_partition(
+                source_name=definition.source_name,
+                dataset_id=dataset_id,
+                as_of_date=as_of_date,
+                rows=partition_rows,
+            )
+            for as_of_date, partition_rows in grouped_rows
+        )
+
+        manifest = BronzeManifest(
+            dataset_id=dataset_id,
+            source_name=definition.source_name,
+            run_timestamp=self._resolve_run_timestamp(),
+            entries=entries,
+        )
+        manifest_path = self._output_root / definition.source_name / dataset_id / "manifest.json"
+        write_manifest(manifest_path, manifest)
+        return BronzeIngestResult(entries=entries, manifest_path=manifest_path)
+
+    def _resolve_run_timestamp(self) -> datetime:
+        if self._deterministic_run_timestamp is not None:
+            return self._deterministic_run_timestamp
+        return datetime.now(timezone.utc).replace(microsecond=0)
+
+    def _write_partition(
+        self,
+        source_name: str,
+        dataset_id: str,
+        as_of_date: date,
+        rows: tuple[ConnectorRow, ...],
+    ) -> ManifestEntry:
+        relative_path = Path(source_name) / dataset_id / f"{as_of_date.isoformat()}.parquet"
+        output_path = self._output_root / relative_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        records = [_row_to_record(row) for row in rows]
+        sorted_records = tuple(sorted(records, key=_record_sort_key))
+        table = ARROW_TABLE.from_pylist(list(sorted_records))
+        PARQUET_WRITER.write_table(table, output_path, compression="snappy")
+
+        return ManifestEntry(
+            path=relative_path,
+            sha256=hashlib.sha256(output_path.read_bytes()).hexdigest(),
+            row_count=len(sorted_records),
+            fetched_at=str(sorted_records[0]["fetched_at"]),
+        )
+
+
+def _group_rows_by_date(
+    rows: tuple[ConnectorRow, ...], date_field_name: str
+) -> tuple[tuple[date, tuple[ConnectorRow, ...]], ...]:
+    grouped: dict[date, list[ConnectorRow]] = {}
+    for row in rows:
+        as_of_date = cast(date, getattr(row, date_field_name))
+        grouped.setdefault(as_of_date, []).append(row)
+    return tuple((as_of_date, tuple(grouped[as_of_date])) for as_of_date in sorted(grouped))
+
+
+def _row_to_record(row: ConnectorRow) -> dict[str, str | int]:
+    payload = cast(dict[str, object], asdict(row))
+    metadata = payload.pop("metadata")
+    if not isinstance(metadata, dict):
+        raise ValueError("row metadata must serialize to a dictionary")
+    metadata_payload = cast(dict[str, object], metadata)
+    record: dict[str, str | int] = {
+        "source_name": _normalize_scalar(metadata_payload["source_name"]),
+        "source_series_id": _normalize_scalar(metadata_payload["source_series_id"]),
+        "fetched_at": _normalize_scalar(metadata_payload["fetched_at"]),
+    }
+    ordered_field_names = sorted(field.name for field in fields(row) if field.name != "metadata")
+    for field_name in ordered_field_names:
+        value = payload[field_name]
+        record[field_name] = _normalize_scalar(value)
+    return record
+
+
+def _normalize_scalar(value: object) -> str | int:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int):
+        return value
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    return str(value)
+
+
+def _record_sort_key(record: dict[str, str | int]) -> tuple[str, ...]:
+    return tuple(f"{key}={record[key]}" for key in sorted(record))
+
+
+class ConnectorRegistry(Protocol):
+    def get_connector(self, source: str) -> object: ...
+
+
+@final
+class FixtureConnectorRegistry:
+    _fixtures_root: Path
+
+    def __init__(self, fixtures_root: Path) -> None:
+        self._fixtures_root = fixtures_root
+
+    def get_connector(self, source: str) -> object:
+        registry: dict[str, object] = {
+            "krx": FixtureKrxConnector(self._fixtures_root),
+            "ecos": FixtureEcosConnector(self._fixtures_root),
+            "kosis": FixtureKosisConnector(self._fixtures_root),
+            "data_portal": FixtureDataPortalConnector(self._fixtures_root),
+        }
+        if source not in registry:
+            raise ValueError(f"unsupported source: {source}")
+        return registry[source]
+
+
+@final
+class LiveConnectorRegistry:
+    def get_connector(self, source: str) -> object:
+        raise NotImplementedError(f"live connector not implemented for source: {source}")

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/manifests.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/manifests.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import TypedDict, cast
+
+
+class ManifestEntryDict(TypedDict):
+    path: str
+    sha256: str
+    row_count: int
+    fetched_at: str
+
+
+class BronzeManifestDict(TypedDict):
+    dataset_id: str
+    source_name: str
+    run_timestamp: str
+    entries: list[ManifestEntryDict]
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestEntry:
+    path: Path
+    sha256: str
+    row_count: int
+    fetched_at: str
+
+    def to_dict(self) -> ManifestEntryDict:
+        return {
+            "path": self.path.as_posix(),
+            "sha256": self.sha256,
+            "row_count": self.row_count,
+            "fetched_at": self.fetched_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: ManifestEntryDict) -> ManifestEntry:
+        return cls(
+            path=Path(payload["path"]),
+            sha256=payload["sha256"],
+            row_count=payload["row_count"],
+            fetched_at=payload["fetched_at"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BronzeManifest:
+    dataset_id: str
+    source_name: str
+    run_timestamp: datetime
+    entries: tuple[ManifestEntry, ...]
+
+    def to_dict(self) -> BronzeManifestDict:
+        return {
+            "dataset_id": self.dataset_id,
+            "source_name": self.source_name,
+            "run_timestamp": self.run_timestamp.isoformat(),
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    def to_deterministic_dict(self) -> dict[str, object]:
+        return {
+            "dataset_id": self.dataset_id,
+            "source_name": self.source_name,
+            "entries": [entry.to_dict() for entry in self.entries],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: BronzeManifestDict) -> BronzeManifest:
+        return cls(
+            dataset_id=payload["dataset_id"],
+            source_name=payload["source_name"],
+            run_timestamp=datetime.fromisoformat(payload["run_timestamp"]),
+            entries=tuple(ManifestEntry.from_dict(raw_entry) for raw_entry in payload["entries"]),
+        )
+
+
+def write_manifest(path: Path, manifest: BronzeManifest) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(
+        json.dumps(manifest.to_dict(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def read_manifest(path: Path) -> BronzeManifest:
+    loaded = cast(object, json.loads(path.read_text(encoding="utf-8")))
+    if not isinstance(loaded, dict):
+        raise ValueError("manifest payload must be an object")
+    return BronzeManifest.from_dict(cast(BronzeManifestDict, cast(object, loaded)))

--- a/apps/kr-kospi/tests/contract/test_bronze_ingest.py
+++ b/apps/kr-kospi/tests/contract/test_bronze_ingest.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
+from typing import cast
 
 import pytest
 
-from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import FixtureKrxConnector
-from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import BronzeIngestor
+from kospi_decision_pipeline_app_kr_kospi.connectors.base import ConnectorRow
+from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import (
+    FixtureDataPortalConnector,
+    FixtureEcosConnector,
+    FixtureKosisConnector,
+    FixtureKrxConnector,
+)
+from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import (
+    BronzeIngestor,
+    FixtureConnectorRegistry,
+    LiveConnectorRegistry,
+    _normalize_scalar,
+    _row_to_record,
+)
 from kospi_decision_pipeline_app_kr_kospi.ingest.manifests import (
     BronzeManifest,
     read_manifest,
@@ -15,6 +29,36 @@ from kospi_decision_pipeline_app_kr_kospi.ingest.manifests import (
 
 FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
 RUN_TIMESTAMP = datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("connector", "dataset_id", "source_name"),
+    [
+        (FixtureKrxConnector(FIXTURES_ROOT), "kospi_index", "krx"),
+        (FixtureKrxConnector(FIXTURES_ROOT), "investor_flow", "krx"),
+        (FixtureKrxConnector(FIXTURES_ROOT), "market_valuation", "krx"),
+        (FixtureEcosConnector(FIXTURES_ROOT), "base_rate", "ecos"),
+        (FixtureEcosConnector(FIXTURES_ROOT), "usd_krw", "ecos"),
+        (FixtureEcosConnector(FIXTURES_ROOT), "bond_yield", "ecos"),
+        (FixtureKosisConnector(FIXTURES_ROOT), "per_pbr_percentiles", "kosis"),
+        (FixtureKosisConnector(FIXTURES_ROOT), "macro_indicators", "kosis"),
+        (FixtureDataPortalConnector(FIXTURES_ROOT), "sample_dataset", "data_portal"),
+    ],
+)
+def test_bronze_ingest_supports_all_fixture_datasets(
+    tmp_path: Path, connector: object, dataset_id: str, source_name: str
+) -> None:
+    ingestor = BronzeIngestor(output_root=tmp_path, deterministic_run_timestamp=RUN_TIMESTAMP)
+
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id=dataset_id,
+        start=date(2024, 1, 2),
+        end=date(2024, 1, 4),
+    )
+
+    assert result.entries
+    assert all(entry.path.parts[0] == source_name for entry in result.entries)
 
 
 def _run_ingest(output_root: Path) -> tuple[tuple[str, ...], BronzeManifest]:
@@ -87,3 +131,66 @@ def test_bronze_ingest_raises_for_unknown_dataset(tmp_path: Path) -> None:
             start=date(2024, 1, 2),
             end=date(2024, 1, 4),
         )
+
+
+def test_bronze_ingest_uses_current_time_when_no_deterministic_timestamp(tmp_path: Path) -> None:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ingestor = BronzeIngestor(output_root=tmp_path)
+
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id="kospi_index",
+        start=date(2024, 1, 2),
+        end=date(2024, 1, 2),
+    )
+    manifest = read_manifest(result.manifest_path)
+
+    assert manifest.run_timestamp.tzinfo == timezone.utc
+    assert manifest.run_timestamp.microsecond == 0
+
+
+def test_fixture_connector_registry_returns_expected_connectors() -> None:
+    registry = FixtureConnectorRegistry(FIXTURES_ROOT)
+
+    assert isinstance(registry.get_connector("krx"), FixtureKrxConnector)
+    assert isinstance(registry.get_connector("ecos"), FixtureEcosConnector)
+    assert isinstance(registry.get_connector("kosis"), FixtureKosisConnector)
+    assert isinstance(registry.get_connector("data_portal"), FixtureDataPortalConnector)
+
+
+def test_fixture_connector_registry_rejects_unknown_source() -> None:
+    registry = FixtureConnectorRegistry(FIXTURES_ROOT)
+
+    with pytest.raises(ValueError, match="unsupported source"):
+        registry.get_connector("missing")
+
+
+def test_live_connector_registry_is_a_non_ci_hook() -> None:
+    registry = LiveConnectorRegistry()
+
+    with pytest.raises(NotImplementedError, match="live connector not implemented"):
+        registry.get_connector("krx")
+
+
+def test_row_to_record_rejects_non_mapping_metadata() -> None:
+    @dataclass(frozen=True, slots=True)
+    class BrokenRow:
+        metadata: object
+        trade_date: date
+
+    broken_row = BrokenRow(metadata="broken", trade_date=date(2024, 1, 2))
+
+    with pytest.raises(ValueError, match="metadata"):
+        _row_to_record(cast(ConnectorRow, broken_row))
+
+
+def test_normalize_scalar_handles_boolean_branch() -> None:
+    assert _normalize_scalar(True) == "true"
+
+
+def test_read_manifest_rejects_non_object_payload(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    _ = manifest_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="manifest payload must be an object"):
+        read_manifest(manifest_path)

--- a/apps/kr-kospi/tests/contract/test_bronze_ingest.py
+++ b/apps/kr-kospi/tests/contract/test_bronze_ingest.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import FixtureKrxConnector
+from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import BronzeIngestor
+from kospi_decision_pipeline_app_kr_kospi.ingest.manifests import (
+    BronzeManifest,
+    read_manifest,
+)
+
+
+FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
+RUN_TIMESTAMP = datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc)
+
+
+def _run_ingest(output_root: Path) -> tuple[tuple[str, ...], BronzeManifest]:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ingestor = BronzeIngestor(output_root=output_root, deterministic_run_timestamp=RUN_TIMESTAMP)
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id="kospi_index",
+        start=date(2024, 1, 2),
+        end=date(2024, 1, 4),
+    )
+    manifest = read_manifest(output_root / "krx" / "kospi_index" / "manifest.json")
+    return tuple(entry.sha256 for entry in result.entries), manifest
+
+
+def test_fixture_bronze_ingest_writes_partitioned_parquet_and_manifest(tmp_path: Path) -> None:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ingestor = BronzeIngestor(output_root=tmp_path, deterministic_run_timestamp=RUN_TIMESTAMP)
+
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id="kospi_index",
+        start=date(2024, 1, 2),
+        end=date(2024, 1, 4),
+    )
+
+    written_paths = [entry.path for entry in result.entries]
+    assert written_paths == [
+        Path("krx/kospi_index/2024-01-02.parquet"),
+        Path("krx/kospi_index/2024-01-03.parquet"),
+        Path("krx/kospi_index/2024-01-04.parquet"),
+    ]
+    assert all((tmp_path / path).is_file() for path in written_paths)
+
+    manifest = read_manifest(tmp_path / "krx" / "kospi_index" / "manifest.json")
+    assert manifest.dataset_id == "kospi_index"
+    assert manifest.source_name == "krx"
+    assert manifest.run_timestamp == RUN_TIMESTAMP
+    assert [entry.path for entry in manifest.entries] == written_paths
+    assert [entry.row_count for entry in manifest.entries] == [1, 1, 1]
+    assert [entry.fetched_at for entry in manifest.entries] == [
+        "2024-01-10T09:00:00+00:00",
+        "2024-01-10T09:00:00+00:00",
+        "2024-01-10T09:00:00+00:00",
+    ]
+
+
+def test_fixture_bronze_ingest_is_deterministic_for_same_input(tmp_path: Path) -> None:
+    first_hashes, first_manifest = _run_ingest(tmp_path / "run-one")
+    second_hashes, second_manifest = _run_ingest(tmp_path / "run-two")
+
+    assert first_hashes == second_hashes
+    assert first_manifest.to_deterministic_dict() == second_manifest.to_deterministic_dict()
+
+
+def test_manifest_round_trip_preserves_entries(tmp_path: Path) -> None:
+    _, manifest = _run_ingest(tmp_path)
+
+    assert manifest == BronzeManifest.from_dict(manifest.to_dict())
+
+
+def test_bronze_ingest_raises_for_unknown_dataset(tmp_path: Path) -> None:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ingestor = BronzeIngestor(output_root=tmp_path, deterministic_run_timestamp=RUN_TIMESTAMP)
+
+    with pytest.raises(ValueError, match="unsupported dataset"):
+        ingestor.ingest(
+            connector=connector,
+            dataset_id="missing_dataset",
+            start=date(2024, 1, 2),
+            end=date(2024, 1, 4),
+        )

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -36,6 +36,110 @@ def test_cli_main_returns_zero_for_run(capsys) -> None:
     assert capsys.readouterr().out.strip() == "run: not yet implemented"
 
 
+def test_cli_main_runs_fixture_ingest(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_ingest_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_ingest_command",
+        fake_run_ingest_command,
+    )
+
+    assert (
+        main(
+            [
+                "ingest",
+                "--source",
+                "krx",
+                "--dataset",
+                "kospi_index",
+                "--from",
+                "2024-01-02",
+                "--to",
+                "2024-01-04",
+                "--out",
+                "tmp/bronze",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "source": "krx",
+        "dataset": "kospi_index",
+        "start": "2024-01-02",
+        "end": "2024-01-04",
+        "output_dir": "tmp/bronze",
+        "live": False,
+    }
+
+
+def test_cli_main_enables_live_mode_with_flag(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_ingest_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_ingest_command",
+        fake_run_ingest_command,
+    )
+
+    assert (
+        main(
+            [
+                "ingest",
+                "--source",
+                "krx",
+                "--dataset",
+                "kospi_index",
+                "--from",
+                "2024-01-02",
+                "--to",
+                "2024-01-04",
+                "--live",
+            ]
+        )
+        == 0
+    )
+    assert captured["live"] is True
+
+
+def test_cli_main_enables_live_mode_with_env_var(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_ingest_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_ingest_command",
+        fake_run_ingest_command,
+    )
+    monkeypatch.setenv("KOSPI_LIVE", "1")
+
+    assert (
+        main(
+            [
+                "ingest",
+                "--source",
+                "krx",
+                "--dataset",
+                "kospi_index",
+                "--from",
+                "2024-01-02",
+                "--to",
+                "2024-01-04",
+            ]
+        )
+        == 0
+    )
+    assert captured["live"] is True
+
+
 def test_cli_main_prints_help_without_command(capsys) -> None:
     assert main([]) == 0
     assert "build-features" in capsys.readouterr().out

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import runpy
 
 from kospi_decision_pipeline_app_kr_kospi import __version__
-from kospi_decision_pipeline_app_kr_kospi.cli import main
+from kospi_decision_pipeline_app_kr_kospi.cli import (
+    _fixtures_root,
+    _parse_date,
+    main,
+    run_ingest_command,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -138,6 +143,29 @@ def test_cli_main_enables_live_mode_with_env_var(monkeypatch) -> None:
         == 0
     )
     assert captured["live"] is True
+
+
+def test_run_ingest_command_writes_fixture_output(tmp_path: Path, capsys) -> None:
+    assert (
+        run_ingest_command(
+            source="krx",
+            dataset="kospi_index",
+            start="2024-01-02",
+            end="2024-01-03",
+            output_dir=str(tmp_path),
+            live=False,
+        )
+        == 0
+    )
+
+    assert (tmp_path / "krx" / "kospi_index" / "2024-01-02.parquet").is_file()
+    assert (tmp_path / "krx" / "kospi_index" / "manifest.json").is_file()
+    assert "wrote krx/kospi_index/2024-01-02.parquet sha256=" in capsys.readouterr().out
+
+
+def test_parse_date_and_fixture_root_helpers() -> None:
+    assert _parse_date("2024-01-02").isoformat() == "2024-01-02"
+    assert (_fixtures_root() / "krx" / "kospi_index.json").is_file()
 
 
 def test_cli_main_prints_help_without_command(capsys) -> None:


### PR DESCRIPTION
## Summary
- add a deterministic Bronze ingest layer that writes daily Parquet partitions plus stable content-hashed manifests for every supported fixture dataset
- wire `kospi-pipeline ingest` to fixture registries by default, with live-mode selection guarded behind `--live` or `KOSPI_LIVE=1`
- lock the behavior down with end-to-end determinism, manifest, registry, CLI, coverage, and live-hook seam tests

## Validation
- `python -m ruff check .`
- `python -m mypy --strict core/src apps/kr-kospi/src`
- `python -m pytest --cov --cov-branch --cov-report=term-missing`