### PR TITLE
Implement frozen decision schemas and deterministic serializers (#10)

### DIFF
--- a/core/src/kospi_decision_pipeline_core/schemas/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/__init__.py
@@ -1,12 +1,31 @@
 from .config import AgentWeightConfig, AgentsConfig, ScenarioConfig, ThresholdsConfig
-from .decisions import DecisionRecord
+from .decisions import (
+    AgentVote,
+    BacktestRow,
+    DecisionRecord,
+    DecisionResult,
+    EvidenceItem,
+    GroundTruthLabel,
+    ModelLabel,
+)
 from .features import FeatureRecord
+from .serialization import BACKTEST_CSV_FIELDS, from_jsonl_line, to_csv_row, to_jsonl_line
 
 __all__ = [
+    "AgentVote",
     "AgentWeightConfig",
     "AgentsConfig",
+    "BACKTEST_CSV_FIELDS",
+    "BacktestRow",
     "DecisionRecord",
+    "DecisionResult",
+    "EvidenceItem",
     "FeatureRecord",
+    "GroundTruthLabel",
+    "from_jsonl_line",
+    "ModelLabel",
     "ScenarioConfig",
     "ThresholdsConfig",
+    "to_csv_row",
+    "to_jsonl_line",
 ]

--- a/core/src/kospi_decision_pipeline_core/schemas/decisions.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/decisions.py
@@ -1,2 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Literal, TypeVar, cast
+
+
+ModelLabel = Literal["up", "down", "skip"]
+GroundTruthLabel = Literal["up", "down", "flat"]
+
+_MODEL_LABELS = frozenset({"up", "down", "skip"})
+_GROUND_TRUTH_LABELS = frozenset({"up", "down", "flat"})
+_TupleItem = TypeVar("_TupleItem")
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceItem:
+    name: str
+    value: float
+    source: str
+    as_of: date
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "name", _ensure_string(self.name, context="name"))
+        object.__setattr__(self, "value", _ensure_float(self.value, context="value"))
+        object.__setattr__(self, "source", _ensure_string(self.source, context="source"))
+        object.__setattr__(self, "as_of", _ensure_date(self.as_of, context="as_of"))
+
+
+@dataclass(frozen=True, slots=True)
+class AgentVote:
+    agent_name: str
+    rule_version: str
+    label: ModelLabel
+    score: float
+    weight: float
+    weighted_score: float
+    evidence: tuple[EvidenceItem, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "agent_name",
+            _ensure_string(self.agent_name, context="agent_name"),
+        )
+        object.__setattr__(
+            self,
+            "rule_version",
+            _ensure_string(self.rule_version, context="rule_version"),
+        )
+        object.__setattr__(self, "label", _ensure_model_label(self.label, context="label"))
+        object.__setattr__(self, "score", _ensure_float(self.score, context="score"))
+        object.__setattr__(self, "weight", _ensure_float(self.weight, context="weight"))
+        object.__setattr__(
+            self,
+            "weighted_score",
+            _ensure_float(self.weighted_score, context="weighted_score"),
+        )
+        object.__setattr__(
+            self,
+            "evidence",
+            _ensure_tuple_of(self.evidence, EvidenceItem, context="evidence"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionResult:
+    decision_date: date
+    label: ModelLabel
+    aggregate_score: float
+    threshold_up: float
+    threshold_down: float
+    votes: tuple[AgentVote, ...]
+    config_signature: str
+    snapshot_id: str
+
+    def __post_init__(self) -> None:
+        decision_date = _ensure_date(self.decision_date, context="decision_date")
+        label = _ensure_model_label(self.label, context="label")
+        aggregate_score = _ensure_float(self.aggregate_score, context="aggregate_score")
+        threshold_up = _ensure_float(self.threshold_up, context="threshold_up")
+        threshold_down = _ensure_float(self.threshold_down, context="threshold_down")
+        if threshold_up <= threshold_down:
+            raise ValueError("threshold_up must be greater than threshold_down")
+        object.__setattr__(self, "decision_date", decision_date)
+        object.__setattr__(self, "label", label)
+        object.__setattr__(self, "aggregate_score", aggregate_score)
+        object.__setattr__(self, "threshold_up", threshold_up)
+        object.__setattr__(self, "threshold_down", threshold_down)
+        object.__setattr__(self, "votes", _ensure_tuple_of(self.votes, AgentVote, context="votes"))
+        object.__setattr__(
+            self,
+            "config_signature",
+            _ensure_string(self.config_signature, context="config_signature"),
+        )
+        object.__setattr__(
+            self, "snapshot_id", _ensure_string(self.snapshot_id, context="snapshot_id")
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestRow:
+    decision_date: date
+    label: ModelLabel
+    aggregate_score: float
+    ground_truth: GroundTruthLabel
+    next_day_return: float
+    hit: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "decision_date",
+            _ensure_date(self.decision_date, context="decision_date"),
+        )
+        object.__setattr__(self, "label", _ensure_model_label(self.label, context="label"))
+        object.__setattr__(
+            self,
+            "aggregate_score",
+            _ensure_float(self.aggregate_score, context="aggregate_score"),
+        )
+        object.__setattr__(
+            self,
+            "ground_truth",
+            _ensure_ground_truth_label(self.ground_truth, context="ground_truth"),
+        )
+        object.__setattr__(
+            self,
+            "next_day_return",
+            _ensure_float(self.next_day_return, context="next_day_return"),
+        )
+        object.__setattr__(self, "hit", _ensure_bool(self.hit, context="hit"))
+
+
+@dataclass(frozen=True, slots=True)
 class DecisionRecord:
     pass
+
+
+def _ensure_string(value: object, *, context: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{context} must be a string")
+    return value
+
+
+def _ensure_float(value: object, *, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{context} must be a float")
+    return float(value)
+
+
+def _ensure_date(value: object, *, context: str) -> date:
+    if not isinstance(value, date):
+        raise ValueError(f"{context} must be a date")
+    return value
+
+
+def _ensure_bool(value: object, *, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{context} must be a bool")
+    return value
+
+
+def _ensure_model_label(value: object, *, context: str) -> ModelLabel:
+    if not isinstance(value, str) or value not in _MODEL_LABELS:
+        raise ValueError(f"{context} must be one of: down, skip, up")
+    return cast(ModelLabel, value)
+
+
+def _ensure_ground_truth_label(value: object, *, context: str) -> GroundTruthLabel:
+    if not isinstance(value, str) or value not in _GROUND_TRUTH_LABELS:
+        raise ValueError(f"{context} must be one of: down, flat, up")
+    return cast(GroundTruthLabel, value)
+
+
+def _ensure_tuple_of(
+    value: object,
+    item_type: type[_TupleItem],
+    *,
+    context: str,
+) -> tuple[_TupleItem, ...]:
+    if not isinstance(value, tuple):
+        raise ValueError(f"{context} must be a tuple")
+    normalized = cast(tuple[object, ...], value)
+    for item in normalized:
+        if not isinstance(item, item_type):
+            raise ValueError(f"{context} items must be {item_type.__name__}")
+    return cast(tuple[_TupleItem, ...], normalized)

--- a/core/src/kospi_decision_pipeline_core/schemas/serialization.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/serialization.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from datetime import date
+from typing import cast, overload
+
+from .decisions import (
+    AgentVote,
+    BacktestRow,
+    DecisionResult,
+    EvidenceItem,
+    GroundTruthLabel,
+    ModelLabel,
+)
+
+BACKTEST_CSV_FIELDS: tuple[str, ...] = (
+    "decision_date",
+    "label",
+    "aggregate_score",
+    "ground_truth",
+    "next_day_return",
+    "hit",
+)
+
+
+@overload
+def from_jsonl_line(schema_type: type[EvidenceItem], line: str) -> EvidenceItem: ...
+
+
+@overload
+def from_jsonl_line(schema_type: type[AgentVote], line: str) -> AgentVote: ...
+
+
+@overload
+def from_jsonl_line(schema_type: type[DecisionResult], line: str) -> DecisionResult: ...
+
+
+@overload
+def from_jsonl_line(schema_type: type[BacktestRow], line: str) -> BacktestRow: ...
+
+
+def from_jsonl_line(
+    schema_type: type[EvidenceItem] | type[AgentVote] | type[DecisionResult] | type[BacktestRow],
+    line: str,
+) -> EvidenceItem | AgentVote | DecisionResult | BacktestRow:
+    if schema_type is EvidenceItem:
+        return parse_evidence_item(line)
+    if schema_type is AgentVote:
+        return parse_agent_vote(line)
+    if schema_type is DecisionResult:
+        return parse_decision_result(line)
+    if schema_type is BacktestRow:
+        return parse_backtest_row(line)
+    raise ValueError(f"unsupported schema type: {schema_type}")
+
+
+def to_jsonl_line(obj: EvidenceItem | AgentVote | DecisionResult | BacktestRow) -> str:
+    return json.dumps(_to_json_value(obj), separators=(",", ":"), ensure_ascii=False)
+
+
+def to_csv_row(
+    obj: BacktestRow | DecisionResult | AgentVote | EvidenceItem,
+    fields: tuple[str, ...],
+) -> dict[str, str]:
+    if not isinstance(obj, BacktestRow):
+        raise ValueError("to_csv_row supports only flat BacktestRow values")
+    return {field: _backtest_field_string(obj, field) for field in fields}
+
+
+def parse_evidence_item(line: str) -> EvidenceItem:
+    payload = _parse_json_object(line)
+    return EvidenceItem(
+        name=_require_string(payload, "name"),
+        value=_require_float(payload, "value"),
+        source=_require_string(payload, "source"),
+        as_of=_require_date(payload, "as_of"),
+    )
+
+
+def parse_agent_vote(line: str) -> AgentVote:
+    payload = _parse_json_object(line)
+    evidence_payload = _require_list(payload, "evidence")
+    return AgentVote(
+        agent_name=_require_string(payload, "agent_name"),
+        rule_version=_require_string(payload, "rule_version"),
+        label=_require_model_label(payload, "label"),
+        score=_require_float(payload, "score"),
+        weight=_require_float(payload, "weight"),
+        weighted_score=_require_float(payload, "weighted_score"),
+        evidence=tuple(parse_evidence_item(_dump_json(item)) for item in evidence_payload),
+    )
+
+
+def parse_decision_result(line: str) -> DecisionResult:
+    payload = _parse_json_object(line)
+    votes_payload = _require_list(payload, "votes")
+    return DecisionResult(
+        decision_date=_require_date(payload, "decision_date"),
+        label=_require_model_label(payload, "label"),
+        aggregate_score=_require_float(payload, "aggregate_score"),
+        threshold_up=_require_float(payload, "threshold_up"),
+        threshold_down=_require_float(payload, "threshold_down"),
+        votes=tuple(parse_agent_vote(_dump_json(item)) for item in votes_payload),
+        config_signature=_require_string(payload, "config_signature"),
+        snapshot_id=_require_string(payload, "snapshot_id"),
+    )
+
+
+def parse_backtest_row(line: str) -> BacktestRow:
+    payload = _parse_json_object(line)
+    return BacktestRow(
+        decision_date=_require_date(payload, "decision_date"),
+        label=_require_model_label(payload, "label"),
+        aggregate_score=_require_float(payload, "aggregate_score"),
+        ground_truth=_require_ground_truth_label(payload, "ground_truth"),
+        next_day_return=_require_float(payload, "next_day_return"),
+        hit=_require_bool(payload, "hit"),
+    )
+
+
+def _to_json_value(
+    obj: EvidenceItem | AgentVote | DecisionResult | BacktestRow,
+) -> dict[str, object]:
+    if isinstance(obj, EvidenceItem):
+        return {
+            "name": obj.name,
+            "value": obj.value,
+            "source": obj.source,
+            "as_of": obj.as_of.isoformat(),
+        }
+    if isinstance(obj, AgentVote):
+        return {
+            "agent_name": obj.agent_name,
+            "rule_version": obj.rule_version,
+            "label": obj.label,
+            "score": obj.score,
+            "weight": obj.weight,
+            "weighted_score": obj.weighted_score,
+            "evidence": [_to_json_value(item) for item in obj.evidence],
+        }
+    if isinstance(obj, DecisionResult):
+        return {
+            "decision_date": obj.decision_date.isoformat(),
+            "label": obj.label,
+            "aggregate_score": obj.aggregate_score,
+            "threshold_up": obj.threshold_up,
+            "threshold_down": obj.threshold_down,
+            "votes": [_to_json_value(item) for item in obj.votes],
+            "config_signature": obj.config_signature,
+            "snapshot_id": obj.snapshot_id,
+        }
+    return {
+        "decision_date": obj.decision_date.isoformat(),
+        "label": obj.label,
+        "aggregate_score": obj.aggregate_score,
+        "ground_truth": obj.ground_truth,
+        "next_day_return": obj.next_day_return,
+        "hit": obj.hit,
+    }
+
+
+def _parse_json_object(line: str) -> dict[str, object]:
+    payload = cast(object, json.loads(line))
+    if not isinstance(payload, Mapping):
+        raise ValueError("JSON payload must be a JSON object")
+    return {
+        str(raw_key): value for raw_key, value in cast(Mapping[object, object], payload).items()
+    }
+
+
+def _require_value(payload: Mapping[str, object], key: str) -> object:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    return payload[key]
+
+
+def _require_string(payload: Mapping[str, object], key: str) -> str:
+    value = _require_value(payload, key)
+    if not isinstance(value, str):
+        raise ValueError(f"{key} must be a string")
+    return value
+
+
+def _require_float(payload: Mapping[str, object], key: str) -> float:
+    value = _require_value(payload, key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{key} must be a float")
+    return float(value)
+
+
+def _require_bool(payload: Mapping[str, object], key: str) -> bool:
+    value = _require_value(payload, key)
+    if not isinstance(value, bool):
+        raise ValueError(f"{key} must be a bool")
+    return value
+
+
+def _require_date(payload: Mapping[str, object], key: str) -> date:
+    value = _require_string(payload, key)
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an ISO date") from exc
+
+
+def _require_list(payload: Mapping[str, object], key: str) -> list[object]:
+    value = _require_value(payload, key)
+    if not isinstance(value, list):
+        raise ValueError(f"{key} must be a list")
+    return cast(list[object], value)
+
+
+def _require_model_label(payload: Mapping[str, object], key: str) -> ModelLabel:
+    value = _require_string(payload, key)
+    if value not in {"up", "down", "skip"}:
+        raise ValueError(f"{key} must be one of: down, skip, up")
+    return cast(ModelLabel, value)
+
+
+def _require_ground_truth_label(payload: Mapping[str, object], key: str) -> GroundTruthLabel:
+    value = _require_string(payload, key)
+    if value not in {"up", "down", "flat"}:
+        raise ValueError(f"{key} must be one of: down, flat, up")
+    return cast(GroundTruthLabel, value)
+
+
+def _dump_json(value: object) -> str:
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _backtest_field_string(row: BacktestRow, field: str) -> str:
+    if field == "decision_date":
+        return row.decision_date.isoformat()
+    if field == "label":
+        return row.label
+    if field == "aggregate_score":
+        return str(row.aggregate_score)
+    if field == "ground_truth":
+        return row.ground_truth
+    if field == "next_day_return":
+        return str(row.next_day_return)
+    if field == "hit":
+        return "true" if row.hit else "false"
+    raise ValueError(f"unknown CSV field: {field}")

--- a/core/src/kospi_decision_pipeline_core/schemas/serialization.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/serialization.py
@@ -59,13 +59,12 @@ def to_jsonl_line(obj: EvidenceItem | AgentVote | DecisionResult | BacktestRow) 
     return json.dumps(_to_json_value(obj), separators=(",", ":"), ensure_ascii=False)
 
 
-def to_csv_row(
-    obj: BacktestRow | DecisionResult | AgentVote | EvidenceItem,
-    fields: tuple[str, ...],
-) -> dict[str, str]:
+def to_csv_row(obj: BacktestRow, fields: tuple[str, ...]) -> dict[str, str]:
     if not isinstance(obj, BacktestRow):
         raise ValueError("to_csv_row supports only flat BacktestRow values")
-    return {field: _backtest_field_string(obj, field) for field in fields}
+    if fields != BACKTEST_CSV_FIELDS:
+        raise ValueError("fields must equal BACKTEST_CSV_FIELDS")
+    return {field: _backtest_field_string(obj, field) for field in BACKTEST_CSV_FIELDS}
 
 
 def parse_evidence_item(line: str) -> EvidenceItem:
@@ -240,6 +239,4 @@ def _backtest_field_string(row: BacktestRow, field: str) -> str:
         return row.ground_truth
     if field == "next_day_return":
         return str(row.next_day_return)
-    if field == "hit":
-        return "true" if row.hit else "false"
-    raise ValueError(f"unknown CSV field: {field}")
+    return "true" if row.hit else "false"

--- a/core/tests/schemas/test_decisions.py
+++ b/core/tests/schemas/test_decisions.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date
+from typing import cast
 
 import pytest
 
@@ -9,6 +11,8 @@ from kospi_decision_pipeline_core.schemas.decisions import (
     BacktestRow,
     DecisionResult,
     EvidenceItem,
+    GroundTruthLabel,
+    ModelLabel,
 )
 
 
@@ -42,7 +46,7 @@ def test_evidence_item_construction_and_immutability() -> None:
     assert evidence.as_of == date(2026, 4, 24)
 
     with pytest.raises(AttributeError):
-        evidence.name = "momentum"
+        setattr(evidence, "name", "momentum")
 
 
 def test_agent_vote_construction_and_immutability() -> None:
@@ -57,7 +61,7 @@ def test_agent_vote_construction_and_immutability() -> None:
     assert vote.evidence == (make_evidence_item(),)
 
     with pytest.raises(AttributeError):
-        vote.weight = 0.40
+        setattr(vote, "weight", 0.40)
 
 
 def test_decision_result_construction_and_immutability() -> None:
@@ -77,7 +81,7 @@ def test_decision_result_construction_and_immutability() -> None:
     assert decision.snapshot_id == "snapshot:2026-04-25"
 
     with pytest.raises(AttributeError):
-        decision.votes = ()
+        setattr(decision, "votes", ())
 
 
 def test_backtest_row_construction_and_immutability() -> None:
@@ -95,7 +99,7 @@ def test_backtest_row_construction_and_immutability() -> None:
     assert row.hit is True
 
     with pytest.raises(AttributeError):
-        row.hit = False
+        setattr(row, "hit", False)
 
 
 @pytest.mark.parametrize(
@@ -105,7 +109,7 @@ def test_backtest_row_construction_and_immutability() -> None:
             lambda: AgentVote(
                 agent_name="technical",
                 rule_version="technical@v1",
-                label="flat",
+                label=cast(ModelLabel, cast(object, "flat")),
                 score=0.72,
                 weight=0.30,
                 weighted_score=0.216,
@@ -118,7 +122,7 @@ def test_backtest_row_construction_and_immutability() -> None:
                 decision_date=date(2026, 4, 25),
                 label="skip",
                 aggregate_score=0.0,
-                ground_truth="skip",
+                ground_truth=cast(GroundTruthLabel, cast(object, "skip")),
                 next_day_return=0.0,
                 hit=False,
             ),
@@ -127,7 +131,7 @@ def test_backtest_row_construction_and_immutability() -> None:
         (
             lambda: DecisionResult(
                 decision_date=date(2026, 4, 25),
-                label="flat",
+                label=cast(ModelLabel, cast(object, "flat")),
                 aggregate_score=0.0,
                 threshold_up=0.25,
                 threshold_down=-0.25,
@@ -139,7 +143,7 @@ def test_backtest_row_construction_and_immutability() -> None:
         ),
     ],
 )
-def test_runtime_literal_validation(factory: object, match: str) -> None:
+def test_runtime_literal_validation(factory: Callable[[], object], match: str) -> None:
     with pytest.raises(ValueError, match=match):
         _ = factory()
 
@@ -153,7 +157,7 @@ def test_agent_vote_rejects_non_tuple_evidence() -> None:
             score=0.72,
             weight=0.30,
             weighted_score=0.216,
-            evidence=[make_evidence_item()],
+            evidence=cast(tuple[EvidenceItem, ...], cast(object, [make_evidence_item()])),
         )
 
 
@@ -165,7 +169,89 @@ def test_decision_result_rejects_non_tuple_votes() -> None:
             aggregate_score=0.42,
             threshold_up=0.25,
             threshold_down=-0.25,
-            votes=[make_agent_vote()],
+            votes=cast(tuple[AgentVote, ...], cast(object, [make_agent_vote()])),
             config_signature="cfg:abc123",
             snapshot_id="snapshot:2026-04-25",
         )
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: EvidenceItem(
+                name=cast(str, cast(object, 1)),
+                value=1.25,
+                source="gold.features",
+                as_of=date(2026, 4, 24),
+            ),
+            "name must be a string",
+        ),
+        (
+            lambda: EvidenceItem(
+                name="volume_zscore",
+                value=cast(float, cast(object, True)),
+                source="gold.features",
+                as_of=date(2026, 4, 24),
+            ),
+            "value must be a float",
+        ),
+        (
+            lambda: EvidenceItem(
+                name="volume_zscore",
+                value=1.25,
+                source=cast(str, cast(object, 1)),
+                as_of=date(2026, 4, 24),
+            ),
+            "source must be a string",
+        ),
+        (
+            lambda: EvidenceItem(
+                name="volume_zscore",
+                value=1.25,
+                source="gold.features",
+                as_of=cast(date, cast(object, "2026-04-24")),
+            ),
+            "as_of must be a date",
+        ),
+        (
+            lambda: DecisionResult(
+                decision_date=date(2026, 4, 25),
+                label="up",
+                aggregate_score=0.42,
+                threshold_up=-0.25,
+                threshold_down=-0.25,
+                votes=(make_agent_vote(),),
+                config_signature="cfg:abc123",
+                snapshot_id="snapshot:2026-04-25",
+            ),
+            "threshold_up must be greater than threshold_down",
+        ),
+        (
+            lambda: BacktestRow(
+                decision_date=date(2026, 4, 25),
+                label="down",
+                aggregate_score=-0.41,
+                ground_truth="down",
+                next_day_return=-0.018,
+                hit=cast(bool, cast(object, 1)),
+            ),
+            "hit must be a bool",
+        ),
+        (
+            lambda: AgentVote(
+                agent_name="technical",
+                rule_version="technical@v1",
+                label="up",
+                score=0.72,
+                weight=0.30,
+                weighted_score=0.216,
+                evidence=(cast(EvidenceItem, cast(object, "bad")),),
+            ),
+            "evidence items must be EvidenceItem",
+        ),
+    ],
+)
+def test_runtime_type_validation(factory: Callable[[], object], match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _ = factory()

--- a/core/tests/schemas/test_decisions.py
+++ b/core/tests/schemas/test_decisions.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from kospi_decision_pipeline_core.schemas.decisions import (
+    AgentVote,
+    BacktestRow,
+    DecisionResult,
+    EvidenceItem,
+)
+
+
+def make_evidence_item() -> EvidenceItem:
+    return EvidenceItem(
+        name="volume_zscore",
+        value=1.25,
+        source="gold.features",
+        as_of=date(2026, 4, 24),
+    )
+
+
+def make_agent_vote() -> AgentVote:
+    return AgentVote(
+        agent_name="technical",
+        rule_version="technical@v1",
+        label="up",
+        score=0.72,
+        weight=0.30,
+        weighted_score=0.216,
+        evidence=(make_evidence_item(),),
+    )
+
+
+def test_evidence_item_construction_and_immutability() -> None:
+    evidence = make_evidence_item()
+
+    assert evidence.name == "volume_zscore"
+    assert evidence.value == 1.25
+    assert evidence.source == "gold.features"
+    assert evidence.as_of == date(2026, 4, 24)
+
+    with pytest.raises(AttributeError):
+        evidence.name = "momentum"
+
+
+def test_agent_vote_construction_and_immutability() -> None:
+    vote = make_agent_vote()
+
+    assert vote.agent_name == "technical"
+    assert vote.rule_version == "technical@v1"
+    assert vote.label == "up"
+    assert vote.score == 0.72
+    assert vote.weight == 0.30
+    assert vote.weighted_score == 0.216
+    assert vote.evidence == (make_evidence_item(),)
+
+    with pytest.raises(AttributeError):
+        vote.weight = 0.40
+
+
+def test_decision_result_construction_and_immutability() -> None:
+    decision = DecisionResult(
+        decision_date=date(2026, 4, 25),
+        label="up",
+        aggregate_score=0.42,
+        threshold_up=0.25,
+        threshold_down=-0.25,
+        votes=(make_agent_vote(),),
+        config_signature="cfg:abc123",
+        snapshot_id="snapshot:2026-04-25",
+    )
+
+    assert decision.votes == (make_agent_vote(),)
+    assert decision.config_signature == "cfg:abc123"
+    assert decision.snapshot_id == "snapshot:2026-04-25"
+
+    with pytest.raises(AttributeError):
+        decision.votes = ()
+
+
+def test_backtest_row_construction_and_immutability() -> None:
+    row = BacktestRow(
+        decision_date=date(2026, 4, 25),
+        label="down",
+        aggregate_score=-0.41,
+        ground_truth="down",
+        next_day_return=-0.018,
+        hit=True,
+    )
+
+    assert row.ground_truth == "down"
+    assert row.next_day_return == -0.018
+    assert row.hit is True
+
+    with pytest.raises(AttributeError):
+        row.hit = False
+
+
+@pytest.mark.parametrize(
+    ("factory", "match"),
+    [
+        (
+            lambda: AgentVote(
+                agent_name="technical",
+                rule_version="technical@v1",
+                label="flat",
+                score=0.72,
+                weight=0.30,
+                weighted_score=0.216,
+                evidence=(make_evidence_item(),),
+            ),
+            "label must be one of",
+        ),
+        (
+            lambda: BacktestRow(
+                decision_date=date(2026, 4, 25),
+                label="skip",
+                aggregate_score=0.0,
+                ground_truth="skip",
+                next_day_return=0.0,
+                hit=False,
+            ),
+            "ground_truth must be one of",
+        ),
+        (
+            lambda: DecisionResult(
+                decision_date=date(2026, 4, 25),
+                label="flat",
+                aggregate_score=0.0,
+                threshold_up=0.25,
+                threshold_down=-0.25,
+                votes=(make_agent_vote(),),
+                config_signature="cfg:abc123",
+                snapshot_id="snapshot:2026-04-25",
+            ),
+            "label must be one of",
+        ),
+    ],
+)
+def test_runtime_literal_validation(factory: object, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        _ = factory()
+
+
+def test_agent_vote_rejects_non_tuple_evidence() -> None:
+    with pytest.raises(ValueError, match="evidence must be a tuple"):
+        _ = AgentVote(
+            agent_name="technical",
+            rule_version="technical@v1",
+            label="up",
+            score=0.72,
+            weight=0.30,
+            weighted_score=0.216,
+            evidence=[make_evidence_item()],
+        )
+
+
+def test_decision_result_rejects_non_tuple_votes() -> None:
+    with pytest.raises(ValueError, match="votes must be a tuple"):
+        _ = DecisionResult(
+            decision_date=date(2026, 4, 25),
+            label="up",
+            aggregate_score=0.42,
+            threshold_up=0.25,
+            threshold_down=-0.25,
+            votes=[make_agent_vote()],
+            config_signature="cfg:abc123",
+            snapshot_id="snapshot:2026-04-25",
+        )

--- a/core/tests/schemas/test_serialization.py
+++ b/core/tests/schemas/test_serialization.py
@@ -138,7 +138,7 @@ def test_backtest_csv_fields_and_row_are_stable() -> None:
 
 def test_to_csv_row_rejects_nested_schema_objects() -> None:
     with pytest.raises(ValueError, match="flat BacktestRow"):
-        _ = to_csv_row(make_decision_result(), BACKTEST_CSV_FIELDS)
+        _ = to_csv_row(cast(BacktestRow, cast(object, make_decision_result())), BACKTEST_CSV_FIELDS)
 
 
 def test_parse_helpers_reject_invalid_payloads() -> None:
@@ -220,6 +220,6 @@ def test_parse_helpers_reject_invalid_scalar_types(
         _ = parser(payload)
 
 
-def test_to_csv_row_rejects_unknown_fields() -> None:
-    with pytest.raises(ValueError, match="unknown CSV field"):
-        _ = to_csv_row(make_backtest_row(), BACKTEST_CSV_FIELDS + ("votes",))
+def test_to_csv_row_rejects_non_stable_fields() -> None:
+    with pytest.raises(ValueError, match="fields must equal BACKTEST_CSV_FIELDS"):
+        _ = to_csv_row(make_backtest_row(), BACKTEST_CSV_FIELDS[::-1])

--- a/core/tests/schemas/test_serialization.py
+++ b/core/tests/schemas/test_serialization.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from kospi_decision_pipeline_core.schemas.decisions import (
+    AgentVote,
+    BacktestRow,
+    DecisionResult,
+    EvidenceItem,
+)
+from kospi_decision_pipeline_core.schemas.serialization import (
+    BACKTEST_CSV_FIELDS,
+    from_jsonl_line,
+    parse_agent_vote,
+    parse_backtest_row,
+    parse_decision_result,
+    parse_evidence_item,
+    to_csv_row,
+    to_jsonl_line,
+)
+
+
+def make_decision_result() -> DecisionResult:
+    evidence = EvidenceItem(
+        name="volume_zscore",
+        value=1.25,
+        source="gold.features",
+        as_of=date(2026, 4, 24),
+    )
+    vote = AgentVote(
+        agent_name="technical",
+        rule_version="technical@v1",
+        label="up",
+        score=0.72,
+        weight=0.30,
+        weighted_score=0.216,
+        evidence=(evidence,),
+    )
+    return DecisionResult(
+        decision_date=date(2026, 4, 25),
+        label="up",
+        aggregate_score=0.42,
+        threshold_up=0.25,
+        threshold_down=-0.25,
+        votes=(vote,),
+        config_signature="cfg:abc123",
+        snapshot_id="snapshot:2026-04-25",
+    )
+
+
+def make_backtest_row() -> BacktestRow:
+    return BacktestRow(
+        decision_date=date(2026, 4, 25),
+        label="down",
+        aggregate_score=-0.41,
+        ground_truth="down",
+        next_day_return=-0.018,
+        hit=True,
+    )
+
+
+def test_to_jsonl_line_is_deterministic_and_uses_declared_field_order() -> None:
+    decision = make_decision_result()
+
+    expected = (
+        '{"decision_date":"2026-04-25","label":"up","aggregate_score":0.42,'
+        '"threshold_up":0.25,"threshold_down":-0.25,"votes":[{"agent_name":"technical",'
+        '"rule_version":"technical@v1","label":"up","score":0.72,"weight":0.3,'
+        '"weighted_score":0.216,"evidence":[{"name":"volume_zscore","value":1.25,'
+        '"source":"gold.features","as_of":"2026-04-24"}]}],'
+        '"config_signature":"cfg:abc123","snapshot_id":"snapshot:2026-04-25"}'
+    )
+
+    assert to_jsonl_line(decision) == expected
+    assert to_jsonl_line(decision) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        make_decision_result(),
+        make_backtest_row(),
+        AgentVote(
+            agent_name="technical",
+            rule_version="technical@v1",
+            label="up",
+            score=0.72,
+            weight=0.30,
+            weighted_score=0.216,
+            evidence=(
+                EvidenceItem(
+                    name="volume_zscore",
+                    value=1.25,
+                    source="gold.features",
+                    as_of=date(2026, 4, 24),
+                ),
+            ),
+        ),
+        EvidenceItem(
+            name="volume_zscore",
+            value=1.25,
+            source="gold.features",
+            as_of=date(2026, 4, 24),
+        ),
+    ],
+)
+def test_jsonl_round_trip(value: object) -> None:
+    assert from_jsonl_line(type(value), to_jsonl_line(value)) == value
+
+
+def test_backtest_csv_fields_and_row_are_stable() -> None:
+    row = make_backtest_row()
+
+    assert BACKTEST_CSV_FIELDS == (
+        "decision_date",
+        "label",
+        "aggregate_score",
+        "ground_truth",
+        "next_day_return",
+        "hit",
+    )
+    assert to_csv_row(row, BACKTEST_CSV_FIELDS) == {
+        "decision_date": "2026-04-25",
+        "label": "down",
+        "aggregate_score": "-0.41",
+        "ground_truth": "down",
+        "next_day_return": "-0.018",
+        "hit": "true",
+    }
+
+
+def test_to_csv_row_rejects_nested_schema_objects() -> None:
+    with pytest.raises(ValueError, match="flat BacktestRow"):
+        _ = to_csv_row(make_decision_result(), BACKTEST_CSV_FIELDS)
+
+
+def test_parse_helpers_reject_invalid_payloads() -> None:
+    with pytest.raises(ValueError, match="JSON object"):
+        _ = parse_evidence_item("[]")
+
+    with pytest.raises(ValueError, match="votes must be a list"):
+        _ = parse_decision_result(
+            '{"decision_date":"2026-04-25","label":"up","aggregate_score":0.42,'
+            '"threshold_up":0.25,"threshold_down":-0.25,"votes":{},'
+            '"config_signature":"cfg:abc123","snapshot_id":"snapshot:2026-04-25"}'
+        )
+
+    with pytest.raises(ValueError, match="evidence must be a list"):
+        _ = parse_agent_vote(
+            '{"agent_name":"technical","rule_version":"technical@v1","label":"up",'
+            '"score":0.72,"weight":0.3,"weighted_score":0.216,"evidence":{}}'
+        )
+
+    with pytest.raises(ValueError, match="unsupported schema type"):
+        _ = from_jsonl_line(str, '"value"')
+
+
+def test_parse_backtest_row_rejects_missing_field() -> None:
+    with pytest.raises(ValueError, match="missing required key: hit"):
+        _ = parse_backtest_row(
+            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,'
+            '"ground_truth":"down","next_day_return":-0.018}'
+        )

--- a/core/tests/schemas/test_serialization.py
+++ b/core/tests/schemas/test_serialization.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import date
+from typing import cast
 
 import pytest
 
@@ -20,6 +22,8 @@ from kospi_decision_pipeline_core.schemas.serialization import (
     to_csv_row,
     to_jsonl_line,
 )
+
+SchemaValue = EvidenceItem | AgentVote | DecisionResult | BacktestRow
 
 
 def make_decision_result() -> DecisionResult:
@@ -107,7 +111,8 @@ def test_to_jsonl_line_is_deterministic_and_uses_declared_field_order() -> None:
     ],
 )
 def test_jsonl_round_trip(value: object) -> None:
-    assert from_jsonl_line(type(value), to_jsonl_line(value)) == value
+    schema_value = cast(SchemaValue, value)
+    assert from_jsonl_line(type(schema_value), to_jsonl_line(schema_value)) == schema_value
 
 
 def test_backtest_csv_fields_and_row_are_stable() -> None:
@@ -142,24 +147,79 @@ def test_parse_helpers_reject_invalid_payloads() -> None:
 
     with pytest.raises(ValueError, match="votes must be a list"):
         _ = parse_decision_result(
-            '{"decision_date":"2026-04-25","label":"up","aggregate_score":0.42,'
-            '"threshold_up":0.25,"threshold_down":-0.25,"votes":{},'
-            '"config_signature":"cfg:abc123","snapshot_id":"snapshot:2026-04-25"}'
+            "{"
+            + '"decision_date":"2026-04-25","label":"up","aggregate_score":0.42,'
+            + '"threshold_up":0.25,"threshold_down":-0.25,"votes":{},'
+            + '"config_signature":"cfg:abc123","snapshot_id":"snapshot:2026-04-25"'
+            + "}"
         )
 
     with pytest.raises(ValueError, match="evidence must be a list"):
         _ = parse_agent_vote(
-            '{"agent_name":"technical","rule_version":"technical@v1","label":"up",'
-            '"score":0.72,"weight":0.3,"weighted_score":0.216,"evidence":{}}'
+            "{"
+            + '"agent_name":"technical","rule_version":"technical@v1","label":"up",'
+            + '"score":0.72,"weight":0.3,"weighted_score":0.216,"evidence":{}'
+            + "}"
         )
 
     with pytest.raises(ValueError, match="unsupported schema type"):
-        _ = from_jsonl_line(str, '"value"')
+        _ = from_jsonl_line(cast(type[BacktestRow], str), '"value"')
 
 
 def test_parse_backtest_row_rejects_missing_field() -> None:
     with pytest.raises(ValueError, match="missing required key: hit"):
         _ = parse_backtest_row(
-            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,'
-            '"ground_truth":"down","next_day_return":-0.018}'
+            "{"
+            + '"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,'
+            + '"ground_truth":"down","next_day_return":-0.018'
+            + "}"
         )
+
+
+@pytest.mark.parametrize(
+    ("parser", "payload", "match"),
+    [
+        (
+            parse_evidence_item,
+            '{"name":1,"value":1.25,"source":"gold.features","as_of":"2026-04-24"}',
+            "name must be a string",
+        ),
+        (
+            parse_evidence_item,
+            '{"name":"volume_zscore","value":true,"source":"gold.features","as_of":"2026-04-24"}',
+            "value must be a float",
+        ),
+        (
+            parse_evidence_item,
+            '{"name":"volume_zscore","value":1.25,"source":"gold.features","as_of":"bad-date"}',
+            "as_of must be an ISO date",
+        ),
+        (
+            parse_agent_vote,
+            '{"agent_name":"technical","rule_version":"technical@v1","label":"flat","score":0.72,"weight":0.3,"weighted_score":0.216,"evidence":[]}',
+            "label must be one of",
+        ),
+        (
+            parse_backtest_row,
+            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"ground_truth":"skip","next_day_return":-0.018,"hit":true}',
+            "ground_truth must be one of",
+        ),
+        (
+            parse_backtest_row,
+            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"ground_truth":"down","next_day_return":-0.018,"hit":1}',
+            "hit must be a bool",
+        ),
+    ],
+)
+def test_parse_helpers_reject_invalid_scalar_types(
+    parser: Callable[[str], object],
+    payload: str,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _ = parser(payload)
+
+
+def test_to_csv_row_rejects_unknown_fields() -> None:
+    with pytest.raises(ValueError, match="unknown CSV field"):
+        _ = to_csv_row(make_backtest_row(), BACKTEST_CSV_FIELDS + ("votes",))


### PR DESCRIPTION
## Summary
- add frozen `EvidenceItem`, `AgentVote`, `DecisionResult`, and `BacktestRow` schemas with runtime validation for literal labels, tuple immutability, and threshold invariants
- add deterministic JSONL serialization/parsing and flat BacktestRow CSV export with stable field order
- cover the new schema and serialization code with RED-first tests, 100% line+branch coverage, and passing core tests/mypy

Closes #10