### PR TITLE
[#8] Build Gold decision-feature dataset

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry, LiveConnectorRegistry
+from .transforms.gold_features import GoldFeatureBuilder, gold_sha256
 from .transforms.silver import DATASET_DEFINITIONS, SilverNormalizer, silver_sha256
 
 
@@ -56,24 +57,55 @@ def run_build_features_command(
     start: str,
     end: str,
     bronze_dir: str,
+    silver_dir: str,
     output_dir: str,
 ) -> int:
-    if layer != "silver":
-        print(f"build-features --layer {layer}: not yet implemented")
+    start_date = parse_date(start)
+    end_date = parse_date(end)
+    if layer == "silver":
+        if (source, dataset) not in DATASET_DEFINITIONS:
+            raise ValueError(f"unsupported Silver dataset: {source}/{dataset}")
+        normalizer = SilverNormalizer(output_root=Path(output_dir))
+        written_paths = normalizer.normalize_dataset(
+            bronze_root=Path(bronze_dir),
+            source_name=source,
+            dataset_id=dataset,
+            start=start_date,
+            end=end_date,
+        )
+        for path in written_paths:
+            relative_path = path.relative_to(Path(output_dir))
+            print(f"wrote {relative_path.as_posix()} sha256={silver_sha256(path)}")
         return 0
-    if (source, dataset) not in DATASET_DEFINITIONS:
-        raise ValueError(f"unsupported Silver dataset: {source}/{dataset}")
-    normalizer = SilverNormalizer(output_root=Path(output_dir))
-    written_paths = normalizer.normalize_dataset(
-        bronze_root=Path(bronze_dir),
-        source_name=source,
-        dataset_id=dataset,
-        start=parse_date(start),
-        end=parse_date(end),
-    )
-    for path in written_paths:
-        relative_path = path.relative_to(Path(output_dir))
-        print(f"wrote {relative_path.as_posix()} sha256={silver_sha256(path)}")
+    if layer == "gold":
+        output_path = GoldFeatureBuilder(output_root=Path(output_dir)).build(
+            silver_root=Path(silver_dir),
+            start=start_date,
+            end=end_date,
+        )
+        print(f"wrote {output_path.name} sha256={gold_sha256(output_path)}")
+        return 0
+    if layer == "all":
+        silver_root = Path(silver_dir)
+        normalizer = SilverNormalizer(output_root=silver_root)
+        for requirement in GoldFeatureBuilder.REQUIRED_SILVER_DATASETS:
+            written_paths = normalizer.normalize_dataset(
+                bronze_root=Path(bronze_dir),
+                source_name=requirement.source_name,
+                dataset_id=requirement.dataset_id,
+                start=start_date,
+                end=end_date,
+            )
+            for path in written_paths:
+                relative_path = path.relative_to(silver_root)
+                print(f"wrote {relative_path.as_posix()} sha256={silver_sha256(path)}")
+        output_path = GoldFeatureBuilder(output_root=Path(output_dir)).build(
+            silver_root=silver_root,
+            start=start_date,
+            end=end_date,
+        )
+        print(f"wrote {output_path.name} sha256={gold_sha256(output_path)}")
+        return 0
     return 0
 
 
@@ -85,6 +117,7 @@ class _CliArgs(argparse.Namespace):
     start: str = ""
     end: str = ""
     bronze_dir: str = "data/bronze"
+    silver_dir: str = "data/silver"
     output_dir: str = "data/bronze"
     live: bool = False
 
@@ -103,14 +136,17 @@ def main(argv: list[str] | None = None) -> int:
     _ = ingest_parser.add_argument("--out", dest="output_dir", default="data/bronze")
     _ = ingest_parser.add_argument("--live", action="store_true")
     build_features_parser = sub.add_parser("build-features", help="build typed features")
-    _ = build_features_parser.add_argument("--layer", choices=("silver",), required=True)
     _ = build_features_parser.add_argument(
-        "--source", choices=("krx", "ecos", "kosis", "data_portal"), required=True
+        "--layer", choices=("silver", "gold", "all"), required=True
     )
-    _ = build_features_parser.add_argument("--dataset", required=True)
+    _ = build_features_parser.add_argument(
+        "--source", choices=("krx", "ecos", "kosis", "data_portal"), default=""
+    )
+    _ = build_features_parser.add_argument("--dataset", default="")
     _ = build_features_parser.add_argument("--from", dest="start", required=True)
     _ = build_features_parser.add_argument("--to", dest="end", required=True)
     _ = build_features_parser.add_argument("--bronze-dir", default="data/bronze")
+    _ = build_features_parser.add_argument("--silver-dir", default="data/silver")
     _ = build_features_parser.add_argument("--out", dest="output_dir", default="data/silver")
     for name in ("run", "backtest", "report"):
         _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
@@ -137,6 +173,7 @@ def main(argv: list[str] | None = None) -> int:
             start=str(args.start),
             end=str(args.end),
             bronze_dir=str(args.bronze_dir),
+            silver_dir=str(args.silver_dir),
             output_dir=str(args.output_dir),
         )
     print(f"{cmd}: not yet implemented")

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -108,7 +108,7 @@ def run_build_features_command(
         )
         print(f"wrote {output_path.name} sha256={gold_sha256(output_path)}")
         return 0
-    return 0
+    raise ValueError(f"unsupported feature layer: {layer}")
 
 
 class _CliArgs(argparse.Namespace):

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -62,10 +62,11 @@ def run_build_features_command(
 ) -> int:
     start_date = parse_date(start)
     end_date = parse_date(end)
+    resolved_output_dir = Path(output_dir)
     if layer == "silver":
         if (source, dataset) not in DATASET_DEFINITIONS:
             raise ValueError(f"unsupported Silver dataset: {source}/{dataset}")
-        normalizer = SilverNormalizer(output_root=Path(output_dir))
+        normalizer = SilverNormalizer(output_root=resolved_output_dir)
         written_paths = normalizer.normalize_dataset(
             bronze_root=Path(bronze_dir),
             source_name=source,
@@ -74,11 +75,11 @@ def run_build_features_command(
             end=end_date,
         )
         for path in written_paths:
-            relative_path = path.relative_to(Path(output_dir))
+            relative_path = path.relative_to(resolved_output_dir)
             print(f"wrote {relative_path.as_posix()} sha256={silver_sha256(path)}")
         return 0
     if layer == "gold":
-        output_path = GoldFeatureBuilder(output_root=Path(output_dir)).build(
+        output_path = GoldFeatureBuilder(output_root=resolved_output_dir).build(
             silver_root=Path(silver_dir),
             start=start_date,
             end=end_date,
@@ -99,7 +100,7 @@ def run_build_features_command(
             for path in written_paths:
                 relative_path = path.relative_to(silver_root)
                 print(f"wrote {relative_path.as_posix()} sha256={silver_sha256(path)}")
-        output_path = GoldFeatureBuilder(output_root=Path(output_dir)).build(
+        output_path = GoldFeatureBuilder(output_root=resolved_output_dir).build(
             silver_root=silver_root,
             start=start_date,
             end=end_date,
@@ -118,7 +119,7 @@ class _CliArgs(argparse.Namespace):
     end: str = ""
     bronze_dir: str = "data/bronze"
     silver_dir: str = "data/silver"
-    output_dir: str = "data/bronze"
+    output_dir: str = ""
     live: bool = False
 
 
@@ -147,7 +148,7 @@ def main(argv: list[str] | None = None) -> int:
     _ = build_features_parser.add_argument("--to", dest="end", required=True)
     _ = build_features_parser.add_argument("--bronze-dir", default="data/bronze")
     _ = build_features_parser.add_argument("--silver-dir", default="data/silver")
-    _ = build_features_parser.add_argument("--out", dest="output_dir", default="data/silver")
+    _ = build_features_parser.add_argument("--out", dest="output_dir", default="")
     for name in ("run", "backtest", "report"):
         _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
     args = parser.parse_args(argv, namespace=_CliArgs())
@@ -166,15 +167,21 @@ def main(argv: list[str] | None = None) -> int:
             live=live_mode,
         )
     if cmd == "build-features":
+        layer = str(args.layer)
+        if layer == "silver" and (str(args.source) == "" or str(args.dataset) == ""):
+            build_features_parser.error("--source and --dataset are required when --layer silver")
+        output_dir = str(args.output_dir)
+        if output_dir == "":
+            output_dir = "data/gold" if layer in {"gold", "all"} else "data/silver"
         return run_build_features_command(
-            layer=str(args.layer),
+            layer=layer,
             source=str(args.source),
             dataset=str(args.dataset),
             start=str(args.start),
             end=str(args.end),
             bronze_dir=str(args.bronze_dir),
             silver_dir=str(args.silver_dir),
-            output_dir=str(args.output_dir),
+            output_dir=output_dir,
         )
     print(f"{cmd}: not yet implemented")
     return 0

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry, LiveConnectorRegistry
-from .transforms.gold_features import GoldFeatureBuilder, gold_sha256
+from .transforms.gold_features import GoldFeatureBuilder, gold_lookback_start, gold_sha256
 from .transforms.silver import DATASET_DEFINITIONS, SilverNormalizer, silver_sha256
 
 
@@ -89,12 +89,13 @@ def run_build_features_command(
     if layer == "all":
         silver_root = Path(silver_dir)
         normalizer = SilverNormalizer(output_root=silver_root)
+        silver_start = gold_lookback_start(start=start_date, calendar=normalizer._calendar)
         for requirement in GoldFeatureBuilder.REQUIRED_SILVER_DATASETS:
             written_paths = normalizer.normalize_dataset(
                 bronze_root=Path(bronze_dir),
                 source_name=requirement.source_name,
                 dataset_id=requirement.dataset_id,
-                start=start_date,
+                start=silver_start,
                 end=end_date,
             )
             for path in written_paths:

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
@@ -42,6 +42,8 @@ def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
 READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
 WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
 TRADING_DAYS_FOR_PERCENTILE = 252
+REALIZED_VOL_WINDOW = 20
+ATR_WINDOW = 14
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +67,9 @@ class DailyInputs:
     kr_bond_yield_3y: float
     kospi_per: float
     kospi_pbr: float
+
+
+GoldRow = dict[str, date | float]
 
 
 class GoldFeatureError(ValueError):
@@ -160,6 +165,10 @@ def _rolling_percentile_ignore_none(
     return _percentile_rank(filtered, current_value)
 
 
+def _required_history_for_realized_vol_percentile() -> int:
+    return REALIZED_VOL_WINDOW + TRADING_DAYS_FOR_PERCENTILE
+
+
 @final
 class GoldFeatureBuilder:
     OUTPUT_FILE_NAME = "decision_features.parquet"
@@ -187,7 +196,7 @@ class GoldFeatureBuilder:
         gold_rows = self._build_rows(daily_inputs)
         output_path = self._output_root / self.OUTPUT_FILE_NAME
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        table = _table_from_pylist(gold_rows)
+        table = _table_from_pylist(cast(list[dict[str, object]], gold_rows))
         assert_no_forbidden_gold_columns(table.column_names)
         WRITE_TABLE(table, output_path, compression="snappy")
         return output_path
@@ -245,16 +254,15 @@ class GoldFeatureBuilder:
         preferred_rows = [
             row for row in rows if _text_value(row, "maturity_code", "bond_yield") == "3Y"
         ]
-        selected_rows = preferred_rows if preferred_rows else rows
-        if len(selected_rows) != 1:
-            raise InvalidGoldInputError("bond_yield", "maturity_code", selected_rows)
-        row = selected_rows[0]
+        if len(preferred_rows) != 1:
+            raise InvalidGoldInputError("bond_yield", "maturity_code", rows)
+        row = preferred_rows[0]
         row_date = _date_value(row, "as_of_date", "bond_yield")
         if row_date != as_of_date:
             raise InvalidGoldInputError("bond_yield", "as_of_date", row_date)
         return row
 
-    def _build_rows(self, daily_inputs: Sequence[DailyInputs]) -> list[dict[str, object]]:
+    def _build_rows(self, daily_inputs: Sequence[DailyInputs]) -> list[GoldRow]:
         closes = [row.kospi_close for row in daily_inputs]
         highs = [row.kospi_high for row in daily_inputs]
         lows = [row.kospi_low for row in daily_inputs]
@@ -274,17 +282,20 @@ class GoldFeatureBuilder:
 
         realized_vols: list[float | None] = []
         for index in range(len(daily_inputs)):
-            if index < 20:
+            if index < REALIZED_VOL_WINDOW:
                 realized_vols.append(None)
                 continue
             trailing_returns = [
-                value for value in daily_returns[(index - 19) : index + 1] if value is not None
+                value
+                for value in daily_returns[(index - (REALIZED_VOL_WINDOW - 1)) : index + 1]
+                if value is not None
             ]
             realized_vols.append(pstdev(trailing_returns) * sqrt(252.0))
 
-        rows: list[dict[str, object]] = []
+        rows: list[GoldRow] = []
+        minimum_index = _required_history_for_realized_vol_percentile() - 1
         for index in range(len(daily_inputs)):
-            if index < TRADING_DAYS_FOR_PERCENTILE - 1:
+            if index < minimum_index:
                 continue
             close_window = closes[(index - 19) : index + 1]
             close_window_min = min(close_window)
@@ -298,7 +309,7 @@ class GoldFeatureBuilder:
             realized_vol = realized_vols[index]
             if realized_vol is None:
                 raise InvalidGoldInputError("kospi_index", "kospi_realized_vol_20d", realized_vol)
-            row: dict[str, object] = {
+            row: GoldRow = {
                 "as_of_date": daily_inputs[index].as_of_date,
                 "kospi_close": closes[index],
                 "kospi_return_1d": (closes[index] / closes[index - 1]) - 1.0,
@@ -319,6 +330,10 @@ class GoldFeatureBuilder:
                 "institution_net_buy_krw_5d_sum": sum(institution_flows[(index - 4) : index + 1]),
                 "individual_net_buy_krw_5d_sum": sum(individual_flows[(index - 4) : index + 1]),
                 "foreign_net_buy_5d_pct_of_turnover": sum(foreign_flows[(index - 4) : index + 1])
+                / sum(turnover[(index - 4) : index + 1]),
+                "institution_net_buy_5d_pct_of_turnover": sum(
+                    institution_flows[(index - 4) : index + 1]
+                )
                 / sum(turnover[(index - 4) : index + 1]),
                 "kospi_per": pers[index],
                 "kospi_pbr": pbrs[index],

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
@@ -147,24 +147,6 @@ def _percentile_rank(values: Sequence[float], current_value: float) -> float:
     return count / len(values)
 
 
-def _rolling_percentile(values: Sequence[float], index: int, *, window: int) -> float:
-    window_values = values[(index - window + 1) : index + 1]
-    return _percentile_rank(window_values, window_values[-1])
-
-
-def _rolling_percentile_ignore_none(
-    values: Sequence[float | None],
-    index: int,
-    *,
-    window: int,
-) -> float:
-    filtered = [value for value in values[(index - window + 1) : index + 1] if value is not None]
-    current_value = values[index]
-    if current_value is None or not filtered:
-        raise ValueError("current rolling value must be present")
-    return _percentile_rank(filtered, current_value)
-
-
 def _required_history_for_realized_vol_percentile() -> int:
     return REALIZED_VOL_WINDOW + TRADING_DAYS_FOR_PERCENTILE
 
@@ -384,8 +366,7 @@ class GoldFeatureBuilder:
                 / 14.0,
             }
             assert_no_forbidden_gold_columns(row.keys())
-            if valid_segment[-1].as_of_date >= requested_start:
-                rows.append(row)
+            rows.append(row)
         return rows
 
 

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
@@ -169,6 +169,20 @@ def _required_history_for_realized_vol_percentile() -> int:
     return REALIZED_VOL_WINDOW + TRADING_DAYS_FOR_PERCENTILE
 
 
+def gold_warmup_trading_days() -> int:
+    return _required_history_for_realized_vol_percentile() - 1
+
+
+def gold_lookback_start(*, start: date, calendar: TradingCalendar) -> date:
+    current = start
+    remaining = gold_warmup_trading_days()
+    while remaining > 0:
+        current -= timedelta(days=1)
+        if calendar.is_trading_day(current):
+            remaining -= 1
+    return current
+
+
 @final
 class GoldFeatureBuilder:
     OUTPUT_FILE_NAME = "decision_features.parquet"
@@ -189,11 +203,17 @@ class GoldFeatureBuilder:
         self._calendar = TradingCalendar() if calendar is None else calendar
 
     def build(self, *, silver_root: Path, start: date, end: date) -> Path:
-        trading_days = _trading_days_between(start, end, self._calendar)
-        daily_inputs = [
-            self._load_daily_inputs(silver_root, as_of_date) for as_of_date in trading_days
-        ]
-        gold_rows = self._build_rows(daily_inputs)
+        read_start = gold_lookback_start(start=start, calendar=self._calendar)
+        trading_days = _trading_days_between(read_start, end, self._calendar)
+        daily_inputs: list[DailyInputs | None] = []
+        for as_of_date in trading_days:
+            try:
+                daily_inputs.append(self._load_daily_inputs(silver_root, as_of_date))
+            except MissingGoldInputError:
+                if as_of_date >= start:
+                    raise
+                daily_inputs.append(None)
+        gold_rows = self._build_rows(daily_inputs, requested_start=start)
         output_path = self._output_root / self.OUTPUT_FILE_NAME
         output_path.parent.mkdir(parents=True, exist_ok=True)
         table = _table_from_pylist(cast(list[dict[str, object]], gold_rows))
@@ -262,42 +282,44 @@ class GoldFeatureBuilder:
             raise InvalidGoldInputError("bond_yield", "as_of_date", row_date)
         return row
 
-    def _build_rows(self, daily_inputs: Sequence[DailyInputs]) -> list[GoldRow]:
-        closes = [row.kospi_close for row in daily_inputs]
-        highs = [row.kospi_high for row in daily_inputs]
-        lows = [row.kospi_low for row in daily_inputs]
-        turnover = [row.turnover_krw for row in daily_inputs]
-        base_rates = [row.bok_base_rate for row in daily_inputs]
-        usd_krw_rates = [row.usd_krw_close for row in daily_inputs]
-        bond_yields = [row.kr_bond_yield_3y for row in daily_inputs]
-        foreign_flows = [row.foreign_net_buy_krw for row in daily_inputs]
-        institution_flows = [row.institution_net_buy_krw for row in daily_inputs]
-        individual_flows = [row.individual_net_buy_krw for row in daily_inputs]
-        pers = [row.kospi_per for row in daily_inputs]
-        pbrs = [row.kospi_pbr for row in daily_inputs]
-
-        daily_returns: list[float | None] = [None]
-        for index in range(1, len(daily_inputs)):
-            daily_returns.append((closes[index] / closes[index - 1]) - 1.0)
-
-        realized_vols: list[float | None] = []
-        for index in range(len(daily_inputs)):
-            if index < REALIZED_VOL_WINDOW:
-                realized_vols.append(None)
-                continue
-            trailing_returns = [
-                value
-                for value in daily_returns[(index - (REALIZED_VOL_WINDOW - 1)) : index + 1]
-                if value is not None
-            ]
-            realized_vols.append(pstdev(trailing_returns) * sqrt(252.0))
-
+    def _build_rows(
+        self,
+        daily_inputs: Sequence[DailyInputs | None],
+        *,
+        requested_start: date,
+    ) -> list[GoldRow]:
         rows: list[GoldRow] = []
         minimum_index = _required_history_for_realized_vol_percentile() - 1
         for index in range(len(daily_inputs)):
             if index < minimum_index:
                 continue
-            close_window = closes[(index - 19) : index + 1]
+            segment = daily_inputs[(index - minimum_index) : index + 1]
+            if any(item is None for item in segment):
+                continue
+            valid_segment = cast(list[DailyInputs], segment)
+            closes = [row.kospi_close for row in valid_segment]
+            highs = [row.kospi_high for row in valid_segment]
+            lows = [row.kospi_low for row in valid_segment]
+            turnover = [row.turnover_krw for row in valid_segment]
+            base_rates = [row.bok_base_rate for row in valid_segment]
+            usd_krw_rates = [row.usd_krw_close for row in valid_segment]
+            bond_yields = [row.kr_bond_yield_3y for row in valid_segment]
+            foreign_flows = [row.foreign_net_buy_krw for row in valid_segment]
+            institution_flows = [row.institution_net_buy_krw for row in valid_segment]
+            individual_flows = [row.individual_net_buy_krw for row in valid_segment]
+            pers = [row.kospi_per for row in valid_segment]
+            pbrs = [row.kospi_pbr for row in valid_segment]
+            local_index = len(valid_segment) - 1
+            daily_returns = [
+                (closes[return_index] / closes[return_index - 1]) - 1.0
+                for return_index in range(1, len(valid_segment))
+            ]
+            realized_vols = [
+                pstdev(daily_returns[(realized_index - REALIZED_VOL_WINDOW) : realized_index])
+                * sqrt(252.0)
+                for realized_index in range(REALIZED_VOL_WINDOW, len(valid_segment))
+            ]
+            close_window = closes[(local_index - 19) : local_index + 1]
             close_window_min = min(close_window)
             close_window_max = max(close_window)
             close_position_denominator = close_window_max - close_window_min
@@ -305,56 +327,65 @@ class GoldFeatureBuilder:
                 raise InvalidGoldInputError(
                     "kospi_index", "kospi_close_position_denominator", close_position_denominator
                 )
-            ma5 = sum(closes[(index - 4) : index + 1]) / 5.0
-            realized_vol = realized_vols[index]
-            if realized_vol is None:
-                raise InvalidGoldInputError("kospi_index", "kospi_realized_vol_20d", realized_vol)
+            ma5 = sum(closes[(local_index - 4) : local_index + 1]) / 5.0
+            realized_vol = realized_vols[-1]
             row: GoldRow = {
-                "as_of_date": daily_inputs[index].as_of_date,
-                "kospi_close": closes[index],
-                "kospi_return_1d": (closes[index] / closes[index - 1]) - 1.0,
-                "kospi_return_3d": (closes[index] / closes[index - 3]) - 1.0,
-                "kospi_return_5d": (closes[index] / closes[index - 5]) - 1.0,
+                "as_of_date": valid_segment[-1].as_of_date,
+                "kospi_close": closes[local_index],
+                "kospi_return_1d": (closes[local_index] / closes[local_index - 1]) - 1.0,
+                "kospi_return_3d": (closes[local_index] / closes[local_index - 3]) - 1.0,
+                "kospi_return_5d": (closes[local_index] / closes[local_index - 5]) - 1.0,
                 "kospi_ma5": ma5,
                 "kospi_ma20": sum(close_window) / 20.0,
-                "kospi_ma5_gap": (closes[index] - ma5) / ma5,
-                "kospi_close_position": (closes[index] - close_window_min)
+                "kospi_ma5_gap": (closes[local_index] - ma5) / ma5,
+                "kospi_close_position": (closes[local_index] - close_window_min)
                 / close_position_denominator,
-                "bok_base_rate": base_rates[index],
-                "bok_base_rate_change_30d": base_rates[index] - base_rates[index - 30],
-                "usd_krw_close": usd_krw_rates[index],
-                "usd_krw_return_5d": (usd_krw_rates[index] / usd_krw_rates[index - 5]) - 1.0,
-                "kr_bond_yield_3y": bond_yields[index],
-                "kr_bond_yield_change_30d": bond_yields[index] - bond_yields[index - 30],
-                "foreign_net_buy_krw_5d_sum": sum(foreign_flows[(index - 4) : index + 1]),
-                "institution_net_buy_krw_5d_sum": sum(institution_flows[(index - 4) : index + 1]),
-                "individual_net_buy_krw_5d_sum": sum(individual_flows[(index - 4) : index + 1]),
-                "foreign_net_buy_5d_pct_of_turnover": sum(foreign_flows[(index - 4) : index + 1])
-                / sum(turnover[(index - 4) : index + 1]),
-                "institution_net_buy_5d_pct_of_turnover": sum(
-                    institution_flows[(index - 4) : index + 1]
-                )
-                / sum(turnover[(index - 4) : index + 1]),
-                "kospi_per": pers[index],
-                "kospi_pbr": pbrs[index],
-                "kospi_per_percentile_252d": _rolling_percentile(
-                    pers, index, window=TRADING_DAYS_FOR_PERCENTILE
+                "bok_base_rate": base_rates[local_index],
+                "bok_base_rate_change_30d": base_rates[local_index] - base_rates[local_index - 30],
+                "usd_krw_close": usd_krw_rates[local_index],
+                "usd_krw_return_5d": (usd_krw_rates[local_index] / usd_krw_rates[local_index - 5])
+                - 1.0,
+                "kr_bond_yield_3y": bond_yields[local_index],
+                "kr_bond_yield_change_30d": bond_yields[local_index]
+                - bond_yields[local_index - 30],
+                "foreign_net_buy_krw_5d_sum": sum(
+                    foreign_flows[(local_index - 4) : local_index + 1]
                 ),
-                "kospi_pbr_percentile_252d": _rolling_percentile(
-                    pbrs, index, window=TRADING_DAYS_FOR_PERCENTILE
+                "institution_net_buy_krw_5d_sum": sum(
+                    institution_flows[(local_index - 4) : local_index + 1]
+                ),
+                "individual_net_buy_krw_5d_sum": sum(
+                    individual_flows[(local_index - 4) : local_index + 1]
+                ),
+                "foreign_net_buy_5d_pct_of_turnover": sum(
+                    foreign_flows[(local_index - 4) : local_index + 1]
+                )
+                / sum(turnover[(local_index - 4) : local_index + 1]),
+                "institution_net_buy_5d_pct_of_turnover": sum(
+                    institution_flows[(local_index - 4) : local_index + 1]
+                )
+                / sum(turnover[(local_index - 4) : local_index + 1]),
+                "kospi_per": pers[local_index],
+                "kospi_pbr": pbrs[local_index],
+                "kospi_per_percentile_252d": _percentile_rank(
+                    pers[-TRADING_DAYS_FOR_PERCENTILE:], pers[-1]
+                ),
+                "kospi_pbr_percentile_252d": _percentile_rank(
+                    pbrs[-TRADING_DAYS_FOR_PERCENTILE:], pbrs[-1]
                 ),
                 "kospi_realized_vol_20d": realized_vol,
-                "kospi_realized_vol_20d_percentile_252d": _rolling_percentile_ignore_none(
-                    realized_vols, index, window=TRADING_DAYS_FOR_PERCENTILE
+                "kospi_realized_vol_20d_percentile_252d": _percentile_rank(
+                    realized_vols[-TRADING_DAYS_FOR_PERCENTILE:], realized_vol
                 ),
                 "kospi_atr_14d": sum(
                     highs[inner_index] - lows[inner_index]
-                    for inner_index in range(index - 13, index + 1)
+                    for inner_index in range(local_index - 13, local_index + 1)
                 )
                 / 14.0,
             }
             assert_no_forbidden_gold_columns(row.keys())
-            rows.append(row)
+            if valid_segment[-1].as_of_date >= requested_start:
+                rows.append(row)
         return rows
 
 
@@ -366,5 +397,7 @@ __all__ = [
     "SilverDatasetRequirement",
     "TRADING_DAYS_FOR_PERCENTILE",
     "assert_no_forbidden_gold_columns",
+    "gold_lookback_start",
     "gold_sha256",
+    "gold_warmup_trading_days",
 ]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/gold_features.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import date, timedelta
+import hashlib
+from math import sqrt
+from pathlib import Path
+from statistics import pstdev
+from typing import Protocol, cast, final
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .calendar import TradingCalendar
+
+
+class _ArrowTable(Protocol):
+    @property
+    def column_names(self) -> list[str]: ...
+
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+TRADING_DAYS_FOR_PERCENTILE = 252
+
+
+@dataclass(frozen=True, slots=True)
+class SilverDatasetRequirement:
+    source_name: str
+    dataset_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class DailyInputs:
+    as_of_date: date
+    kospi_high: float
+    kospi_low: float
+    kospi_close: float
+    turnover_krw: float
+    foreign_net_buy_krw: float
+    institution_net_buy_krw: float
+    individual_net_buy_krw: float
+    bok_base_rate: float
+    usd_krw_close: float
+    kr_bond_yield_3y: float
+    kospi_per: float
+    kospi_pbr: float
+
+
+class GoldFeatureError(ValueError):
+    pass
+
+
+class MissingGoldInputError(GoldFeatureError):
+    def __init__(self, dataset_id: str, as_of_date: date) -> None:
+        super().__init__(
+            f"missing required Silver input '{dataset_id}' for {as_of_date.isoformat()}"
+        )
+
+
+class InvalidGoldInputError(GoldFeatureError):
+    def __init__(self, dataset_id: str, field_name: str, value: object) -> None:
+        super().__init__(
+            f"invalid Silver input for dataset '{dataset_id}' field '{field_name}': {value}"
+        )
+
+
+def _canonical_row_key(row: dict[str, object]) -> tuple[str, ...]:
+    return tuple(f"{column}={row[column]}" for column in sorted(row))
+
+
+def assert_no_forbidden_gold_columns(columns: Iterable[str]) -> None:
+    forbidden = [name for name in columns if name.startswith(("target_", "future_"))]
+    if forbidden:
+        raise ValueError(f"forbidden columns in Gold output: {forbidden}")
+
+
+def gold_sha256(path: Path) -> str:
+    rows = READ_TABLE(path).to_pylist()
+    canonical = "\n".join("|".join(_canonical_row_key(row)) for row in rows)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _float_value(row: dict[str, object], field_name: str, dataset_id: str) -> float:
+    value = row.get(field_name)
+    if value is None or isinstance(value, bool):
+        raise InvalidGoldInputError(dataset_id, field_name, value)
+    if isinstance(value, int | float):
+        return float(value)
+    try:
+        return float(str(value))
+    except ValueError as exc:
+        raise InvalidGoldInputError(dataset_id, field_name, value) from exc
+
+
+def _date_value(row: dict[str, object], field_name: str, dataset_id: str) -> date:
+    value = row.get(field_name)
+    if not isinstance(value, date):
+        raise InvalidGoldInputError(dataset_id, field_name, value)
+    return value
+
+
+def _text_value(row: dict[str, object], field_name: str, dataset_id: str) -> str:
+    value = row.get(field_name)
+    if not isinstance(value, str):
+        raise InvalidGoldInputError(dataset_id, field_name, value)
+    return value
+
+
+def _trading_days_between(start: date, end: date, calendar: TradingCalendar) -> tuple[date, ...]:
+    current = start
+    dates: list[date] = []
+    while current <= end:
+        if calendar.is_trading_day(current):
+            dates.append(current)
+        current += timedelta(days=1)
+    return tuple(dates)
+
+
+def _percentile_rank(values: Sequence[float], current_value: float) -> float:
+    count = sum(1 for value in values if value <= current_value)
+    return count / len(values)
+
+
+def _rolling_percentile(values: Sequence[float], index: int, *, window: int) -> float:
+    window_values = values[(index - window + 1) : index + 1]
+    return _percentile_rank(window_values, window_values[-1])
+
+
+def _rolling_percentile_ignore_none(
+    values: Sequence[float | None],
+    index: int,
+    *,
+    window: int,
+) -> float:
+    filtered = [value for value in values[(index - window + 1) : index + 1] if value is not None]
+    current_value = values[index]
+    if current_value is None or not filtered:
+        raise ValueError("current rolling value must be present")
+    return _percentile_rank(filtered, current_value)
+
+
+@final
+class GoldFeatureBuilder:
+    OUTPUT_FILE_NAME = "decision_features.parquet"
+    REQUIRED_SILVER_DATASETS = (
+        SilverDatasetRequirement("krx", "kospi_index"),
+        SilverDatasetRequirement("krx", "investor_flow"),
+        SilverDatasetRequirement("ecos", "base_rate"),
+        SilverDatasetRequirement("ecos", "usd_krw"),
+        SilverDatasetRequirement("ecos", "bond_yield"),
+        SilverDatasetRequirement("krx", "market_valuation"),
+    )
+
+    _output_root: Path
+    _calendar: TradingCalendar
+
+    def __init__(self, output_root: Path, calendar: TradingCalendar | None = None) -> None:
+        self._output_root = output_root
+        self._calendar = TradingCalendar() if calendar is None else calendar
+
+    def build(self, *, silver_root: Path, start: date, end: date) -> Path:
+        trading_days = _trading_days_between(start, end, self._calendar)
+        daily_inputs = [
+            self._load_daily_inputs(silver_root, as_of_date) for as_of_date in trading_days
+        ]
+        gold_rows = self._build_rows(daily_inputs)
+        output_path = self._output_root / self.OUTPUT_FILE_NAME
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        table = _table_from_pylist(gold_rows)
+        assert_no_forbidden_gold_columns(table.column_names)
+        WRITE_TABLE(table, output_path, compression="snappy")
+        return output_path
+
+    def _load_daily_inputs(self, silver_root: Path, as_of_date: date) -> DailyInputs:
+        kospi_index = self._read_required_row(silver_root, "kospi_index", as_of_date)
+        investor_flow = self._read_required_row(silver_root, "investor_flow", as_of_date)
+        base_rate = self._read_required_row(silver_root, "base_rate", as_of_date)
+        usd_krw = self._read_required_row(silver_root, "usd_krw", as_of_date)
+        bond_yield = self._read_bond_yield_row(silver_root, as_of_date)
+        market_valuation = self._read_required_row(silver_root, "market_valuation", as_of_date)
+        return DailyInputs(
+            as_of_date=as_of_date,
+            kospi_high=_float_value(kospi_index, "high", "kospi_index"),
+            kospi_low=_float_value(kospi_index, "low", "kospi_index"),
+            kospi_close=_float_value(kospi_index, "close", "kospi_index"),
+            turnover_krw=_float_value(kospi_index, "turnover_krw", "kospi_index"),
+            foreign_net_buy_krw=_float_value(investor_flow, "foreign_net_buy_krw", "investor_flow"),
+            institution_net_buy_krw=_float_value(
+                investor_flow, "institution_net_buy_krw", "investor_flow"
+            ),
+            individual_net_buy_krw=_float_value(
+                investor_flow, "individual_net_buy_krw", "investor_flow"
+            ),
+            bok_base_rate=_float_value(base_rate, "base_rate_pct", "base_rate"),
+            usd_krw_close=_float_value(usd_krw, "usd_krw_rate", "usd_krw"),
+            kr_bond_yield_3y=_float_value(bond_yield, "yield_rate_pct", "bond_yield"),
+            kospi_per=_float_value(market_valuation, "trailing_per", "market_valuation"),
+            kospi_pbr=_float_value(market_valuation, "trailing_pbr", "market_valuation"),
+        )
+
+    def _read_required_row(
+        self,
+        silver_root: Path,
+        dataset_id: str,
+        as_of_date: date,
+    ) -> dict[str, object]:
+        path = silver_root / dataset_id / f"{as_of_date.isoformat()}.parquet"
+        if not path.is_file():
+            raise MissingGoldInputError(dataset_id, as_of_date)
+        rows = READ_TABLE(path).to_pylist()
+        if len(rows) != 1:
+            raise InvalidGoldInputError(dataset_id, "row_count", len(rows))
+        row = rows[0]
+        row_date = _date_value(row, "as_of_date", dataset_id)
+        if row_date != as_of_date:
+            raise InvalidGoldInputError(dataset_id, "as_of_date", row_date)
+        return row
+
+    def _read_bond_yield_row(self, silver_root: Path, as_of_date: date) -> dict[str, object]:
+        path = silver_root / "bond_yield" / f"{as_of_date.isoformat()}.parquet"
+        if not path.is_file():
+            raise MissingGoldInputError("bond_yield", as_of_date)
+        rows = READ_TABLE(path).to_pylist()
+        preferred_rows = [
+            row for row in rows if _text_value(row, "maturity_code", "bond_yield") == "3Y"
+        ]
+        selected_rows = preferred_rows if preferred_rows else rows
+        if len(selected_rows) != 1:
+            raise InvalidGoldInputError("bond_yield", "maturity_code", selected_rows)
+        row = selected_rows[0]
+        row_date = _date_value(row, "as_of_date", "bond_yield")
+        if row_date != as_of_date:
+            raise InvalidGoldInputError("bond_yield", "as_of_date", row_date)
+        return row
+
+    def _build_rows(self, daily_inputs: Sequence[DailyInputs]) -> list[dict[str, object]]:
+        closes = [row.kospi_close for row in daily_inputs]
+        highs = [row.kospi_high for row in daily_inputs]
+        lows = [row.kospi_low for row in daily_inputs]
+        turnover = [row.turnover_krw for row in daily_inputs]
+        base_rates = [row.bok_base_rate for row in daily_inputs]
+        usd_krw_rates = [row.usd_krw_close for row in daily_inputs]
+        bond_yields = [row.kr_bond_yield_3y for row in daily_inputs]
+        foreign_flows = [row.foreign_net_buy_krw for row in daily_inputs]
+        institution_flows = [row.institution_net_buy_krw for row in daily_inputs]
+        individual_flows = [row.individual_net_buy_krw for row in daily_inputs]
+        pers = [row.kospi_per for row in daily_inputs]
+        pbrs = [row.kospi_pbr for row in daily_inputs]
+
+        daily_returns: list[float | None] = [None]
+        for index in range(1, len(daily_inputs)):
+            daily_returns.append((closes[index] / closes[index - 1]) - 1.0)
+
+        realized_vols: list[float | None] = []
+        for index in range(len(daily_inputs)):
+            if index < 20:
+                realized_vols.append(None)
+                continue
+            trailing_returns = [
+                value for value in daily_returns[(index - 19) : index + 1] if value is not None
+            ]
+            realized_vols.append(pstdev(trailing_returns) * sqrt(252.0))
+
+        rows: list[dict[str, object]] = []
+        for index in range(len(daily_inputs)):
+            if index < TRADING_DAYS_FOR_PERCENTILE - 1:
+                continue
+            close_window = closes[(index - 19) : index + 1]
+            close_window_min = min(close_window)
+            close_window_max = max(close_window)
+            close_position_denominator = close_window_max - close_window_min
+            if close_position_denominator == 0.0:
+                raise InvalidGoldInputError(
+                    "kospi_index", "kospi_close_position_denominator", close_position_denominator
+                )
+            ma5 = sum(closes[(index - 4) : index + 1]) / 5.0
+            realized_vol = realized_vols[index]
+            if realized_vol is None:
+                raise InvalidGoldInputError("kospi_index", "kospi_realized_vol_20d", realized_vol)
+            row: dict[str, object] = {
+                "as_of_date": daily_inputs[index].as_of_date,
+                "kospi_close": closes[index],
+                "kospi_return_1d": (closes[index] / closes[index - 1]) - 1.0,
+                "kospi_return_3d": (closes[index] / closes[index - 3]) - 1.0,
+                "kospi_return_5d": (closes[index] / closes[index - 5]) - 1.0,
+                "kospi_ma5": ma5,
+                "kospi_ma20": sum(close_window) / 20.0,
+                "kospi_ma5_gap": (closes[index] - ma5) / ma5,
+                "kospi_close_position": (closes[index] - close_window_min)
+                / close_position_denominator,
+                "bok_base_rate": base_rates[index],
+                "bok_base_rate_change_30d": base_rates[index] - base_rates[index - 30],
+                "usd_krw_close": usd_krw_rates[index],
+                "usd_krw_return_5d": (usd_krw_rates[index] / usd_krw_rates[index - 5]) - 1.0,
+                "kr_bond_yield_3y": bond_yields[index],
+                "kr_bond_yield_change_30d": bond_yields[index] - bond_yields[index - 30],
+                "foreign_net_buy_krw_5d_sum": sum(foreign_flows[(index - 4) : index + 1]),
+                "institution_net_buy_krw_5d_sum": sum(institution_flows[(index - 4) : index + 1]),
+                "individual_net_buy_krw_5d_sum": sum(individual_flows[(index - 4) : index + 1]),
+                "foreign_net_buy_5d_pct_of_turnover": sum(foreign_flows[(index - 4) : index + 1])
+                / sum(turnover[(index - 4) : index + 1]),
+                "kospi_per": pers[index],
+                "kospi_pbr": pbrs[index],
+                "kospi_per_percentile_252d": _rolling_percentile(
+                    pers, index, window=TRADING_DAYS_FOR_PERCENTILE
+                ),
+                "kospi_pbr_percentile_252d": _rolling_percentile(
+                    pbrs, index, window=TRADING_DAYS_FOR_PERCENTILE
+                ),
+                "kospi_realized_vol_20d": realized_vol,
+                "kospi_realized_vol_20d_percentile_252d": _rolling_percentile_ignore_none(
+                    realized_vols, index, window=TRADING_DAYS_FOR_PERCENTILE
+                ),
+                "kospi_atr_14d": sum(
+                    highs[inner_index] - lows[inner_index]
+                    for inner_index in range(index - 13, index + 1)
+                )
+                / 14.0,
+            }
+            assert_no_forbidden_gold_columns(row.keys())
+            rows.append(row)
+        return rows
+
+
+__all__ = [
+    "GoldFeatureBuilder",
+    "GoldFeatureError",
+    "InvalidGoldInputError",
+    "MissingGoldInputError",
+    "SilverDatasetRequirement",
+    "TRADING_DAYS_FOR_PERCENTILE",
+    "assert_no_forbidden_gold_columns",
+    "gold_sha256",
+]

--- a/apps/kr-kospi/tests/contract/test_gold_features.py
+++ b/apps/kr-kospi/tests/contract/test_gold_features.py
@@ -17,7 +17,9 @@ from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import (
     InvalidGoldInputError,
     MissingGoldInputError,
     assert_no_forbidden_gold_columns,
+    gold_lookback_start,
     gold_sha256,
+    gold_warmup_trading_days,
 )
 
 
@@ -201,11 +203,12 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
     days = _trading_days(272)
     silver_root = tmp_path / "silver"
     _build_complete_silver_history(silver_root, days)
+    target_day = days[-1]
 
     output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
         silver_root=silver_root,
-        start=days[0],
-        end=days[-1],
+        start=target_day,
+        end=target_day,
     )
 
     rows = _read_rows(output_path)
@@ -233,7 +236,7 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
         realized_vols.append(pstdev(returns_window) * sqrt(252))
     realized_vol_percentile = _percentile_rank(realized_vols[-252:], realized_vols[-1])
 
-    assert row["as_of_date"] == days[-1]
+    assert row["as_of_date"] == target_day
     assert set(row) == EXPECTED_GOLD_COLUMNS
     assert row["kospi_close"] == pytest.approx(close)
     assert row["kospi_return_1d"] == pytest.approx((close / close_prices[-2]) - 1)
@@ -297,12 +300,12 @@ def test_gold_feature_builder_preserves_as_of_date_semantics(tmp_path: Path) -> 
 
     first_output = GoldFeatureBuilder(output_root=tmp_path / "gold-one").build(
         silver_root=first_silver_root,
-        start=days[0],
+        start=days[-2],
         end=days[-1],
     )
     second_output = GoldFeatureBuilder(output_root=tmp_path / "gold-two").build(
         silver_root=second_silver_root,
-        start=days[0],
+        start=days[-2],
         end=days[-1],
     )
 
@@ -315,21 +318,47 @@ def test_gold_feature_builder_preserves_as_of_date_semantics(tmp_path: Path) -> 
 
 
 def test_gold_feature_builder_skips_rows_without_full_252d_history(tmp_path: Path) -> None:
-    days = _trading_days(251)
+    days = _trading_days(251, start=date(2025, 1, 2))
     silver_root = tmp_path / "silver"
     _build_complete_silver_history(silver_root, days)
 
     output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
         silver_root=silver_root,
-        start=days[0],
+        start=days[-1],
         end=days[-1],
     )
 
     assert _read_rows(output_path) == []
 
 
+def test_gold_feature_builder_uses_pre_start_silver_history(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+
+    output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+        silver_root=silver_root,
+        start=days[-1],
+        end=days[-1],
+    )
+
+    rows = _read_rows(output_path)
+    assert len(rows) == 1
+    assert rows[0]["as_of_date"] == days[-1]
+
+
+def test_gold_lookback_start_steps_back_required_trading_days() -> None:
+    calendar = TradingCalendar()
+    start = date(2025, 2, 13)
+    lookback_start = gold_lookback_start(start=start, calendar=calendar)
+
+    days = _trading_days(272)
+    assert lookback_start == days[0]
+    assert gold_warmup_trading_days() == 271
+
+
 def test_gold_feature_builder_raises_typed_error_for_missing_required_input(tmp_path: Path) -> None:
-    days = _trading_days(252)
+    days = _trading_days(252, start=date(2025, 1, 2))
     silver_root = tmp_path / "silver"
     _build_complete_silver_history(silver_root, days)
     missing_date = days[-1]
@@ -338,7 +367,7 @@ def test_gold_feature_builder_raises_typed_error_for_missing_required_input(tmp_
     with pytest.raises(MissingGoldInputError, match="bond_yield"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -350,12 +379,12 @@ def test_gold_feature_builder_is_deterministic_for_identical_silver_input(tmp_pa
 
     first_path = GoldFeatureBuilder(output_root=tmp_path / "gold-one").build(
         silver_root=silver_root,
-        start=days[0],
+        start=days[-1],
         end=days[-1],
     )
     second_path = GoldFeatureBuilder(output_root=tmp_path / "gold-two").build(
         silver_root=silver_root,
-        start=days[0],
+        start=days[-1],
         end=days[-1],
     )
 
@@ -393,7 +422,7 @@ def test_gold_feature_builder_requires_single_3y_bond_yield_row(tmp_path: Path) 
     with pytest.raises(InvalidGoldInputError, match="maturity_code"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -434,7 +463,7 @@ def test_gold_feature_builder_raises_for_wrong_row_count(tmp_path: Path) -> None
     with pytest.raises(InvalidGoldInputError, match="row_count"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -460,7 +489,7 @@ def test_gold_feature_builder_raises_for_wrong_as_of_date(tmp_path: Path) -> Non
     with pytest.raises(InvalidGoldInputError, match="as_of_date"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -486,7 +515,7 @@ def test_gold_feature_builder_raises_for_invalid_float_input(tmp_path: Path) -> 
     with pytest.raises(InvalidGoldInputError, match="usd_krw_rate"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -514,7 +543,7 @@ def test_gold_feature_builder_raises_for_invalid_date_input(tmp_path: Path) -> N
     with pytest.raises(InvalidGoldInputError, match="as_of_date"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -541,7 +570,7 @@ def test_gold_feature_builder_raises_for_invalid_text_input(tmp_path: Path) -> N
     with pytest.raises(InvalidGoldInputError, match="maturity_code"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )
 
@@ -572,6 +601,6 @@ def test_gold_feature_builder_raises_for_zero_close_position_denominator(tmp_pat
     with pytest.raises(InvalidGoldInputError, match="kospi_close_position_denominator"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
-            start=days[0],
+            start=days[-1],
             end=days[-1],
         )

--- a/apps/kr-kospi/tests/contract/test_gold_features.py
+++ b/apps/kr-kospi/tests/contract/test_gold_features.py
@@ -169,6 +169,10 @@ def _build_gold(root: Path, *, days: list[date]) -> Path:
     )
 
 
+def _percentile_rank(values: list[float], current_value: float) -> float:
+    return sum(1 for value in values if value <= current_value) / len(values)
+
+
 def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) -> None:
     days = _trading_days(252)
     silver_root = tmp_path / "silver"
@@ -196,6 +200,14 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
         (close_prices[index] / close_prices[index - 1]) - 1 for index in range(1, len(close_prices))
     ]
     realized_vol = pstdev(daily_returns[-20:]) * sqrt(252)
+    realized_vols: list[float] = []
+    for index in range(20, len(close_prices)):
+        returns_window = [
+            (close_prices[inner_index] / close_prices[inner_index - 1]) - 1
+            for inner_index in range(index - 19, index + 1)
+        ]
+        realized_vols.append(pstdev(returns_window) * sqrt(252))
+    realized_vol_percentile = _percentile_rank(realized_vols, realized_vols[-1])
 
     assert row["as_of_date"] == days[-1]
     assert row["kospi_close"] == pytest.approx(close)
@@ -223,7 +235,7 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
     assert row["kospi_per_percentile_252d"] == pytest.approx(1.0)
     assert row["kospi_pbr_percentile_252d"] == pytest.approx(1.0)
     assert row["kospi_realized_vol_20d"] == pytest.approx(realized_vol)
-    assert row["kospi_realized_vol_20d_percentile_252d"] == pytest.approx(1.0)
+    assert row["kospi_realized_vol_20d_percentile_252d"] == pytest.approx(realized_vol_percentile)
     assert row["kospi_atr_14d"] == pytest.approx(10.0)
     assert not any(column.startswith("target_") for column in row)
     assert not any(column.startswith("future_") for column in row)

--- a/apps/kr-kospi/tests/contract/test_gold_features.py
+++ b/apps/kr-kospi/tests/contract/test_gold_features.py
@@ -520,6 +520,60 @@ def test_gold_feature_builder_raises_for_invalid_float_input(tmp_path: Path) -> 
         )
 
 
+def test_gold_feature_builder_raises_for_boolean_float_input(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "usd_krw",
+        target_date,
+        {
+            "as_of_date": target_date,
+            "source_name": "ecos",
+            "source_series_id": "usd_krw",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "usd_krw_rate": True,
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="usd_krw_rate"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[-1],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_accepts_integer_float_input(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "usd_krw",
+        target_date,
+        {
+            "as_of_date": target_date,
+            "source_name": "ecos",
+            "source_series_id": "usd_krw",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "usd_krw_rate": 1500,
+        },
+    )
+
+    output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+        silver_root=silver_root,
+        start=days[-1],
+        end=days[-1],
+    )
+
+    rows = _read_rows(output_path)
+    assert rows[0]["usd_krw_close"] == pytest.approx(1500.0)
+
+
 def test_gold_feature_builder_raises_for_invalid_date_input(tmp_path: Path) -> None:
     days = _trading_days(272)
     silver_root = tmp_path / "silver"
@@ -568,6 +622,33 @@ def test_gold_feature_builder_raises_for_invalid_text_input(tmp_path: Path) -> N
     )
 
     with pytest.raises(InvalidGoldInputError, match="maturity_code"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[-1],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_bond_yield_as_of_date_mismatch(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "bond_yield",
+        target_date,
+        {
+            "as_of_date": days[-2],
+            "source_name": "ecos",
+            "source_series_id": "bond_yield",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "maturity_code": "3Y",
+            "yield_rate_pct": Decimal("4.00"),
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="as_of_date"):
         _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
             silver_root=silver_root,
             start=days[-1],

--- a/apps/kr-kospi/tests/contract/test_gold_features.py
+++ b/apps/kr-kospi/tests/contract/test_gold_features.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from math import sqrt
+from pathlib import Path
+from statistics import pstdev
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.transforms.calendar import TradingCalendar
+from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import (
+    GoldFeatureBuilder,
+    MissingGoldInputError,
+    assert_no_forbidden_gold_columns,
+    gold_sha256,
+)
+
+
+class _ArrowTable(Protocol):
+    @property
+    def column_names(self) -> list[str]: ...
+
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _read_rows(path: Path) -> list[dict[str, object]]:
+    return READ_TABLE(path).to_pylist()
+
+
+def _write_silver_partition(
+    root: Path,
+    dataset_id: str,
+    partition_date: date,
+    row: dict[str, object],
+) -> None:
+    path = root / dataset_id / f"{partition_date.isoformat()}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist([row]), path, compression="snappy")
+
+
+def _trading_days(count: int, *, start: date = date(2024, 1, 2)) -> list[date]:
+    calendar = TradingCalendar()
+    current = start
+    days: list[date] = []
+    while len(days) < count:
+        if calendar.is_trading_day(current):
+            days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def _build_complete_silver_history(root: Path, days: list[date]) -> None:
+    for index, as_of_date in enumerate(days):
+        close = Decimal(100 + index)
+        _write_silver_partition(
+            root,
+            "kospi_index",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "open": close - Decimal("1"),
+                "high": close + Decimal("5"),
+                "low": close - Decimal("5"),
+                "close": close,
+                "volume_shares": 1_000_000 + index,
+                "turnover_krw": Decimal(1000 + (10 * index)),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "investor_flow",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "investor_flow",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "foreign_net_buy_krw": Decimal(100 + (2 * index)),
+                "institution_net_buy_krw": Decimal(200 + (3 * index)),
+                "individual_net_buy_krw": Decimal(-(300 + (5 * index))),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "base_rate",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "base_rate",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "base_rate_pct": Decimal("3.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "usd_krw",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "usd_krw",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "usd_krw_rate": Decimal(1200 + index),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "bond_yield",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "bond_yield",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "maturity_code": "3Y",
+                "yield_rate_pct": Decimal("2.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "market_valuation",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "market_valuation",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "market_cap_krw": Decimal(2_000_000 + (1000 * index)),
+                "trailing_per": Decimal("10.00") + (Decimal(index) / Decimal("10")),
+                "trailing_pbr": Decimal("1.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
+
+
+def _build_gold(root: Path, *, days: list[date]) -> Path:
+    return GoldFeatureBuilder(output_root=root / "gold").build(
+        silver_root=root / "silver",
+        start=days[0],
+        end=days[-1],
+    )
+
+
+def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) -> None:
+    days = _trading_days(252)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+
+    output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+        silver_root=silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+
+    rows = _read_rows(output_path)
+    assert len(rows) == 1
+    row = rows[0]
+
+    close_prices = [100 + index for index in range(252)]
+    close = close_prices[-1]
+    ma5 = sum(close_prices[-5:]) / 5
+    ma20 = sum(close_prices[-20:]) / 20
+    turnover = [1000 + (10 * index) for index in range(252)]
+    foreign = [100 + (2 * index) for index in range(252)]
+    institution = [200 + (3 * index) for index in range(252)]
+    individual = [-(300 + (5 * index)) for index in range(252)]
+    daily_returns = [
+        (close_prices[index] / close_prices[index - 1]) - 1 for index in range(1, len(close_prices))
+    ]
+    realized_vol = pstdev(daily_returns[-20:]) * sqrt(252)
+
+    assert row["as_of_date"] == days[-1]
+    assert row["kospi_close"] == pytest.approx(close)
+    assert row["kospi_return_1d"] == pytest.approx((close / close_prices[-2]) - 1)
+    assert row["kospi_return_3d"] == pytest.approx((close / close_prices[-4]) - 1)
+    assert row["kospi_return_5d"] == pytest.approx((close / close_prices[-6]) - 1)
+    assert row["kospi_ma5"] == pytest.approx(ma5)
+    assert row["kospi_ma20"] == pytest.approx(ma20)
+    assert row["kospi_ma5_gap"] == pytest.approx((close - ma5) / ma5)
+    assert row["kospi_close_position"] == pytest.approx(1.0)
+    assert row["bok_base_rate"] == pytest.approx(5.51)
+    assert row["bok_base_rate_change_30d"] == pytest.approx(0.30)
+    assert row["usd_krw_close"] == pytest.approx(1451.0)
+    assert row["usd_krw_return_5d"] == pytest.approx((1451 / 1446) - 1)
+    assert row["kr_bond_yield_3y"] == pytest.approx(4.51)
+    assert row["kr_bond_yield_change_30d"] == pytest.approx(0.30)
+    assert row["foreign_net_buy_krw_5d_sum"] == pytest.approx(sum(foreign[-5:]))
+    assert row["institution_net_buy_krw_5d_sum"] == pytest.approx(sum(institution[-5:]))
+    assert row["individual_net_buy_krw_5d_sum"] == pytest.approx(sum(individual[-5:]))
+    assert row["foreign_net_buy_5d_pct_of_turnover"] == pytest.approx(
+        sum(foreign[-5:]) / sum(turnover[-5:])
+    )
+    assert row["kospi_per"] == pytest.approx(35.1)
+    assert row["kospi_pbr"] == pytest.approx(3.51)
+    assert row["kospi_per_percentile_252d"] == pytest.approx(1.0)
+    assert row["kospi_pbr_percentile_252d"] == pytest.approx(1.0)
+    assert row["kospi_realized_vol_20d"] == pytest.approx(realized_vol)
+    assert row["kospi_realized_vol_20d_percentile_252d"] == pytest.approx(1.0)
+    assert row["kospi_atr_14d"] == pytest.approx(10.0)
+    assert not any(column.startswith("target_") for column in row)
+    assert not any(column.startswith("future_") for column in row)
+
+
+def test_gold_feature_builder_preserves_as_of_date_semantics(tmp_path: Path) -> None:
+    days = _trading_days(253)
+    first_silver_root = tmp_path / "silver-one"
+    second_silver_root = tmp_path / "silver-two"
+    _build_complete_silver_history(first_silver_root, days)
+    _build_complete_silver_history(second_silver_root, days)
+
+    future_date = days[-1]
+    _write_silver_partition(
+        second_silver_root,
+        "kospi_index",
+        future_date,
+        {
+            "as_of_date": future_date,
+            "source_name": "krx",
+            "source_series_id": "kospi_index",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "open": Decimal("1"),
+            "high": Decimal("5000"),
+            "low": Decimal("1"),
+            "close": Decimal("5000"),
+            "volume_shares": 999,
+            "turnover_krw": Decimal("999999"),
+        },
+    )
+
+    first_output = GoldFeatureBuilder(output_root=tmp_path / "gold-one").build(
+        silver_root=first_silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+    second_output = GoldFeatureBuilder(output_root=tmp_path / "gold-two").build(
+        silver_root=second_silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+
+    first_rows = _read_rows(first_output)
+    second_rows = _read_rows(second_output)
+    assert len(first_rows) == 2
+    assert len(second_rows) == 2
+    assert first_rows[0] == second_rows[0]
+    assert first_rows[0]["as_of_date"] == days[-2]
+
+
+def test_gold_feature_builder_skips_rows_without_full_252d_history(tmp_path: Path) -> None:
+    days = _trading_days(251)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+
+    output_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+        silver_root=silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+
+    assert _read_rows(output_path) == []
+
+
+def test_gold_feature_builder_raises_typed_error_for_missing_required_input(tmp_path: Path) -> None:
+    days = _trading_days(252)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    missing_date = days[-1]
+    (silver_root / "bond_yield" / f"{missing_date.isoformat()}.parquet").unlink()
+
+    with pytest.raises(MissingGoldInputError, match="bond_yield"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_is_deterministic_for_identical_silver_input(tmp_path: Path) -> None:
+    days = _trading_days(253)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+
+    first_path = GoldFeatureBuilder(output_root=tmp_path / "gold-one").build(
+        silver_root=silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+    second_path = GoldFeatureBuilder(output_root=tmp_path / "gold-two").build(
+        silver_root=silver_root,
+        start=days[0],
+        end=days[-1],
+    )
+
+    assert _read_rows(first_path) == _read_rows(second_path)
+    assert gold_sha256(first_path) == gold_sha256(second_path)
+
+
+def test_assert_no_forbidden_gold_columns_rejects_target_and_future_prefixes() -> None:
+    with pytest.raises(ValueError, match="target_signal"):
+        assert_no_forbidden_gold_columns(["target_signal"])
+
+    with pytest.raises(ValueError, match="future_return_1d"):
+        assert_no_forbidden_gold_columns(["future_return_1d"])

--- a/apps/kr-kospi/tests/contract/test_gold_features.py
+++ b/apps/kr-kospi/tests/contract/test_gold_features.py
@@ -14,6 +14,7 @@ import pytest
 from kospi_decision_pipeline_app_kr_kospi.transforms.calendar import TradingCalendar
 from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import (
     GoldFeatureBuilder,
+    InvalidGoldInputError,
     MissingGoldInputError,
     assert_no_forbidden_gold_columns,
     gold_sha256,
@@ -161,20 +162,43 @@ def _build_complete_silver_history(root: Path, days: list[date]) -> None:
         )
 
 
-def _build_gold(root: Path, *, days: list[date]) -> Path:
-    return GoldFeatureBuilder(output_root=root / "gold").build(
-        silver_root=root / "silver",
-        start=days[0],
-        end=days[-1],
-    )
-
-
 def _percentile_rank(values: list[float], current_value: float) -> float:
     return sum(1 for value in values if value <= current_value) / len(values)
 
 
+EXPECTED_GOLD_COLUMNS = {
+    "as_of_date",
+    "kospi_close",
+    "kospi_return_1d",
+    "kospi_return_3d",
+    "kospi_return_5d",
+    "kospi_ma5",
+    "kospi_ma20",
+    "kospi_ma5_gap",
+    "kospi_close_position",
+    "bok_base_rate",
+    "bok_base_rate_change_30d",
+    "usd_krw_close",
+    "usd_krw_return_5d",
+    "kr_bond_yield_3y",
+    "kr_bond_yield_change_30d",
+    "foreign_net_buy_krw_5d_sum",
+    "institution_net_buy_krw_5d_sum",
+    "individual_net_buy_krw_5d_sum",
+    "foreign_net_buy_5d_pct_of_turnover",
+    "institution_net_buy_5d_pct_of_turnover",
+    "kospi_per",
+    "kospi_pbr",
+    "kospi_per_percentile_252d",
+    "kospi_pbr_percentile_252d",
+    "kospi_realized_vol_20d",
+    "kospi_realized_vol_20d_percentile_252d",
+    "kospi_atr_14d",
+}
+
+
 def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) -> None:
-    days = _trading_days(252)
+    days = _trading_days(272)
     silver_root = tmp_path / "silver"
     _build_complete_silver_history(silver_root, days)
 
@@ -188,14 +212,14 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
     assert len(rows) == 1
     row = rows[0]
 
-    close_prices = [100 + index for index in range(252)]
+    close_prices = [100 + index for index in range(272)]
     close = close_prices[-1]
     ma5 = sum(close_prices[-5:]) / 5
     ma20 = sum(close_prices[-20:]) / 20
-    turnover = [1000 + (10 * index) for index in range(252)]
-    foreign = [100 + (2 * index) for index in range(252)]
-    institution = [200 + (3 * index) for index in range(252)]
-    individual = [-(300 + (5 * index)) for index in range(252)]
+    turnover = [1000 + (10 * index) for index in range(272)]
+    foreign = [100 + (2 * index) for index in range(272)]
+    institution = [200 + (3 * index) for index in range(272)]
+    individual = [-(300 + (5 * index)) for index in range(272)]
     daily_returns = [
         (close_prices[index] / close_prices[index - 1]) - 1 for index in range(1, len(close_prices))
     ]
@@ -207,9 +231,10 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
             for inner_index in range(index - 19, index + 1)
         ]
         realized_vols.append(pstdev(returns_window) * sqrt(252))
-    realized_vol_percentile = _percentile_rank(realized_vols, realized_vols[-1])
+    realized_vol_percentile = _percentile_rank(realized_vols[-252:], realized_vols[-1])
 
     assert row["as_of_date"] == days[-1]
+    assert set(row) == EXPECTED_GOLD_COLUMNS
     assert row["kospi_close"] == pytest.approx(close)
     assert row["kospi_return_1d"] == pytest.approx((close / close_prices[-2]) - 1)
     assert row["kospi_return_3d"] == pytest.approx((close / close_prices[-4]) - 1)
@@ -218,11 +243,11 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
     assert row["kospi_ma20"] == pytest.approx(ma20)
     assert row["kospi_ma5_gap"] == pytest.approx((close - ma5) / ma5)
     assert row["kospi_close_position"] == pytest.approx(1.0)
-    assert row["bok_base_rate"] == pytest.approx(5.51)
+    assert row["bok_base_rate"] == pytest.approx(5.71)
     assert row["bok_base_rate_change_30d"] == pytest.approx(0.30)
-    assert row["usd_krw_close"] == pytest.approx(1451.0)
-    assert row["usd_krw_return_5d"] == pytest.approx((1451 / 1446) - 1)
-    assert row["kr_bond_yield_3y"] == pytest.approx(4.51)
+    assert row["usd_krw_close"] == pytest.approx(1471.0)
+    assert row["usd_krw_return_5d"] == pytest.approx((1471 / 1466) - 1)
+    assert row["kr_bond_yield_3y"] == pytest.approx(4.71)
     assert row["kr_bond_yield_change_30d"] == pytest.approx(0.30)
     assert row["foreign_net_buy_krw_5d_sum"] == pytest.approx(sum(foreign[-5:]))
     assert row["institution_net_buy_krw_5d_sum"] == pytest.approx(sum(institution[-5:]))
@@ -230,8 +255,11 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
     assert row["foreign_net_buy_5d_pct_of_turnover"] == pytest.approx(
         sum(foreign[-5:]) / sum(turnover[-5:])
     )
-    assert row["kospi_per"] == pytest.approx(35.1)
-    assert row["kospi_pbr"] == pytest.approx(3.51)
+    assert row["institution_net_buy_5d_pct_of_turnover"] == pytest.approx(
+        sum(institution[-5:]) / sum(turnover[-5:])
+    )
+    assert row["kospi_per"] == pytest.approx(37.1)
+    assert row["kospi_pbr"] == pytest.approx(3.71)
     assert row["kospi_per_percentile_252d"] == pytest.approx(1.0)
     assert row["kospi_pbr_percentile_252d"] == pytest.approx(1.0)
     assert row["kospi_realized_vol_20d"] == pytest.approx(realized_vol)
@@ -242,7 +270,7 @@ def test_gold_feature_builder_computes_trailing_only_features(tmp_path: Path) ->
 
 
 def test_gold_feature_builder_preserves_as_of_date_semantics(tmp_path: Path) -> None:
-    days = _trading_days(253)
+    days = _trading_days(273)
     first_silver_root = tmp_path / "silver-one"
     second_silver_root = tmp_path / "silver-two"
     _build_complete_silver_history(first_silver_root, days)
@@ -316,7 +344,7 @@ def test_gold_feature_builder_raises_typed_error_for_missing_required_input(tmp_
 
 
 def test_gold_feature_builder_is_deterministic_for_identical_silver_input(tmp_path: Path) -> None:
-    days = _trading_days(253)
+    days = _trading_days(273)
     silver_root = tmp_path / "silver"
     _build_complete_silver_history(silver_root, days)
 
@@ -341,3 +369,209 @@ def test_assert_no_forbidden_gold_columns_rejects_target_and_future_prefixes() -
 
     with pytest.raises(ValueError, match="future_return_1d"):
         assert_no_forbidden_gold_columns(["future_return_1d"])
+
+
+def test_gold_feature_builder_requires_single_3y_bond_yield_row(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "bond_yield",
+        target_date,
+        {
+            "as_of_date": target_date,
+            "source_name": "ecos",
+            "source_series_id": "bond_yield",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "maturity_code": "10Y",
+            "yield_rate_pct": Decimal("4.00"),
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="maturity_code"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_wrong_row_count(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    path = silver_root / "investor_flow" / f"{target_date.isoformat()}.parquet"
+    WRITE_TABLE(
+        _table_from_pylist(
+            [
+                {
+                    "as_of_date": target_date,
+                    "source_name": "krx",
+                    "source_series_id": "investor_flow",
+                    "fetched_at": "2024-01-10T09:00:00+00:00",
+                    "foreign_net_buy_krw": Decimal("1"),
+                    "institution_net_buy_krw": Decimal("2"),
+                    "individual_net_buy_krw": Decimal("3"),
+                },
+                {
+                    "as_of_date": target_date,
+                    "source_name": "krx",
+                    "source_series_id": "investor_flow",
+                    "fetched_at": "2024-01-10T09:00:00+00:00",
+                    "foreign_net_buy_krw": Decimal("4"),
+                    "institution_net_buy_krw": Decimal("5"),
+                    "individual_net_buy_krw": Decimal("6"),
+                },
+            ]
+        ),
+        path,
+        compression="snappy",
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="row_count"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_wrong_as_of_date(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "base_rate",
+        target_date,
+        {
+            "as_of_date": days[-2],
+            "source_name": "ecos",
+            "source_series_id": "base_rate",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "base_rate_pct": Decimal("1.00"),
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="as_of_date"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_invalid_float_input(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "usd_krw",
+        target_date,
+        {
+            "as_of_date": target_date,
+            "source_name": "ecos",
+            "source_series_id": "usd_krw",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "usd_krw_rate": "bad",
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="usd_krw_rate"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_invalid_date_input(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "market_valuation",
+        target_date,
+        {
+            "as_of_date": "2024-01-01",
+            "source_name": "krx",
+            "source_series_id": "market_valuation",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "market_cap_krw": Decimal("1"),
+            "trailing_per": Decimal("2"),
+            "trailing_pbr": Decimal("3"),
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="as_of_date"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_invalid_text_input(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    target_date = days[-1]
+    _write_silver_partition(
+        silver_root,
+        "bond_yield",
+        target_date,
+        {
+            "as_of_date": target_date,
+            "source_name": "ecos",
+            "source_series_id": "bond_yield",
+            "fetched_at": "2024-01-10T09:00:00+00:00",
+            "maturity_code": 3,
+            "yield_rate_pct": Decimal("4.00"),
+        },
+    )
+
+    with pytest.raises(InvalidGoldInputError, match="maturity_code"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )
+
+
+def test_gold_feature_builder_raises_for_zero_close_position_denominator(tmp_path: Path) -> None:
+    days = _trading_days(272)
+    silver_root = tmp_path / "silver"
+    _build_complete_silver_history(silver_root, days)
+    for target_date in days[-20:]:
+        _write_silver_partition(
+            silver_root,
+            "kospi_index",
+            target_date,
+            {
+                "as_of_date": target_date,
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "open": Decimal("100"),
+                "high": Decimal("100"),
+                "low": Decimal("100"),
+                "close": Decimal("100"),
+                "volume_shares": 1_000_000,
+                "turnover_krw": Decimal("1000"),
+            },
+        )
+
+    with pytest.raises(InvalidGoldInputError, match="kospi_close_position_denominator"):
+        _ = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+            silver_root=silver_root,
+            start=days[0],
+            end=days[-1],
+        )

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -353,6 +353,17 @@ def test_cli_main_routes_build_features_silver_args(monkeypatch: pytest.MonkeyPa
     }
 
 
+def test_cli_main_requires_source_and_dataset_for_silver(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit, match="2"):
+        _ = main(
+            ["build-features", "--layer", "silver", "--from", "2024-01-02", "--to", "2024-01-03"]
+        )
+
+    assert "--source and --dataset are required when --layer silver" in capsys.readouterr().err
+
+
 def test_cli_main_routes_build_features_gold_args(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
@@ -490,4 +501,85 @@ def test_run_build_features_command_writes_gold_output(
 
     output_path = tmp_path / "gold" / GoldFeatureBuilder.OUTPUT_FILE_NAME
     assert output_path.is_file()
+    assert "wrote decision_features.parquet sha256=" in capsys.readouterr().out
+
+
+def test_cli_main_uses_gold_default_output_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_build_features_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_build_features_command",
+        fake_run_build_features_command,
+    )
+
+    assert (
+        main(
+            [
+                "build-features",
+                "--layer",
+                "gold",
+                "--from",
+                "2024-01-02",
+                "--to",
+                "2024-12-31",
+            ]
+        )
+        == 0
+    )
+    assert captured["output_dir"] == "data/gold"
+
+
+def test_run_build_features_command_writes_all_layers_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
+    from kospi_decision_pipeline_app_kr_kospi.transforms.silver import SilverNormalizer
+
+    written_silver_path = tmp_path / "silver" / "kospi_index" / "2024-01-02.parquet"
+    written_silver_path.parent.mkdir(parents=True, exist_ok=True)
+    written_silver_path.write_bytes(b"silver")
+    written_gold_path = tmp_path / "gold" / GoldFeatureBuilder.OUTPUT_FILE_NAME
+    written_gold_path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(
+        _table_from_pylist([{"as_of_date": date(2024, 1, 3), "kospi_close": 1.0}]),
+        written_gold_path,
+        compression="snappy",
+    )
+
+    def fake_normalize_dataset(self: SilverNormalizer, **_: object) -> tuple[Path, ...]:
+        return (written_silver_path,)
+
+    def fake_build(self: GoldFeatureBuilder, *, silver_root: Path, start: date, end: date) -> Path:
+        assert silver_root == tmp_path / "silver"
+        assert start.isoformat() == "2024-01-02"
+        assert end.isoformat() == "2024-01-03"
+        return written_gold_path
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(SilverNormalizer, "normalize_dataset", fake_normalize_dataset)
+    monkeypatch.setattr(GoldFeatureBuilder, "build", fake_build)
+
+    try:
+        assert (
+            run_build_features_command(
+                layer="all",
+                source="",
+                dataset="",
+                start="2024-01-02",
+                end="2024-01-03",
+                bronze_dir=str(tmp_path / "bronze"),
+                silver_dir=str(tmp_path / "silver"),
+                output_dir=str(tmp_path / "gold"),
+            )
+            == 0
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert written_silver_path.is_file()
+    assert written_gold_path.is_file()
     assert "wrote decision_features.parquet sha256=" in capsys.readouterr().out

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -449,6 +449,20 @@ def test_run_build_features_command_rejects_unsupported_dataset() -> None:
         )
 
 
+def test_run_build_features_command_rejects_unsupported_layer() -> None:
+    with pytest.raises(ValueError, match="unsupported feature layer"):
+        _ = run_build_features_command(
+            layer="unsupported",
+            source="",
+            dataset="",
+            start="2024-01-02",
+            end="2024-01-03",
+            bronze_dir="tmp/bronze",
+            silver_dir="tmp/silver",
+            output_dir="tmp/output",
+        )
+
+
 def test_parse_date_and_fixture_root_helpers() -> None:
     assert parse_date("2024-01-02").isoformat() == "2024-01-02"
     assert (fixtures_root() / "krx" / "kospi_index.json").is_file()

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from datetime import date, timedelta
+from decimal import Decimal
 from pathlib import Path
 import runpy
+from typing import Protocol, cast
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 from kospi_decision_pipeline_app_kr_kospi import __version__
@@ -19,6 +24,7 @@ from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import (
     BronzeIngestor,
     FixtureConnectorRegistry,
 )
+from kospi_decision_pipeline_app_kr_kospi.transforms.calendar import TradingCalendar
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -27,6 +33,135 @@ ENV = {
     + ":"
     + str(REPO_ROOT / "apps" / "kr-kospi" / "src"),
 }
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _write_silver_partition(
+    root: Path,
+    dataset_id: str,
+    partition_date: date,
+    row: dict[str, object],
+) -> None:
+    path = root / dataset_id / f"{partition_date.isoformat()}.parquet"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist([row]), path, compression="snappy")
+
+
+def _trading_days(count: int) -> list[date]:
+    calendar = TradingCalendar()
+    current = date(2024, 1, 2)
+    days: list[date] = []
+    while len(days) < count:
+        if calendar.is_trading_day(current):
+            days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def _build_complete_silver_history(root: Path, days: list[date]) -> None:
+    for index, as_of_date in enumerate(days):
+        close = Decimal(100 + index)
+        _write_silver_partition(
+            root,
+            "kospi_index",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "open": close - Decimal("1"),
+                "high": close + Decimal("5"),
+                "low": close - Decimal("5"),
+                "close": close,
+                "volume_shares": 1_000_000 + index,
+                "turnover_krw": Decimal(1000 + (10 * index)),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "investor_flow",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "investor_flow",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "foreign_net_buy_krw": Decimal(100 + (2 * index)),
+                "institution_net_buy_krw": Decimal(200 + (3 * index)),
+                "individual_net_buy_krw": Decimal(-(300 + (5 * index))),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "base_rate",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "base_rate",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "base_rate_pct": Decimal("3.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "usd_krw",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "usd_krw",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "usd_krw_rate": Decimal(1200 + index),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "bond_yield",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "bond_yield",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "maturity_code": "3Y",
+                "yield_rate_pct": Decimal("2.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
+        _write_silver_partition(
+            root,
+            "market_valuation",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "market_valuation",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "market_cap_krw": Decimal(2_000_000 + (1000 * index)),
+                "trailing_per": Decimal("10.00") + (Decimal(index) / Decimal("10")),
+                "trailing_pbr": Decimal("1.00") + (Decimal(index) / Decimal("100")),
+            },
+        )
 
 
 def test_cli_stub_subcommand_output() -> None:
@@ -335,7 +470,6 @@ def test_run_build_features_command_writes_gold_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
-    from tests.contract.test_gold_features import _build_complete_silver_history, _trading_days
 
     days = _trading_days(252)
     _build_complete_silver_history(tmp_path / "silver", days)

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -213,7 +213,50 @@ def test_cli_main_routes_build_features_silver_args(monkeypatch: pytest.MonkeyPa
         "start": "2024-01-02",
         "end": "2024-01-03",
         "bronze_dir": "tmp/bronze",
+        "silver_dir": "data/silver",
         "output_dir": "tmp/silver",
+    }
+
+
+def test_cli_main_routes_build_features_gold_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_build_features_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_build_features_command",
+        fake_run_build_features_command,
+    )
+
+    assert (
+        main(
+            [
+                "build-features",
+                "--layer",
+                "gold",
+                "--from",
+                "2024-01-02",
+                "--to",
+                "2024-12-31",
+                "--silver-dir",
+                "tmp/silver",
+                "--out",
+                "tmp/gold",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "layer": "gold",
+        "source": "",
+        "dataset": "",
+        "start": "2024-01-02",
+        "end": "2024-12-31",
+        "bronze_dir": "data/bronze",
+        "silver_dir": "tmp/silver",
+        "output_dir": "tmp/gold",
     }
 
 
@@ -236,6 +279,7 @@ def test_run_build_features_command_writes_silver_output(
             start="2024-01-02",
             end="2024-01-03",
             bronze_dir=str(tmp_path / "bronze"),
+            silver_dir=str(tmp_path / "silver"),
             output_dir=str(tmp_path / "silver"),
         )
         == 0
@@ -254,6 +298,7 @@ def test_run_build_features_command_rejects_unsupported_dataset() -> None:
             start="2024-01-02",
             end="2024-01-03",
             bronze_dir="tmp/bronze",
+            silver_dir="tmp/silver",
             output_dir="tmp/silver",
         )
 
@@ -286,20 +331,29 @@ def test_module_main_raises_system_exit(monkeypatch: pytest.MonkeyPatch) -> None
         assert exc.code == 0
 
 
-def test_run_build_features_command_reports_non_silver_layer(
-    capsys: pytest.CaptureFixture[str],
+def test_run_build_features_command_writes_gold_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
+    from tests.contract.test_gold_features import _build_complete_silver_history, _trading_days
+
+    days = _trading_days(252)
+    _build_complete_silver_history(tmp_path / "silver", days)
+
     assert (
         run_build_features_command(
             layer="gold",
-            source="krx",
-            dataset="kospi_index",
-            start="2024-01-02",
-            end="2024-01-03",
-            bronze_dir="tmp/bronze",
-            output_dir="tmp/gold",
+            source="",
+            dataset="",
+            start=days[0].isoformat(),
+            end=days[-1].isoformat(),
+            bronze_dir=str(tmp_path / "bronze"),
+            silver_dir=str(tmp_path / "silver"),
+            output_dir=str(tmp_path / "gold"),
         )
         == 0
     )
 
-    assert capsys.readouterr().out.strip() == "build-features --layer gold: not yet implemented"
+    output_path = tmp_path / "gold" / GoldFeatureBuilder.OUTPUT_FILE_NAME
+    assert output_path.is_file()
+    assert "wrote decision_features.parquet sha256=" in capsys.readouterr().out

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -482,7 +482,7 @@ def test_run_build_features_command_writes_gold_output(
 ) -> None:
     from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
 
-    days = _trading_days(252)
+    days = _trading_days(272)
     _build_complete_silver_history(tmp_path / "silver", days)
 
     assert (
@@ -490,7 +490,7 @@ def test_run_build_features_command_writes_gold_output(
             layer="gold",
             source="",
             dataset="",
-            start=days[0].isoformat(),
+            start=days[-1].isoformat(),
             end=days[-1].isoformat(),
             bronze_dir=str(tmp_path / "bronze"),
             silver_dir=str(tmp_path / "silver"),
@@ -555,8 +555,8 @@ def test_run_build_features_command_writes_all_layers_output(
 
     def fake_build(self: GoldFeatureBuilder, *, silver_root: Path, start: date, end: date) -> Path:
         assert silver_root == tmp_path / "silver"
-        assert start.isoformat() == "2024-01-02"
-        assert end.isoformat() == "2024-01-03"
+        assert start.isoformat() == "2025-02-13"
+        assert end.isoformat() == "2025-02-14"
         return written_gold_path
 
     monkeypatch = pytest.MonkeyPatch()
@@ -569,8 +569,8 @@ def test_run_build_features_command_writes_all_layers_output(
                 layer="all",
                 source="",
                 dataset="",
-                start="2024-01-02",
-                end="2024-01-03",
+                start="2025-02-13",
+                end="2025-02-14",
                 bronze_dir=str(tmp_path / "bronze"),
                 silver_dir=str(tmp_path / "silver"),
                 output_dir=str(tmp_path / "gold"),
@@ -583,3 +583,56 @@ def test_run_build_features_command_writes_all_layers_output(
     assert written_silver_path.is_file()
     assert written_gold_path.is_file()
     assert "wrote decision_features.parquet sha256=" in capsys.readouterr().out
+
+
+def test_run_build_features_command_uses_warmup_start_for_all_layer(tmp_path: Path) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import (
+        GoldFeatureBuilder,
+        gold_lookback_start,
+    )
+    from kospi_decision_pipeline_app_kr_kospi.transforms.silver import SilverNormalizer
+
+    captured_starts: list[date] = []
+    written_gold_path = tmp_path / "gold" / GoldFeatureBuilder.OUTPUT_FILE_NAME
+    written_gold_path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(
+        _table_from_pylist([{"as_of_date": date(2025, 2, 13), "kospi_close": 1.0}]),
+        written_gold_path,
+        compression="snappy",
+    )
+
+    def fake_normalize_dataset(self: SilverNormalizer, **kwargs: object) -> tuple[Path, ...]:
+        start = kwargs.get("start")
+        assert isinstance(start, date)
+        captured_starts.append(start)
+        return ()
+
+    def fake_build(self: GoldFeatureBuilder, *, silver_root: Path, start: date, end: date) -> Path:
+        assert silver_root == tmp_path / "silver"
+        assert start == date(2025, 2, 13)
+        assert end == date(2025, 2, 13)
+        return written_gold_path
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(SilverNormalizer, "normalize_dataset", fake_normalize_dataset)
+    monkeypatch.setattr(GoldFeatureBuilder, "build", fake_build)
+
+    try:
+        assert (
+            run_build_features_command(
+                layer="all",
+                source="",
+                dataset="",
+                start="2025-02-13",
+                end="2025-02-13",
+                bronze_dir=str(tmp_path / "bronze"),
+                silver_dir=str(tmp_path / "silver"),
+                output_dir=str(tmp_path / "gold"),
+            )
+            == 0
+        )
+    finally:
+        monkeypatch.undo()
+
+    expected_start = gold_lookback_start(start=date(2025, 2, 13), calendar=TradingCalendar())
+    assert captured_starts == [expected_start] * len(GoldFeatureBuilder.REQUIRED_SILVER_DATASETS)


### PR DESCRIPTION
## Summary
- add a deterministic Gold feature builder that materializes trailing-only decision inputs from Silver parquet, enforces strict as-of-date completeness, and validates away target/future leakage
- extend `kospi-pipeline build-features` with `gold` and `all` layers so the CLI can build Gold directly or chain Silver→Gold output generation
- cover the Gold contract with feature-value, history-window, determinism, missing-input, and CLI routing tests while keeping full branch coverage green