### PR TITLE
Future-leakage guardrails and sanitized agent inputs (#9)

### DIFF
--- a/core/src/kospi_decision_pipeline_core/features/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/features/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .agent_input import build_agent_feature_row
 from .leakage_guard import (
     LeakageError,
+    assert_join_not_from_future,
     assert_no_forbidden_columns,
     assert_not_full_period_normalized,
     assert_trailing_window,
@@ -10,6 +11,7 @@ from .leakage_guard import (
 
 __all__ = [
     "LeakageError",
+    "assert_join_not_from_future",
     "assert_no_forbidden_columns",
     "assert_not_full_period_normalized",
     "assert_trailing_window",

--- a/core/src/kospi_decision_pipeline_core/features/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/features/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .agent_input import build_agent_feature_row
+from .leakage_guard import (
+    LeakageError,
+    assert_no_forbidden_columns,
+    assert_not_full_period_normalized,
+    assert_trailing_window,
+)
+
+__all__ = [
+    "LeakageError",
+    "assert_no_forbidden_columns",
+    "assert_not_full_period_normalized",
+    "assert_trailing_window",
+    "build_agent_feature_row",
+]

--- a/core/src/kospi_decision_pipeline_core/features/agent_input.py
+++ b/core/src/kospi_decision_pipeline_core/features/agent_input.py
@@ -9,7 +9,7 @@ FeatureValue = Union[float, int, str]
 
 
 def build_agent_feature_row(
-    gold_row: Mapping[str, FeatureValue],
+    gold_row: Mapping[str, object],
     allowed_columns: tuple[str, ...],
 ) -> dict[str, FeatureValue]:
     assert_no_forbidden_columns(gold_row.keys())
@@ -19,7 +19,16 @@ def build_agent_feature_row(
     if non_whitelisted_columns:
         raise LeakageError(f"non-whitelisted columns detected: {non_whitelisted_columns}")
 
-    return {column: gold_row[column] for column in allowed_columns if column in gold_row}
+    sanitized_row: dict[str, FeatureValue] = {}
+    for column in allowed_columns:
+        if column not in gold_row:
+            continue
+        value = gold_row[column]
+        if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+            raise LeakageError(f"unsupported feature value for '{column}': {value!r}")
+        sanitized_row[column] = value
+
+    return sanitized_row
 
 
 __all__ = ["FeatureValue", "build_agent_feature_row"]

--- a/core/src/kospi_decision_pipeline_core/features/agent_input.py
+++ b/core/src/kospi_decision_pipeline_core/features/agent_input.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Union
+
+from .leakage_guard import LeakageError, assert_no_forbidden_columns
+
+FeatureValue = Union[float, int, str]
+
+
+def build_agent_feature_row(
+    gold_row: Mapping[str, FeatureValue],
+    allowed_columns: tuple[str, ...],
+) -> dict[str, FeatureValue]:
+    assert_no_forbidden_columns(gold_row.keys())
+    assert_no_forbidden_columns(allowed_columns)
+
+    non_whitelisted_columns = sorted(set(gold_row) - set(allowed_columns))
+    if non_whitelisted_columns:
+        raise LeakageError(f"non-whitelisted columns detected: {non_whitelisted_columns}")
+
+    return {column: gold_row[column] for column in allowed_columns if column in gold_row}
+
+
+__all__ = ["FeatureValue", "build_agent_feature_row"]

--- a/core/src/kospi_decision_pipeline_core/features/leakage_guard.py
+++ b/core/src/kospi_decision_pipeline_core/features/leakage_guard.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+
+
+class LeakageError(ValueError):
+    pass
+
+
+def assert_no_forbidden_columns(
+    columns: Iterable[str],
+    forbidden_prefixes: tuple[str, ...] = ("target_", "future_"),
+) -> None:
+    forbidden = [column for column in columns if column.startswith(forbidden_prefixes)]
+    if forbidden:
+        raise LeakageError(f"forbidden columns detected: {forbidden}")
+
+
+def assert_trailing_window(
+    values: Sequence[float],
+    current_index: int,
+    window_size: int,
+    *,
+    window_bounds: tuple[int, int] | None = None,
+) -> None:
+    if current_index < 0 or current_index >= len(values):
+        raise LeakageError("current_index must reference an existing observation")
+    if window_size <= 0:
+        raise LeakageError("window_size must be positive")
+
+    expected_start = current_index - window_size + 1
+    expected_end = current_index
+    if expected_start < 0:
+        raise LeakageError("trailing window requires sufficient history")
+
+    start_idx, end_idx = (expected_start, expected_end) if window_bounds is None else window_bounds
+    if end_idx > current_index:
+        raise LeakageError("trailing window cannot reference future indices")
+    if start_idx != expected_start or end_idx != expected_end:
+        raise LeakageError(
+            "trailing window must exactly equal "
+            + f"[{expected_start}, {expected_end}] for current_index={current_index}"
+        )
+
+
+def assert_not_full_period_normalized(
+    series_stats: Mapping[str, float],
+    window_stats: Mapping[str, float],
+    tol: float = 1e-9,
+) -> None:
+    missing_keys = sorted(set(series_stats) ^ set(window_stats))
+    if missing_keys:
+        raise LeakageError(f"missing statistic keys: {missing_keys}")
+
+    if all(abs(window_stats[key] - series_stats[key]) <= tol for key in series_stats):
+        raise LeakageError(
+            "full-period normalization detected: window_stats match full-period stats"
+        )
+
+
+__all__ = [
+    "LeakageError",
+    "assert_no_forbidden_columns",
+    "assert_not_full_period_normalized",
+    "assert_trailing_window",
+]

--- a/core/src/kospi_decision_pipeline_core/features/leakage_guard.py
+++ b/core/src/kospi_decision_pipeline_core/features/leakage_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
+from datetime import date
 
 
 class LeakageError(ValueError):
@@ -58,8 +59,16 @@ def assert_not_full_period_normalized(
         )
 
 
+def assert_join_not_from_future(*, joined_as_of: date, decision_date: date) -> None:
+    if joined_as_of > decision_date:
+        raise LeakageError(
+            "future-join walk-forward rows must satisfy joined_as_of <= decision_date"
+        )
+
+
 __all__ = [
     "LeakageError",
+    "assert_join_not_from_future",
     "assert_no_forbidden_columns",
     "assert_not_full_period_normalized",
     "assert_trailing_window",

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,1 +1,7 @@
 from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "core" / "src"))

--- a/core/tests/contract/test_no_future_leakage.py
+++ b/core/tests/contract/test_no_future_leakage.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from datetime import date
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT / "core" / "src"))
+
+from kospi_decision_pipeline_core.features import (
+    LeakageError,
+    assert_no_forbidden_columns,
+    assert_not_full_period_normalized,
+    assert_trailing_window,
+    build_agent_feature_row,
+)
+
+
+@contextmanager
+def _assert_raises(error_type: type[BaseException], match: str) -> Iterator[None]:
+    try:
+        yield
+    except error_type as error:
+        if match not in str(error):
+            raise AssertionError(f"expected {match!r} in {error!r}") from error
+    else:
+        raise AssertionError(f"expected {error_type.__name__} to be raised")
+
+
+def _join_walk_forward_row(
+    *,
+    decision_date: date,
+    joined_as_of: date,
+    row: Mapping[str, float | int | str],
+) -> dict[str, float | int | str]:
+    if joined_as_of > decision_date:
+        raise LeakageError(
+            "future-join walk-forward rows must satisfy joined_as_of <= decision_date"
+        )
+    return dict(row)
+
+
+def test_target_injection_poison_fixture_raises_at_agent_input_boundary() -> None:
+    with _assert_raises(LeakageError, "forbidden columns"):
+        _ = build_agent_feature_row(
+            {
+                "as_of_date": "2024-01-05",
+                "kospi_close": 100.0,
+                "target_next_day_return": 0.01,
+            },
+            allowed_columns=("as_of_date", "kospi_close"),
+        )
+
+
+def test_centered_window_poison_fixture_raises() -> None:
+    with _assert_raises(LeakageError, "trailing"):
+        assert_trailing_window(
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            current_index=3,
+            window_size=3,
+            window_bounds=(2, 4),
+        )
+
+
+def test_non_exact_trailing_window_bounds_raise_even_without_future_index() -> None:
+    with _assert_raises(LeakageError, "exactly equal"):
+        assert_trailing_window(
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            current_index=4,
+            window_size=3,
+            window_bounds=(1, 4),
+        )
+
+
+def test_full_period_normalization_poison_fixture_raises() -> None:
+    with _assert_raises(LeakageError, "full-period"):
+        assert_not_full_period_normalized(
+            series_stats={"mean": 0.15, "std": 0.05},
+            window_stats={"mean": 0.15, "std": 0.05},
+        )
+
+
+def test_future_join_walk_forward_poison_fixture_raises() -> None:
+    with _assert_raises(LeakageError, "joined_as_of <= decision_date"):
+        _ = _join_walk_forward_row(
+            decision_date=date(2024, 1, 5),
+            joined_as_of=date(2024, 1, 8),
+            row={"kospi_close": 100.0},
+        )
+
+
+def test_assert_no_forbidden_columns_accepts_safe_columns_and_custom_prefixes() -> None:
+    assert_no_forbidden_columns(("as_of_date", "kospi_close"))
+
+    with _assert_raises(LeakageError, "forbidden columns"):
+        assert_no_forbidden_columns(
+            ("label_internal",),
+            forbidden_prefixes=("label_",),
+        )
+
+
+def test_assert_trailing_window_accepts_exact_trailing_bounds() -> None:
+    assert_trailing_window(
+        [1.0, 2.0, 3.0, 4.0, 5.0],
+        current_index=4,
+        window_size=3,
+        window_bounds=(2, 4),
+    )
+
+
+def test_assert_trailing_window_rejects_invalid_indices() -> None:
+    for current_index, window_size, match in (
+        (-1, 3, "existing observation"),
+        (5, 3, "existing observation"),
+        (2, 0, "window_size must be positive"),
+        (1, 3, "sufficient history"),
+    ):
+        with _assert_raises(LeakageError, match):
+            assert_trailing_window(
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                current_index=current_index,
+                window_size=window_size,
+            )
+
+
+def test_assert_not_full_period_normalized_tolerates_distinct_window_stats() -> None:
+    assert_not_full_period_normalized(
+        series_stats={"mean": 0.15, "std": 0.05},
+        window_stats={"mean": 0.16, "std": 0.05},
+    )
+
+    with _assert_raises(LeakageError, "missing statistic keys"):
+        assert_not_full_period_normalized(
+            series_stats={"mean": 0.15},
+            window_stats={"mean": 0.15, "std": 0.05},
+        )
+
+
+def test_build_agent_feature_row_sanitizes_allowed_columns_only() -> None:
+    row = build_agent_feature_row(
+        {
+            "as_of_date": "2024-01-05",
+            "kospi_close": 100.0,
+        },
+        allowed_columns=("as_of_date", "kospi_close", "kospi_return_5d"),
+    )
+
+    assert row == {"as_of_date": "2024-01-05", "kospi_close": 100.0}
+
+
+def test_build_agent_feature_row_rejects_non_whitelisted_columns() -> None:
+    with _assert_raises(LeakageError, "non-whitelisted columns"):
+        _ = build_agent_feature_row(
+            {
+                "as_of_date": "2024-01-05",
+                "kospi_close": 100.0,
+                "surprise_feature": 1.0,
+            },
+            allowed_columns=("as_of_date", "kospi_close"),
+        )
+
+
+def test_build_agent_feature_row_rejects_forbidden_allowed_columns() -> None:
+    with _assert_raises(LeakageError, "forbidden columns"):
+        _ = build_agent_feature_row(
+            {"as_of_date": "2024-01-05", "kospi_close": 100.0},
+            allowed_columns=("as_of_date", "future_hint"),
+        )

--- a/core/tests/contract/test_no_future_leakage.py
+++ b/core/tests/contract/test_no_future_leakage.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import contextmanager
 from datetime import date
+from decimal import Decimal
+from typing import cast
 
-from kospi_decision_pipeline_core.features import (
+import kospi_decision_pipeline_core.features as features_package
+import kospi_decision_pipeline_core.features.leakage_guard as leakage_guard_module
+from kospi_decision_pipeline_core.features.agent_input import build_agent_feature_row
+from kospi_decision_pipeline_core.features.leakage_guard import (
     LeakageError,
     assert_no_forbidden_columns,
     assert_not_full_period_normalized,
     assert_trailing_window,
-    build_agent_feature_row,
 )
 
 
@@ -30,14 +34,31 @@ def _join_walk_forward_row(
     joined_as_of: date,
     row: Mapping[str, float | int | str],
 ) -> dict[str, float | int | str]:
-    if joined_as_of > decision_date:
-        raise LeakageError(
-            "future-join walk-forward rows must satisfy joined_as_of <= decision_date"
-        )
+    join_guard = cast(
+        Callable[..., None],
+        getattr(leakage_guard_module, "assert_join_not_from_future"),
+    )
+    join_guard(
+        joined_as_of=joined_as_of,
+        decision_date=decision_date,
+    )
     return dict(row)
 
 
+def _build_untyped_agent_feature_row(
+    gold_row: Mapping[str, object],
+    allowed_columns: tuple[str, ...],
+) -> dict[str, object]:
+    factory = cast(
+        Callable[[Mapping[str, object], tuple[str, ...]], dict[str, object]],
+        build_agent_feature_row,
+    )
+    return factory(gold_row, allowed_columns)
+
+
 def test_target_injection_poison_fixture_raises_at_agent_input_boundary() -> None:
+    assert "build_agent_feature_row" in features_package.__all__
+
     with _assert_raises(LeakageError, "forbidden columns"):
         _ = build_agent_feature_row(
             {
@@ -84,6 +105,16 @@ def test_future_join_walk_forward_poison_fixture_raises() -> None:
             joined_as_of=date(2024, 1, 8),
             row={"kospi_close": 100.0},
         )
+
+
+def test_future_join_walk_forward_accepts_safe_join_dates() -> None:
+    row = _join_walk_forward_row(
+        decision_date=date(2024, 1, 5),
+        joined_as_of=date(2024, 1, 5),
+        row={"kospi_close": 100.0},
+    )
+
+    assert row == {"kospi_close": 100.0}
 
 
 def test_assert_no_forbidden_columns_accepts_safe_columns_and_custom_prefixes() -> None:
@@ -163,3 +194,16 @@ def test_build_agent_feature_row_rejects_forbidden_allowed_columns() -> None:
             {"as_of_date": "2024-01-05", "kospi_close": 100.0},
             allowed_columns=("as_of_date", "future_hint"),
         )
+
+
+def test_build_agent_feature_row_rejects_unsupported_scalar_values() -> None:
+    for column, value in (
+        ("is_holiday", True),
+        ("published_at", date(2024, 1, 5)),
+        ("turnover_krw", Decimal("10.5")),
+    ):
+        with _assert_raises(LeakageError, f"unsupported feature value for '{column}'"):
+            _ = _build_untyped_agent_feature_row(
+                {"as_of_date": "2024-01-05", column: value},
+                allowed_columns=("as_of_date", column),
+            )

--- a/core/tests/contract/test_no_future_leakage.py
+++ b/core/tests/contract/test_no_future_leakage.py
@@ -3,11 +3,6 @@ from __future__ import annotations
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from datetime import date
-import sys
-from pathlib import Path
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-sys.path.insert(0, str(REPO_ROOT / "core" / "src"))
 
 from kospi_decision_pipeline_core.features import (
     LeakageError,


### PR DESCRIPTION
## Summary
- add core leakage guard helpers and a strict `build_agent_feature_row` boundary that rejects forbidden or non-whitelisted columns
- add poison-fixture contract coverage for target injection, centered windows, full-period normalization, and future joins
- verify the new feature package at 100% line+branch coverage with Python 3.12 tests and mypy

Closes #9