### PR TITLE
chore: land §19-24 spec + agents.yaml schema extension

### DIFF
--- a/apps/kr-kospi/config/agents.yaml
+++ b/apps/kr-kospi/config/agents.yaml
@@ -4,6 +4,61 @@ weights:
   flow: 0.25
   valuation: 0.10
   volatility: 0.15
+
 thresholds:
   up: 0.25
   down: -0.25
+
+agents:
+  technical:
+    rule_version: technical@1.0.0
+    thresholds:
+      ma5_gap_up_min: 0.005
+      close_position_up_min: 0.60
+      return_5d_up_min: 0.010
+      ma5_gap_down_max: -0.005
+      close_position_down_max: 0.40
+      return_5d_down_max: -0.010
+
+  domestic_macro:
+    rule_version: domestic_macro@1.0.0
+    thresholds:
+      bok_rate_change_up_max: 0.00
+      usdkrw_return_5d_up_max: 0.010
+      bond_yield_change_30d_up_max: 0.05
+      bok_rate_change_down_min: 0.25
+      usdkrw_return_5d_down_min: 0.020
+      bond_yield_change_30d_down_min: 0.10
+      usdkrw_return_5d_mixed_pos_min: 0.015
+      usdkrw_return_5d_mixed_neg_max: -0.015
+      bond_yield_change_30d_mixed_pos_min: 0.05
+      bond_yield_change_30d_mixed_neg_max: 0.00
+
+  flow:
+    rule_version: flow@1.0.0
+    thresholds:
+      foreign_pct_up_min: 0.010
+      foreign_pct_down_max: -0.010
+      foreign_pct_neutral_abs_max: 0.003
+
+  valuation:
+    rule_version: valuation@1.0.0
+    thresholds:
+      per_percentile_up_max: 0.30
+      pbr_percentile_up_max: 0.30
+      per_percentile_down_min: 0.70
+      pbr_percentile_down_min: 0.70
+      fair_value_center: 0.50
+      fair_value_half_band: 0.10
+
+  volatility:
+    rule_version: volatility@1.0.0
+    thresholds:
+      realized_vol_20d_up_max: 0.18
+      realized_vol_pct_up_max: 0.30
+      atr_14d_up_max: 35.0
+      realized_vol_pct_down_min: 0.80
+      realized_vol_20d_down_min: 0.25
+      atr_14d_down_min: 45.0
+      realized_vol_pct_mid_low: 0.30
+      realized_vol_pct_mid_high: 0.80

--- a/core/src/kospi_decision_pipeline_core/schemas/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/__init__.py
@@ -1,4 +1,10 @@
-from .config import AgentWeightConfig, AgentsConfig, ScenarioConfig, ThresholdsConfig
+from .config import (
+    AgentRuleConfig,
+    AgentWeightConfig,
+    AgentsConfig,
+    ScenarioConfig,
+    ThresholdsConfig,
+)
 from .decisions import (
     AgentVote,
     BacktestRow,
@@ -13,6 +19,7 @@ from .serialization import BACKTEST_CSV_FIELDS, from_jsonl_line, to_csv_row, to_
 
 __all__ = [
     "AgentVote",
+    "AgentRuleConfig",
     "AgentWeightConfig",
     "AgentsConfig",
     "BACKTEST_CSV_FIELDS",

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import isclose
 from pathlib import Path
+import re
 from types import MappingProxyType
 from typing import Final, Literal, TypedDict, cast
 
@@ -45,14 +46,16 @@ class ScenarioConfigDict(TypedDict):
 class _AgentsConfigRequiredDict(TypedDict):
     weights: dict[str, float]
     thresholds: ThresholdsConfigDict
+    agents: dict[str, "AgentRuleConfigDict"]
 
 
-class AgentsConfigDict(_AgentsConfigRequiredDict, total=False):
-    rule_versions: dict[str, str]
+class AgentsConfigDict(_AgentsConfigRequiredDict):
+    pass
 
 
-def _empty_rule_versions() -> Mapping[str, str]:
-    return {}
+class AgentRuleConfigDict(TypedDict):
+    rule_version: str
+    thresholds: dict[str, float]
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,28 +92,48 @@ class ThresholdsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class AgentRuleConfig:
+    rule_version: str
+    thresholds: Mapping[str, float]
+
+    def __post_init__(self) -> None:
+        rule_version = _ensure_string(self.rule_version, context="rule_version")
+        if rule_version == "":
+            raise ValueError("rule_version must be a non-empty string")
+        object.__setattr__(self, "rule_version", rule_version)
+        object.__setattr__(
+            self,
+            "thresholds",
+            MappingProxyType(dict(_normalize_float_mapping(self.thresholds, context="thresholds"))),
+        )
+
+    def to_dict(self) -> AgentRuleConfigDict:
+        return {
+            "rule_version": self.rule_version,
+            "thresholds": dict(self.thresholds),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class AgentsConfig:
     weights: AgentWeightConfig
     thresholds: ThresholdsConfig
-    rule_versions: Mapping[str, str] = field(default_factory=_empty_rule_versions)
+    agents: Mapping[str, AgentRuleConfig] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "rule_versions",
-            MappingProxyType(
-                dict(_normalize_string_mapping(self.rule_versions, context="rule_versions"))
-            ),
-        )
+        agent_configs = _normalize_agent_rules_mapping(self.agents, context="agents")
+        _validate_matching_agent_keys(self.weights.values.keys(), agent_configs.keys())
+        object.__setattr__(self, "agents", MappingProxyType(dict(agent_configs)))
 
     def to_dict(self) -> AgentsConfigDict:
-        result: AgentsConfigDict = {
+        return {
             "weights": self.weights.to_dict(),
             "thresholds": self.thresholds.to_dict(),
+            "agents": {
+                agent_name: agent_config.to_dict()
+                for agent_name, agent_config in self.agents.items()
+            },
         }
-        if self.rule_versions:
-            result["rule_versions"] = dict(self.rule_versions)
-        return result
 
 
 @dataclass(frozen=True, slots=True)
@@ -140,16 +163,21 @@ def load_agents_config(path: Path) -> AgentsConfig:
     payload = _load_yaml_mapping(path)
     weights_payload = _require_mapping(payload, "weights")
     thresholds_payload = _require_mapping(payload, "thresholds")
-    rule_versions_payload: object = payload["rule_versions"] if "rule_versions" in payload else {}
+    if "agents" not in payload:
+        raise ValueError("agents block is required")
+    agents_payload = _require_mapping(payload, "agents")
+
+    weights = AgentWeightConfig(_normalize_float_mapping(weights_payload, context="weights"))
+    _validate_matching_agent_keys(weights.values.keys(), agents_payload.keys())
 
     thresholds = ThresholdsConfig(
         up=_require_float(thresholds_payload, "up"),
         down=_require_float(thresholds_payload, "down"),
     )
     return AgentsConfig(
-        weights=AgentWeightConfig(_normalize_float_mapping(weights_payload, context="weights")),
+        weights=weights,
         thresholds=thresholds,
-        rule_versions=_normalize_string_mapping(rule_versions_payload, context="rule_versions"),
+        agents=_load_agent_rules(agents_payload),
     )
 
 
@@ -235,17 +263,54 @@ def _normalize_float_mapping(value: object, context: str) -> dict[str, float]:
     }
 
 
-def _normalize_string_mapping(value: object, context: str) -> dict[str, str]:
-    payload = _ensure_mapping(value, context=context)
-    return {
-        key: _ensure_string(raw_value, context=f"{context}.{key}")
-        for key, raw_value in payload.items()
-    }
-
-
 def _normalize_string_sequence(value: object, context: str) -> tuple[str, ...]:
     sequence = _ensure_sequence(value, context=context)
     return tuple(_ensure_string(item, context=f"{context}[]") for item in sequence)
+
+
+def _normalize_agent_rules_mapping(value: object, context: str) -> dict[str, AgentRuleConfig]:
+    payload = _ensure_mapping(value, context=context)
+    return {
+        agent_name: _ensure_agent_rule_config(agent_rule_config, context=f"{context}.{agent_name}")
+        for agent_name, agent_rule_config in payload.items()
+    }
+
+
+def _ensure_agent_rule_config(value: object, context: str) -> AgentRuleConfig:
+    if not isinstance(value, AgentRuleConfig):
+        raise ValueError(f"{context} must be an AgentRuleConfig")
+    return value
+
+
+def _load_agent_rules(payload: Mapping[str, object]) -> dict[str, AgentRuleConfig]:
+    _validate_known_agent_ids(payload.keys(), context="agents")
+    rule_configs: dict[str, AgentRuleConfig] = {}
+    for agent_name, agent_payload in payload.items():
+        agent_mapping = _ensure_mapping(agent_payload, context=f"agents.{agent_name}")
+        rule_version = _require_string(agent_mapping, "rule_version")
+        _validate_rule_version(agent_name, rule_version)
+        thresholds = _require_mapping(agent_mapping, "thresholds")
+        rule_configs[agent_name] = AgentRuleConfig(
+            rule_version=rule_version,
+            thresholds=_normalize_float_mapping(
+                thresholds, context=f"agents.{agent_name}.thresholds"
+            ),
+        )
+    return rule_configs
+
+
+def _validate_matching_agent_keys(
+    weights_agent_ids: Iterable[str], agents_agent_ids: Iterable[str]
+) -> None:
+    weights_keys = frozenset(weights_agent_ids)
+    agents_keys = frozenset(agents_agent_ids)
+    if weights_keys != agents_keys:
+        raise ValueError("weights and agents must contain identical keys")
+
+
+def _validate_rule_version(agent_name: str, rule_version: str) -> None:
+    if not re.fullmatch(rf"{re.escape(agent_name)}@\d+\.\d+\.\d+", rule_version):
+        raise ValueError(f"agents.{agent_name}.rule_version must match {agent_name}@<semver>")
 
 
 def _validate_known_agent_ids(agent_ids: Iterable[str], context: str) -> None:

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -19,6 +19,15 @@ AgentId = Literal[
     "volatility",
     "decision",
 ]
+RULE_AGENT_IDS: Final[frozenset[str]] = frozenset(
+    {
+        "technical",
+        "domestic_macro",
+        "flow",
+        "valuation",
+        "volatility",
+    }
+)
 KNOWN_AGENT_IDS: Final[frozenset[str]] = frozenset(
     {
         "technical",
@@ -27,6 +36,63 @@ KNOWN_AGENT_IDS: Final[frozenset[str]] = frozenset(
         "valuation",
         "volatility",
         "decision",
+    }
+)
+REQUIRED_AGENT_THRESHOLD_KEYS: Final[Mapping[str, frozenset[str]]] = MappingProxyType(
+    {
+        "technical@1.0.0": frozenset(
+            {
+                "ma5_gap_up_min",
+                "close_position_up_min",
+                "return_5d_up_min",
+                "ma5_gap_down_max",
+                "close_position_down_max",
+                "return_5d_down_max",
+            }
+        ),
+        "domestic_macro@1.0.0": frozenset(
+            {
+                "bok_rate_change_up_max",
+                "usdkrw_return_5d_up_max",
+                "bond_yield_change_30d_up_max",
+                "bok_rate_change_down_min",
+                "usdkrw_return_5d_down_min",
+                "bond_yield_change_30d_down_min",
+                "usdkrw_return_5d_mixed_pos_min",
+                "usdkrw_return_5d_mixed_neg_max",
+                "bond_yield_change_30d_mixed_pos_min",
+                "bond_yield_change_30d_mixed_neg_max",
+            }
+        ),
+        "flow@1.0.0": frozenset(
+            {
+                "foreign_pct_up_min",
+                "foreign_pct_down_max",
+                "foreign_pct_neutral_abs_max",
+            }
+        ),
+        "valuation@1.0.0": frozenset(
+            {
+                "per_percentile_up_max",
+                "pbr_percentile_up_max",
+                "per_percentile_down_min",
+                "pbr_percentile_down_min",
+                "fair_value_center",
+                "fair_value_half_band",
+            }
+        ),
+        "volatility@1.0.0": frozenset(
+            {
+                "realized_vol_20d_up_max",
+                "realized_vol_pct_up_max",
+                "atr_14d_up_max",
+                "realized_vol_pct_down_min",
+                "realized_vol_20d_down_min",
+                "atr_14d_down_min",
+                "realized_vol_pct_mid_low",
+                "realized_vol_pct_mid_high",
+            }
+        ),
     }
 )
 WEIGHT_TOLERANCE: Final[float] = 1e-9
@@ -64,7 +130,7 @@ class AgentWeightConfig:
 
     def __post_init__(self) -> None:
         weights = _normalize_float_mapping(self.values, context="weights")
-        _validate_known_agent_ids(weights.keys(), context="weights")
+        _validate_rule_agent_ids(weights.keys(), context="weights")
         total = sum(weights.values())
         if not isclose(total, 1.0, rel_tol=0.0, abs_tol=WEIGHT_TOLERANCE):
             raise ValueError("weights must sum to 1.0 ± 1e-9")
@@ -283,13 +349,16 @@ def _ensure_agent_rule_config(value: object, context: str) -> AgentRuleConfig:
 
 
 def _load_agent_rules(payload: Mapping[str, object]) -> dict[str, AgentRuleConfig]:
-    _validate_known_agent_ids(payload.keys(), context="agents")
+    _validate_rule_agent_ids(payload.keys(), context="agents")
     rule_configs: dict[str, AgentRuleConfig] = {}
     for agent_name, agent_payload in payload.items():
         agent_mapping = _ensure_mapping(agent_payload, context=f"agents.{agent_name}")
         rule_version = _require_string(agent_mapping, "rule_version")
         _validate_rule_version(agent_name, rule_version)
         thresholds = _require_mapping(agent_mapping, "thresholds")
+        _validate_threshold_keys(
+            rule_version, thresholds.keys(), context=f"agents.{agent_name}.thresholds"
+        )
         rule_configs[agent_name] = AgentRuleConfig(
             rule_version=rule_version,
             thresholds=_normalize_float_mapping(
@@ -311,6 +380,28 @@ def _validate_matching_agent_keys(
 def _validate_rule_version(agent_name: str, rule_version: str) -> None:
     if not re.fullmatch(rf"{re.escape(agent_name)}@\d+\.\d+\.\d+", rule_version):
         raise ValueError(f"agents.{agent_name}.rule_version must match {agent_name}@<semver>")
+
+
+def _validate_threshold_keys(
+    rule_version: str, threshold_keys: Iterable[str], context: str
+) -> None:
+    expected_keys = REQUIRED_AGENT_THRESHOLD_KEYS[rule_version]
+    actual_keys = frozenset(threshold_keys)
+    if actual_keys != expected_keys:
+        missing_keys = sorted(expected_keys - actual_keys)
+        unknown_keys = sorted(actual_keys - expected_keys)
+        details: list[str] = []
+        if missing_keys:
+            details.append(f"missing keys: {', '.join(missing_keys)}")
+        if unknown_keys:
+            details.append(f"unknown keys: {', '.join(unknown_keys)}")
+        raise ValueError(f"{context} must contain exactly the required keys ({'; '.join(details)})")
+
+
+def _validate_rule_agent_ids(agent_ids: Iterable[str], context: str) -> None:
+    unknown_agent_ids = sorted(agent_id for agent_id in agent_ids if agent_id not in RULE_AGENT_IDS)
+    if unknown_agent_ids:
+        raise ValueError(f"unknown agent ids in {context}: {', '.join(unknown_agent_ids)}")
 
 
 def _validate_known_agent_ids(agent_ids: Iterable[str], context: str) -> None:

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from math import isclose
 from pathlib import Path
-import re
 from types import MappingProxyType
 from typing import Final, Literal, TypedDict, cast
 
@@ -93,6 +92,15 @@ REQUIRED_AGENT_THRESHOLD_KEYS: Final[Mapping[str, frozenset[str]]] = MappingProx
                 "realized_vol_pct_mid_high",
             }
         ),
+    }
+)
+EXPECTED_RULE_VERSIONS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "technical": "technical@1.0.0",
+        "domestic_macro": "domestic_macro@1.0.0",
+        "flow": "flow@1.0.0",
+        "valuation": "valuation@1.0.0",
+        "volatility": "volatility@1.0.0",
     }
 )
 WEIGHT_TOLERANCE: Final[float] = 1e-9
@@ -378,8 +386,9 @@ def _validate_matching_agent_keys(
 
 
 def _validate_rule_version(agent_name: str, rule_version: str) -> None:
-    if not re.fullmatch(rf"{re.escape(agent_name)}@\d+\.\d+\.\d+", rule_version):
-        raise ValueError(f"agents.{agent_name}.rule_version must match {agent_name}@<semver>")
+    expected_rule_version = EXPECTED_RULE_VERSIONS[agent_name]
+    if rule_version != expected_rule_version:
+        raise ValueError(f"agents.{agent_name}.rule_version must equal {expected_rule_version}")
 
 
 def _validate_threshold_keys(

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -381,6 +381,18 @@ def test_load_agents_config_rejects_invalid_rule_version_format(tmp_path: Path) 
         _ = load_agents_config(config_path)
 
 
+def test_load_agents_config_rejects_unsupported_rule_version_semver(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    agents = cast(dict[str, dict[str, object]], payload["agents"])
+    agents["technical"]["rule_version"] = "technical@1.0.1"
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(
+        ValueError, match="agents.technical.rule_version must equal technical@1.0.0"
+    ):
+        _ = load_agents_config(config_path)
+
+
 def test_load_agents_config_rejects_non_numeric_agent_threshold_value(tmp_path: Path) -> None:
     payload = valid_agents_payload()
     agents = cast(dict[str, dict[str, object]], payload["agents"])

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -8,6 +8,7 @@ import pytest
 import yaml
 
 from kospi_decision_pipeline_core.schemas.config import (
+    AgentRuleConfig,
     AgentWeightConfig,
     AgentsConfig,
     ScenarioConfig,
@@ -27,6 +28,90 @@ def write_yaml(path: Path, content: object) -> Path:
     return path
 
 
+def valid_agents_payload() -> dict[str, object]:
+    return {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+        "agents": {
+            "technical": {
+                "rule_version": "technical@1.0.0",
+                "thresholds": {
+                    "ma5_gap_up_min": 0.005,
+                    "close_position_up_min": 0.60,
+                    "return_5d_up_min": 0.010,
+                    "ma5_gap_down_max": -0.005,
+                    "close_position_down_max": 0.40,
+                    "return_5d_down_max": -0.010,
+                },
+            },
+            "domestic_macro": {
+                "rule_version": "domestic_macro@1.0.0",
+                "thresholds": {
+                    "bok_rate_change_up_max": 0.00,
+                    "usdkrw_return_5d_up_max": 0.010,
+                    "bond_yield_change_30d_up_max": 0.05,
+                    "bok_rate_change_down_min": 0.25,
+                    "usdkrw_return_5d_down_min": 0.020,
+                    "bond_yield_change_30d_down_min": 0.10,
+                    "usdkrw_return_5d_mixed_pos_min": 0.015,
+                    "usdkrw_return_5d_mixed_neg_max": -0.015,
+                    "bond_yield_change_30d_mixed_pos_min": 0.05,
+                    "bond_yield_change_30d_mixed_neg_max": 0.00,
+                },
+            },
+            "flow": {
+                "rule_version": "flow@1.0.0",
+                "thresholds": {
+                    "foreign_pct_up_min": 0.010,
+                    "foreign_pct_down_max": -0.010,
+                    "foreign_pct_neutral_abs_max": 0.003,
+                },
+            },
+            "valuation": {
+                "rule_version": "valuation@1.0.0",
+                "thresholds": {
+                    "per_percentile_up_max": 0.30,
+                    "pbr_percentile_up_max": 0.30,
+                    "per_percentile_down_min": 0.70,
+                    "pbr_percentile_down_min": 0.70,
+                    "fair_value_center": 0.50,
+                    "fair_value_half_band": 0.10,
+                },
+            },
+            "volatility": {
+                "rule_version": "volatility@1.0.0",
+                "thresholds": {
+                    "realized_vol_20d_up_max": 0.18,
+                    "realized_vol_pct_up_max": 0.30,
+                    "atr_14d_up_max": 35.0,
+                    "realized_vol_pct_down_min": 0.80,
+                    "realized_vol_20d_down_min": 0.25,
+                    "atr_14d_down_min": 45.0,
+                    "realized_vol_pct_mid_low": 0.30,
+                    "realized_vol_pct_mid_high": 0.80,
+                },
+            },
+        },
+    }
+
+
+def valid_agent_rules() -> dict[str, AgentRuleConfig]:
+    payload = cast(dict[str, dict[str, object]], valid_agents_payload()["agents"])
+    return {
+        agent_name: AgentRuleConfig(
+            rule_version=cast(str, agent_payload["rule_version"]),
+            thresholds=cast(dict[str, float], agent_payload["thresholds"]),
+        )
+        for agent_name, agent_payload in payload.items()
+    }
+
+
 def test_config_dataclasses_construct_and_serialize() -> None:
     weights = AgentWeightConfig(
         {
@@ -41,7 +126,7 @@ def test_config_dataclasses_construct_and_serialize() -> None:
     config = AgentsConfig(
         weights=weights,
         thresholds=thresholds,
-        rule_versions={"decision": "v1"},
+        agents=valid_agent_rules(),
     )
     scenario = ScenarioConfig(
         scenario_id="kospi.next_day",
@@ -65,7 +150,7 @@ def test_config_dataclasses_construct_and_serialize() -> None:
             "volatility": 0.15,
         },
         "thresholds": {"up": 0.25, "down": -0.25},
-        "rule_versions": {"decision": "v1"},
+        "agents": cast(dict[str, object], valid_agents_payload()["agents"]),
     }
     assert scenario.to_dict() == {
         "scenario_id": "kospi.next_day",
@@ -81,31 +166,47 @@ def test_config_dataclasses_construct_and_serialize() -> None:
     }
 
 
-def test_agents_config_defaults_rule_versions_to_empty_mapping() -> None:
-    config = AgentsConfig(
-        weights=AgentWeightConfig(
-            {
-                "technical": 0.30,
-                "domestic_macro": 0.20,
-                "flow": 0.25,
-                "valuation": 0.10,
-                "volatility": 0.15,
-            }
-        ),
-        thresholds=ThresholdsConfig(up=0.25, down=-0.25),
+def test_agent_rule_config_thresholds_are_immutable() -> None:
+    rule_config = AgentRuleConfig(
+        rule_version="technical@1.0.0",
+        thresholds={"ma5_gap_up_min": 0.005},
     )
 
-    assert config.rule_versions == {}
-    assert config.to_dict() == {
-        "weights": {
-            "technical": 0.30,
-            "domestic_macro": 0.20,
-            "flow": 0.25,
-            "valuation": 0.10,
-            "volatility": 0.15,
-        },
-        "thresholds": {"up": 0.25, "down": -0.25},
-    }
+    with pytest.raises(TypeError):
+        cast(dict[str, float], rule_config.thresholds)["ma5_gap_up_min"] = 0.010
+
+
+def test_agent_rule_config_rejects_empty_rule_version() -> None:
+    with pytest.raises(ValueError, match="non-empty string"):
+        _ = AgentRuleConfig(rule_version="", thresholds={"ma5_gap_up_min": 0.005})
+
+
+def test_agents_config_rejects_mismatched_weight_and_agent_names_when_constructed_directly() -> (
+    None
+):
+    with pytest.raises(ValueError, match="weights and agents must contain identical keys"):
+        _ = AgentsConfig(
+            weights=AgentWeightConfig({"technical": 0.60, "flow": 0.40}),
+            thresholds=ThresholdsConfig(up=0.25, down=-0.25),
+            agents={
+                "technical": AgentRuleConfig(
+                    rule_version="technical@1.0.0",
+                    thresholds={"ma5_gap_up_min": 0.005},
+                )
+            },
+        )
+
+
+def test_agents_config_rejects_non_agent_rule_config_entries_when_constructed_directly() -> None:
+    with pytest.raises(ValueError, match="agents.technical must be an AgentRuleConfig"):
+        _ = AgentsConfig(
+            weights=AgentWeightConfig({"technical": 1.0}),
+            thresholds=ThresholdsConfig(up=0.25, down=-0.25),
+            agents=cast(
+                dict[str, AgentRuleConfig],
+                {"technical": cast(AgentRuleConfig, object())},
+            ),
+        )
 
 
 def test_agent_weight_config_rejects_sum_not_equal_to_one() -> None:
@@ -142,17 +243,17 @@ def test_scenario_config_rejects_non_string_scenario_id_when_constructed_directl
 
 
 def test_load_agents_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
-    config_path = write_yaml(
-        tmp_path / "agents.yaml",
-        {
-            "weights": {
-                "technical": 0.50,
-                "flow": 0.25,
-                "mystery": 0.25,
-            },
-            "thresholds": {"up": 0.25, "down": -0.25},
-        },
-    )
+    payload = valid_agents_payload()
+    weights = cast(dict[str, float], payload["weights"])
+    agents = cast(dict[str, object], payload["agents"])
+    weights["mystery"] = 0.15
+    weights["technical"] = 0.15
+    del agents["technical"]
+    agents["mystery"] = {
+        "rule_version": "mystery@1.0.0",
+        "thresholds": {"mystery_threshold": 1.0},
+    }
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="unknown agent"):
         _ = load_agents_config(config_path)
@@ -194,42 +295,93 @@ def test_load_agents_config_rejects_non_mapping_root(tmp_path: Path) -> None:
 
 
 def test_load_agents_config_rejects_non_string_weight_keys(tmp_path: Path) -> None:
-    config_path = write_yaml(
-        tmp_path / "agents.yaml",
-        {
-            "weights": {1: 0.50, "flow": 0.50},
-            "thresholds": {"up": 0.25, "down": -0.25},
-        },
-    )
+    payload = valid_agents_payload()
+    payload["weights"] = {1: 0.50, "flow": 0.50}
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="keys must be strings"):
         _ = load_agents_config(config_path)
 
 
 def test_load_agents_config_rejects_missing_threshold_value(tmp_path: Path) -> None:
-    config_path = write_yaml(
-        tmp_path / "agents.yaml",
-        {
-            "weights": {"technical": 0.50, "flow": 0.50},
-            "thresholds": {"down": -0.25},
-        },
-    )
+    payload = valid_agents_payload()
+    payload["thresholds"] = {"down": -0.25}
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="up"):
         _ = load_agents_config(config_path)
 
 
 def test_load_agents_config_rejects_non_float_threshold_value(tmp_path: Path) -> None:
-    config_path = write_yaml(
-        tmp_path / "agents.yaml",
-        {
-            "weights": {"technical": 0.50, "flow": 0.50},
-            "thresholds": {"up": "high", "down": -0.25},
-        },
-    )
+    payload = valid_agents_payload()
+    payload["thresholds"] = {"up": "high", "down": -0.25}
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="up must be a float"):
         _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_parses_agents_block(tmp_path: Path) -> None:
+    config_path = write_yaml(tmp_path / "agents.yaml", valid_agents_payload())
+
+    loaded = load_agents_config(config_path)
+
+    assert loaded.thresholds.to_dict() == {"up": 0.25, "down": -0.25}
+    assert loaded.agents["technical"].rule_version == "technical@1.0.0"
+    assert loaded.agents["technical"].thresholds["ma5_gap_up_min"] == 0.005
+    assert loaded.to_dict() == cast(dict[str, object], valid_agents_payload())
+
+
+def test_load_agents_config_rejects_missing_agents_block(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    del payload["agents"]
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="^agents block is required$"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_mismatched_agent_names_between_weights_and_agents(
+    tmp_path: Path,
+) -> None:
+    payload = valid_agents_payload()
+    weights = cast(dict[str, float], payload["weights"])
+    _ = weights.pop("volatility")
+    weights["decision"] = 0.15
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="weights and agents must contain identical keys"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_invalid_rule_version_format(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    agents = cast(dict[str, dict[str, object]], payload["agents"])
+    agents["technical"]["rule_version"] = "flow@1.0.0"
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="rule_version"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_non_numeric_agent_threshold_value(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    agents = cast(dict[str, dict[str, object]], payload["agents"])
+    thresholds = cast(dict[str, object], agents["technical"]["thresholds"])
+    thresholds["ma5_gap_up_min"] = "high"
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="agents.technical.thresholds.ma5_gap_up_min"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_exposes_immutable_agent_threshold_mapping(tmp_path: Path) -> None:
+    config_path = write_yaml(tmp_path / "agents.yaml", valid_agents_payload())
+
+    loaded = load_agents_config(config_path)
+
+    with pytest.raises(TypeError):
+        cast(dict[str, float], loaded.agents["technical"].thresholds)["ma5_gap_up_min"] = 0.010
 
 
 def test_load_scenario_config_rejects_non_string_scenario_id(tmp_path: Path) -> None:
@@ -278,7 +430,7 @@ def test_load_scenario_config_rejects_non_sequence_agents(tmp_path: Path) -> Non
     [
         (
             "agents.yaml",
-            {"thresholds": {"up": 0.25, "down": -0.25}},
+            {"thresholds": {"up": 0.25, "down": -0.25}, "agents": {}},
             load_agents_config,
             "weights",
         ),
@@ -330,6 +482,7 @@ def test_default_config_files_load_successfully() -> None:
             "volatility": 0.15,
         },
         "thresholds": {"up": 0.25, "down": -0.25},
+        "agents": cast(dict[str, object], valid_agents_payload()["agents"]),
     }
     assert scenario_config.to_dict() == {
         "scenario_id": "kospi.next_day",

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -259,6 +259,23 @@ def test_load_agents_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
         _ = load_agents_config(config_path)
 
 
+def test_load_agents_config_rejects_decision_agent_in_weights_and_agents(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    weights = cast(dict[str, float], payload["weights"])
+    agents = cast(dict[str, object], payload["agents"])
+    _ = weights.pop("volatility")
+    weights["decision"] = 0.15
+    _ = agents.pop("volatility")
+    agents["decision"] = {
+        "rule_version": "decision@1.0.0",
+        "thresholds": {"aggregate_min_score": 0.25},
+    }
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="unknown agent ids in weights: decision"):
+        _ = load_agents_config(config_path)
+
+
 def test_load_scenario_config_rejects_invalid_horizon(tmp_path: Path) -> None:
     config_path = write_yaml(
         tmp_path / "scenario.yaml",
@@ -347,7 +364,7 @@ def test_load_agents_config_rejects_mismatched_agent_names_between_weights_and_a
     payload = valid_agents_payload()
     weights = cast(dict[str, float], payload["weights"])
     _ = weights.pop("volatility")
-    weights["decision"] = 0.15
+    weights["technical"] = 0.45
     config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="weights and agents must contain identical keys"):
@@ -372,6 +389,28 @@ def test_load_agents_config_rejects_non_numeric_agent_threshold_value(tmp_path: 
     config_path = write_yaml(tmp_path / "agents.yaml", payload)
 
     with pytest.raises(ValueError, match="agents.technical.thresholds.ma5_gap_up_min"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_missing_required_agent_threshold_key(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    agents = cast(dict[str, dict[str, object]], payload["agents"])
+    thresholds = cast(dict[str, object], agents["technical"]["thresholds"])
+    del thresholds["return_5d_down_max"]
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="missing keys: return_5d_down_max"):
+        _ = load_agents_config(config_path)
+
+
+def test_load_agents_config_rejects_unknown_agent_threshold_key(tmp_path: Path) -> None:
+    payload = valid_agents_payload()
+    agents = cast(dict[str, dict[str, object]], payload["agents"])
+    thresholds = cast(dict[str, object], agents["technical"]["thresholds"])
+    thresholds["surprise_threshold"] = 0.123
+    config_path = write_yaml(tmp_path / "agents.yaml", payload)
+
+    with pytest.raises(ValueError, match="unknown keys: surprise_threshold"):
         _ = load_agents_config(config_path)
 
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,3 +1,595 @@
-# Specification Placeholder
+# KOSPI Decision Pipeline Specification
 
-Project specification will be finalized in later issues.
+## §19-§23 Common execution contract
+
+The following rules are binding for `technical@1.0.0`, `domestic_macro@1.0.0`, `flow@1.0.0`, `valuation@1.0.0`, and `volatility@1.0.0`.
+
+- `row` means the current `AgentFeatureRow`.
+- Branches are evaluated top-to-bottom. The first matching branch wins.
+- Each branch emits a **fixed** `label` and **fixed** `score`. Scores are not interpolated from distance-to-threshold.
+- `label=up` MUST have `score > 0`; `label=down` MUST have `score < 0`; `label=skip` MUST have `score = 0.0`.
+- If any feature referenced by a branch is `null`, `NaN`, or non-finite, that branch is treated as **not matched**.
+- If no non-fallback branch matches, the agent MUST emit the fallback branch: `label=skip`, `score=0.0`.
+- Each agent MUST read **only** its declared whitelist. Any attempted access outside the whitelist MUST raise an input-validation error.
+- Numeric conventions:
+  - returns and percentiles use decimal form (`0.010 = 1.0%`)
+  - `bok_base_rate_change_30d` and `kr_bond_yield_change_30d` use absolute percentage points (`0.25 = 25bp`)
+  - `kospi_atr_14d` uses KOSPI index points
+- The truth tables below are normative RED-test fixtures. Implementations MUST produce the stated branch, `label`, and `score`.
+
+## §19. TechnicalAgent
+
+**rule_version:** `technical@1.0.0`
+
+**Inputs whitelist (and only these):**
+- `kospi_return_1d`
+- `kospi_return_5d`
+- `kospi_ma5_gap`
+- `kospi_close_position`
+
+**Ordered rule logic**
+
+1. **Bullish short-term trend continuation**
+   - Predicate:
+     - `row.kospi_ma5_gap >= agents.technical.thresholds.ma5_gap_up_min` (`0.005`)
+     - `row.kospi_close_position >= agents.technical.thresholds.close_position_up_min` (`0.60`)
+     - `row.kospi_return_5d >= agents.technical.thresholds.return_5d_up_min` (`0.010`)
+   - Emit:
+     - `label: up`
+     - `score: 0.70`
+   - Evidence:
+     - `{ name: "kospi_ma5_gap", value: row.kospi_ma5_gap, source: "computed" }`
+     - `{ name: "kospi_close_position", value: row.kospi_close_position, source: "computed" }`
+     - `{ name: "kospi_return_5d", value: row.kospi_return_5d, source: "computed" }`
+     - `{ name: "kospi_return_1d", value: row.kospi_return_1d, source: "computed" }`
+
+2. **Bearish short-term trend continuation**
+   - Predicate:
+     - `row.kospi_ma5_gap <= agents.technical.thresholds.ma5_gap_down_max` (`-0.005`)
+     - `row.kospi_close_position <= agents.technical.thresholds.close_position_down_max` (`0.40`)
+     - `row.kospi_return_5d <= agents.technical.thresholds.return_5d_down_max` (`-0.010`)
+   - Emit:
+     - `label: down`
+     - `score: -0.70`
+   - Evidence:
+     - `{ name: "kospi_ma5_gap", value: row.kospi_ma5_gap, source: "computed" }`
+     - `{ name: "kospi_close_position", value: row.kospi_close_position, source: "computed" }`
+     - `{ name: "kospi_return_5d", value: row.kospi_return_5d, source: "computed" }`
+     - `{ name: "kospi_return_1d", value: row.kospi_return_1d, source: "computed" }`
+
+3. **Mixed momentum abstain**
+   - Predicate:
+     - `(row.kospi_return_1d > 0.0 AND row.kospi_return_5d < 0.0) OR (row.kospi_return_1d < 0.0 AND row.kospi_return_5d > 0.0)`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_ma5_gap", value: row.kospi_ma5_gap, source: "computed" }`
+     - `{ name: "kospi_close_position", value: row.kospi_close_position, source: "computed" }`
+     - `{ name: "kospi_return_5d", value: row.kospi_return_5d, source: "computed" }`
+     - `{ name: "kospi_return_1d", value: row.kospi_return_1d, source: "computed" }`
+
+4. **Fallback**
+   - Predicate: `else`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_ma5_gap", value: row.kospi_ma5_gap, source: "computed" }`
+     - `{ name: "kospi_close_position", value: row.kospi_close_position, source: "computed" }`
+     - `{ name: "kospi_return_5d", value: row.kospi_return_5d, source: "computed" }`
+     - `{ name: "kospi_return_1d", value: row.kospi_return_1d, source: "computed" }`
+
+**Threshold rationale:** use coarse trend filters only. A 0.5% MA gap and 1.0% 5-day move are large enough to filter routine daily noise without being curve-fit.
+
+**Truth table**
+
+| Row | kospi_return_1d | kospi_return_5d | kospi_ma5_gap | kospi_close_position | Expected branch | label | score |
+|---|---:|---:|---:|---:|---|---|---:|
+| T1 | 0.004 | 0.018 | 0.008 | 0.72 | Bullish short-term trend continuation | up | 0.70 |
+| T2 | -0.006 | -0.015 | -0.009 | 0.28 | Bearish short-term trend continuation | down | -0.70 |
+| T3 | 0.007 | -0.008 | 0.001 | 0.55 | Mixed momentum abstain | skip | 0.0 |
+| T4 | 0.002 | 0.006 | 0.002 | 0.54 | Fallback | skip | 0.0 |
+
+---
+
+## §20. DomesticMacroAgent
+
+**rule_version:** `domestic_macro@1.0.0`
+
+**Inputs whitelist (and only these):**
+- `bok_base_rate_change_30d`
+- `usd_krw_return_5d`
+- `kr_bond_yield_change_30d`
+
+**Ordered rule logic**
+
+1. **Supportive domestic macro**
+   - Predicate:
+     - `row.bok_base_rate_change_30d <= agents.domestic_macro.thresholds.bok_rate_change_up_max` (`0.00`)
+     - `row.usd_krw_return_5d <= agents.domestic_macro.thresholds.usdkrw_return_5d_up_max` (`0.010`)
+     - `row.kr_bond_yield_change_30d <= agents.domestic_macro.thresholds.bond_yield_change_30d_up_max` (`0.05`)
+   - Emit:
+     - `label: up`
+     - `score: 0.60`
+   - Evidence:
+     - `{ name: "bok_base_rate_change_30d", value: row.bok_base_rate_change_30d, source: "computed" }`
+     - `{ name: "usd_krw_return_5d", value: row.usd_krw_return_5d, source: "computed" }`
+     - `{ name: "kr_bond_yield_change_30d", value: row.kr_bond_yield_change_30d, source: "computed" }`
+
+2. **Risk-off domestic macro**
+   - Predicate:
+     - `row.bok_base_rate_change_30d >= agents.domestic_macro.thresholds.bok_rate_change_down_min` (`0.25`)  
+       **OR**
+     - `(row.usd_krw_return_5d >= agents.domestic_macro.thresholds.usdkrw_return_5d_down_min` (`0.020`)  
+       `AND row.kr_bond_yield_change_30d >= agents.domestic_macro.thresholds.bond_yield_change_30d_down_min` (`0.10`))`
+   - Emit:
+     - `label: down`
+     - `score: -0.70`
+   - Evidence:
+     - `{ name: "bok_base_rate_change_30d", value: row.bok_base_rate_change_30d, source: "computed" }`
+     - `{ name: "usd_krw_return_5d", value: row.usd_krw_return_5d, source: "computed" }`
+     - `{ name: "kr_bond_yield_change_30d", value: row.kr_bond_yield_change_30d, source: "computed" }`
+
+3. **Conflicting macro signals abstain**
+   - Predicate:
+     - `(row.usd_krw_return_5d >= agents.domestic_macro.thresholds.usdkrw_return_5d_mixed_pos_min` (`0.015`) AND row.kr_bond_yield_change_30d < agents.domestic_macro.thresholds.bond_yield_change_30d_mixed_neg_max` (`0.00`))`  
+       **OR**
+     - `(row.usd_krw_return_5d <= agents.domestic_macro.thresholds.usdkrw_return_5d_mixed_neg_max` (`-0.015`) AND row.kr_bond_yield_change_30d > agents.domestic_macro.thresholds.bond_yield_change_30d_mixed_pos_min` (`0.05`))`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "bok_base_rate_change_30d", value: row.bok_base_rate_change_30d, source: "computed" }`
+     - `{ name: "usd_krw_return_5d", value: row.usd_krw_return_5d, source: "computed" }`
+     - `{ name: "kr_bond_yield_change_30d", value: row.kr_bond_yield_change_30d, source: "computed" }`
+
+4. **Fallback**
+   - Predicate: `else`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "bok_base_rate_change_30d", value: row.bok_base_rate_change_30d, source: "computed" }`
+     - `{ name: "usd_krw_return_5d", value: row.usd_krw_return_5d, source: "computed" }`
+     - `{ name: "kr_bond_yield_change_30d", value: row.kr_bond_yield_change_30d, source: "computed" }`
+
+**Threshold rationale:** only large, macro-significant moves should matter on a one-day decision pipeline. A 25bp policy move and 1.5%-2.0% 5-day FX move are defensible “regime” thresholds rather than day-to-day noise.
+
+**Truth table**
+
+| Row | bok_base_rate_change_30d | usd_krw_return_5d | kr_bond_yield_change_30d | Expected branch | label | score |
+|---|---:|---:|---:|---|---|---:|
+| M1 | 0.00 | -0.004 | -0.02 | Supportive domestic macro | up | 0.60 |
+| M2 | 0.25 | 0.005 | 0.01 | Risk-off domestic macro | down | -0.70 |
+| M3 | 0.00 | 0.018 | -0.03 | Conflicting macro signals abstain | skip | 0.0 |
+| M4 | 0.00 | 0.008 | 0.07 | Fallback | skip | 0.0 |
+
+---
+
+## §21. FlowAgent
+
+**rule_version:** `flow@1.0.0`
+
+**Inputs whitelist (and only these):**
+- `foreign_net_buy_krw_5d_sum`
+- `institution_net_buy_krw_5d_sum`
+- `individual_net_buy_krw_5d_sum`
+- `foreign_net_buy_5d_pct_of_turnover`
+
+**Ordered rule logic**
+
+1. **Aligned institutional demand**
+   - Predicate:
+     - `row.foreign_net_buy_krw_5d_sum > 0.0`
+     - `row.institution_net_buy_krw_5d_sum >= 0.0`
+     - `row.individual_net_buy_krw_5d_sum <= 0.0`
+     - `row.foreign_net_buy_5d_pct_of_turnover >= agents.flow.thresholds.foreign_pct_up_min` (`0.010`)
+   - Emit:
+     - `label: up`
+     - `score: 0.80`
+   - Evidence:
+     - `{ name: "foreign_net_buy_krw_5d_sum", value: row.foreign_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "institution_net_buy_krw_5d_sum", value: row.institution_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "individual_net_buy_krw_5d_sum", value: row.individual_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "foreign_net_buy_5d_pct_of_turnover", value: row.foreign_net_buy_5d_pct_of_turnover, source: "computed" }`
+
+2. **Aligned institutional distribution**
+   - Predicate:
+     - `row.foreign_net_buy_krw_5d_sum < 0.0`
+     - `row.institution_net_buy_krw_5d_sum <= 0.0`
+     - `row.individual_net_buy_krw_5d_sum >= 0.0`
+     - `row.foreign_net_buy_5d_pct_of_turnover <= agents.flow.thresholds.foreign_pct_down_max` (`-0.010`)
+   - Emit:
+     - `label: down`
+     - `score: -0.80`
+   - Evidence:
+     - `{ name: "foreign_net_buy_krw_5d_sum", value: row.foreign_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "institution_net_buy_krw_5d_sum", value: row.institution_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "individual_net_buy_krw_5d_sum", value: row.individual_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "foreign_net_buy_5d_pct_of_turnover", value: row.foreign_net_buy_5d_pct_of_turnover, source: "computed" }`
+
+3. **Divergent or weak flow abstain**
+   - Predicate:
+     - `(row.foreign_net_buy_krw_5d_sum * row.institution_net_buy_krw_5d_sum < 0.0)`  
+       **OR**
+     - `(abs(row.foreign_net_buy_5d_pct_of_turnover) < agents.flow.thresholds.foreign_pct_neutral_abs_max` (`0.003`))`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "foreign_net_buy_krw_5d_sum", value: row.foreign_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "institution_net_buy_krw_5d_sum", value: row.institution_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "individual_net_buy_krw_5d_sum", value: row.individual_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "foreign_net_buy_5d_pct_of_turnover", value: row.foreign_net_buy_5d_pct_of_turnover, source: "computed" }`
+
+4. **Fallback**
+   - Predicate: `else`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "foreign_net_buy_krw_5d_sum", value: row.foreign_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "institution_net_buy_krw_5d_sum", value: row.institution_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "individual_net_buy_krw_5d_sum", value: row.individual_net_buy_krw_5d_sum, source: "KRX" }`
+     - `{ name: "foreign_net_buy_5d_pct_of_turnover", value: row.foreign_net_buy_5d_pct_of_turnover, source: "computed" }`
+
+**Threshold rationale:** flow should be normalized by market activity, not raw KRW only. Using foreign flow as percent of turnover avoids regime drift, while requiring sign agreement with institutions avoids acting on single-cohort noise.
+
+**Truth table**
+
+| Row | foreign_net_buy_krw_5d_sum | institution_net_buy_krw_5d_sum | individual_net_buy_krw_5d_sum | foreign_net_buy_5d_pct_of_turnover | Expected branch | label | score |
+|---|---:|---:|---:|---:|---|---|---:|
+| F1 | 1200000000000 | 300000000000 | -1500000000000 | 0.012 | Aligned institutional demand | up | 0.80 |
+| F2 | -1000000000000 | -200000000000 | 1200000000000 | -0.013 | Aligned institutional distribution | down | -0.80 |
+| F3 | 500000000000 | -100000000000 | -400000000000 | 0.006 | Divergent or weak flow abstain | skip | 0.0 |
+| F4 | 400000000000 | 100000000000 | -500000000000 | 0.005 | Fallback | skip | 0.0 |
+
+---
+
+## §22. ValuationAgent
+
+**rule_version:** `valuation@1.0.0`
+
+**Inputs whitelist (and only these):**
+- `kospi_per`
+- `kospi_pbr`
+- `kospi_per_percentile_252d`
+- `kospi_pbr_percentile_252d`
+
+**Ordered rule logic**
+
+1. **Relatively cheap market**
+   - Predicate:
+     - `row.kospi_per > 0.0`
+     - `row.kospi_pbr > 0.0`
+     - `row.kospi_per_percentile_252d <= agents.valuation.thresholds.per_percentile_up_max` (`0.30`)
+     - `row.kospi_pbr_percentile_252d <= agents.valuation.thresholds.pbr_percentile_up_max` (`0.30`)
+   - Emit:
+     - `label: up`
+     - `score: 0.55`
+   - Evidence:
+     - `{ name: "kospi_per", value: row.kospi_per, source: "KRX" }`
+     - `{ name: "kospi_pbr", value: row.kospi_pbr, source: "KRX" }`
+     - `{ name: "kospi_per_percentile_252d", value: row.kospi_per_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_pbr_percentile_252d", value: row.kospi_pbr_percentile_252d, source: "computed" }`
+
+2. **Relatively expensive market**
+   - Predicate:
+     - `row.kospi_per > 0.0`
+     - `row.kospi_pbr > 0.0`
+     - `row.kospi_per_percentile_252d >= agents.valuation.thresholds.per_percentile_down_min` (`0.70`)
+     - `row.kospi_pbr_percentile_252d >= agents.valuation.thresholds.pbr_percentile_down_min` (`0.70`)
+   - Emit:
+     - `label: down`
+     - `score: -0.55`
+   - Evidence:
+     - `{ name: "kospi_per", value: row.kospi_per, source: "KRX" }`
+     - `{ name: "kospi_pbr", value: row.kospi_pbr, source: "KRX" }`
+     - `{ name: "kospi_per_percentile_252d", value: row.kospi_per_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_pbr_percentile_252d", value: row.kospi_pbr_percentile_252d, source: "computed" }`
+
+3. **Fair-value band abstain**
+   - Predicate:
+     - `abs(row.kospi_per_percentile_252d - agents.valuation.thresholds.fair_value_center)` (`0.50`) `<= agents.valuation.thresholds.fair_value_half_band` (`0.10`)
+     - `abs(row.kospi_pbr_percentile_252d - agents.valuation.thresholds.fair_value_center)` (`0.50`) `<= agents.valuation.thresholds.fair_value_half_band` (`0.10`)
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_per", value: row.kospi_per, source: "KRX" }`
+     - `{ name: "kospi_pbr", value: row.kospi_pbr, source: "KRX" }`
+     - `{ name: "kospi_per_percentile_252d", value: row.kospi_per_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_pbr_percentile_252d", value: row.kospi_pbr_percentile_252d, source: "computed" }`
+
+4. **Fallback**
+   - Predicate: `else`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_per", value: row.kospi_per, source: "KRX" }`
+     - `{ name: "kospi_pbr", value: row.kospi_pbr, source: "KRX" }`
+     - `{ name: "kospi_per_percentile_252d", value: row.kospi_per_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_pbr_percentile_252d", value: row.kospi_pbr_percentile_252d, source: "computed" }`
+
+**Threshold rationale:** valuation should be relative, not anchored to fixed long-history constants. The 30th/70th percentile bands are broad enough to identify cheap/rich regimes without pretending valuation alone predicts each next day.
+
+**Truth table**
+
+| Row | kospi_per | kospi_pbr | kospi_per_percentile_252d | kospi_pbr_percentile_252d | Expected branch | label | score |
+|---|---:|---:|---:|---:|---|---|---:|
+| V1 | 9.8 | 0.86 | 0.18 | 0.22 | Relatively cheap market | up | 0.55 |
+| V2 | 13.8 | 1.18 | 0.82 | 0.76 | Relatively expensive market | down | -0.55 |
+| V3 | 11.5 | 0.98 | 0.54 | 0.47 | Fair-value band abstain | skip | 0.0 |
+| V4 | 10.9 | 1.05 | 0.20 | 0.65 | Fallback | skip | 0.0 |
+
+---
+
+## §23. VolatilityAgent
+
+**rule_version:** `volatility@1.0.0`
+
+**Inputs whitelist (and only these):**
+- `kospi_realized_vol_20d`
+- `kospi_realized_vol_20d_percentile_252d`
+- `kospi_atr_14d`
+
+**Ordered rule logic**
+
+1. **Calm regime support**
+   - Predicate:
+     - `row.kospi_realized_vol_20d <= agents.volatility.thresholds.realized_vol_20d_up_max` (`0.18`)
+     - `row.kospi_realized_vol_20d_percentile_252d <= agents.volatility.thresholds.realized_vol_pct_up_max` (`0.30`)
+     - `row.kospi_atr_14d <= agents.volatility.thresholds.atr_14d_up_max` (`35.0`)
+   - Emit:
+     - `label: up`
+     - `score: 0.40`
+   - Evidence:
+     - `{ name: "kospi_realized_vol_20d", value: row.kospi_realized_vol_20d, source: "computed" }`
+     - `{ name: "kospi_realized_vol_20d_percentile_252d", value: row.kospi_realized_vol_20d_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_atr_14d", value: row.kospi_atr_14d, source: "computed" }`
+
+2. **Stress regime risk-off**
+   - Predicate:
+     - `row.kospi_realized_vol_20d_percentile_252d >= agents.volatility.thresholds.realized_vol_pct_down_min` (`0.80`)
+     - `(row.kospi_realized_vol_20d >= agents.volatility.thresholds.realized_vol_20d_down_min` (`0.25`) `OR row.kospi_atr_14d >= agents.volatility.thresholds.atr_14d_down_min` (`45.0`))`
+   - Emit:
+     - `label: down`
+     - `score: -0.65`
+   - Evidence:
+     - `{ name: "kospi_realized_vol_20d", value: row.kospi_realized_vol_20d, source: "computed" }`
+     - `{ name: "kospi_realized_vol_20d_percentile_252d", value: row.kospi_realized_vol_20d_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_atr_14d", value: row.kospi_atr_14d, source: "computed" }`
+
+3. **Middle-volatility abstain**
+   - Predicate:
+     - `row.kospi_realized_vol_20d_percentile_252d > agents.volatility.thresholds.realized_vol_pct_mid_low` (`0.30`)
+     - `row.kospi_realized_vol_20d_percentile_252d < agents.volatility.thresholds.realized_vol_pct_mid_high` (`0.80`)
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_realized_vol_20d", value: row.kospi_realized_vol_20d, source: "computed" }`
+     - `{ name: "kospi_realized_vol_20d_percentile_252d", value: row.kospi_realized_vol_20d_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_atr_14d", value: row.kospi_atr_14d, source: "computed" }`
+
+4. **Fallback**
+   - Predicate: `else`
+   - Emit:
+     - `label: skip`
+     - `score: 0.0`
+   - Evidence:
+     - `{ name: "kospi_realized_vol_20d", value: row.kospi_realized_vol_20d, source: "computed" }`
+     - `{ name: "kospi_realized_vol_20d_percentile_252d", value: row.kospi_realized_vol_20d_percentile_252d, source: "computed" }`
+     - `{ name: "kospi_atr_14d", value: row.kospi_atr_14d, source: "computed" }`
+
+**Threshold rationale:** volatility is primarily a risk throttle. Low volatility only adds a modest positive score; high volatility gets a stronger negative score because regime stress matters more than calmness for next-day decisioning.
+
+**Truth table**
+
+| Row | kospi_realized_vol_20d | kospi_realized_vol_20d_percentile_252d | kospi_atr_14d | Expected branch | label | score |
+|---|---:|---:|---:|---|---|---:|
+| O1 | 0.15 | 0.22 | 28.0 | Calm regime support | up | 0.40 |
+| O2 | 0.29 | 0.88 | 47.0 | Stress regime risk-off | down | -0.65 |
+| O3 | 0.21 | 0.55 | 34.0 | Middle-volatility abstain | skip | 0.0 |
+| O4 | 0.20 | 0.85 | 30.0 | Fallback | skip | 0.0 |
+
+---
+
+## §24. Target labels and walk-forward backtest contract
+
+### §24.1 Ground-truth target label
+
+Ground truth is defined on the **next trading day close-to-close** move.
+
+Let:
+
+- `target_next_day_simple_return = (kospi_close[t+1] / kospi_close[t]) - 1.0`
+- `target_next_day_log_return = ln(kospi_close[t+1] / kospi_close[t])`
+
+Let the flat band be:
+
+- `flat_band_abs_log_return = 0.001`
+
+Then:
+
+- if `target_next_day_log_return >= 0.001`, `target_direction_label = "up"`
+- else if `target_next_day_log_return <= -0.001`, `target_direction_label = "down"`
+- else, `target_direction_label = "flat"`
+
+This label is for backtest/evaluation only. Agents MUST NOT read it.
+
+### §24.2 Target column names
+
+The following are the only target columns for v1.0.0, and all MUST use the `target_` prefix:
+
+- `target_next_day_simple_return`
+- `target_next_day_log_return`
+- `target_direction_label`
+
+Rules:
+
+- No agent may read any column whose name matches `^target_`.
+- No agent may read any column whose name matches `^future_`.
+- `target_*` columns MUST exist only in `data/gold/backtest_dataset.parquet`.
+- Gold feature datasets consumed by agents MUST NOT contain any `target_*` or `future_*` columns.
+
+### §24.3 Walk-forward split
+
+Walk-forward mode is fixed to **expanding-window** for v1.0.0. Rolling-window mode is out of scope.
+
+Binding defaults:
+
+- `min_train_rows = 252`
+- `test_fold_size = 20` trading days
+- `gap_days = 0`
+
+Semantics:
+
+1. Sort rows by `trade_date` ascending.
+2. `train_cutoff` is the **inclusive** maximum `trade_date` in the train fold.
+3. Fold 1:
+   - train = first `252` eligible rows
+   - test = next `20` eligible rows with `trade_date > train_cutoff`
+4. Fold `k+1`:
+   - expand train to include all prior train and prior test rows
+   - set new `train_cutoff` to the last `trade_date` of the expanded train
+   - test = next `20` eligible rows with `trade_date > train_cutoff`
+5. The final fold MAY contain fewer than `20` rows. It MUST still be emitted if it contains at least `1` row.
+6. Because `gap_days = 0`, the first test row is the immediate next eligible trading row after `train_cutoff`.
+
+Raise condition:
+
+- If any candidate test row has `trade_date <= train_cutoff`, the splitter MUST raise.
+- Recommended exception text: `ValueError("test row date must be strictly greater than train_cutoff")`
+
+Eligibility:
+
+- A row is eligible only if all Gold feature columns required by the backtest job are non-null and all three target columns are non-null.
+- The final source row, which has no `t+1` close and therefore no targets, MUST be excluded.
+
+### §24.4 Output schema: `data/gold/backtest_dataset.parquet`
+
+This file is the join of Gold features at date `t` and target columns derived from date `t+1`. It is the **only** file in the project allowed to contain `target_*`.
+
+**Required columns**
+- `trade_date`
+- All Gold feature columns, verbatim:
+  - `kospi_close`
+  - `kospi_return_1d`
+  - `kospi_return_3d`
+  - `kospi_return_5d`
+  - `kospi_ma5`
+  - `kospi_ma20`
+  - `kospi_ma5_gap`
+  - `kospi_close_position`
+  - `bok_base_rate`
+  - `bok_base_rate_change_30d`
+  - `usd_krw_close`
+  - `usd_krw_return_5d`
+  - `kr_bond_yield_3y`
+  - `kr_bond_yield_change_30d`
+  - `foreign_net_buy_krw_5d_sum`
+  - `institution_net_buy_krw_5d_sum`
+  - `individual_net_buy_krw_5d_sum`
+  - `foreign_net_buy_5d_pct_of_turnover`
+  - `kospi_per`
+  - `kospi_pbr`
+  - `kospi_per_percentile_252d`
+  - `kospi_pbr_percentile_252d`
+  - `kospi_realized_vol_20d`
+  - `kospi_realized_vol_20d_percentile_252d`
+  - `kospi_atr_14d`
+- Target columns:
+  - `target_next_day_simple_return`
+  - `target_next_day_log_return`
+  - `target_direction_label`
+
+**Required invariants**
+- sorted ascending by `trade_date`
+- one row per `trade_date`
+- no duplicate `trade_date`
+- no other `target_*` columns
+- no `future_*` columns
+- agent runtime MUST strip or reject all `target_*` columns before scoring
+
+### §24.5 `agents.yaml` schema extension (binding)
+
+The existing aggregate weights and aggregate thresholds remain unchanged. Add a new `agents` block to pin `rule_version` and provide per-agent rule thresholds.
+
+Validation rules:
+
+- `weights` and `agents` MUST contain the same agent names.
+- `agents.<name>.rule_version` MUST exactly match the version in this spec.
+- `agents.<name>.thresholds` MUST contain exactly the keys required by that agent version.
+- Missing or unknown threshold keys MUST raise config validation error.
+
+**Full YAML structure**
+
+```yaml
+weights:
+  technical: 0.30
+  domestic_macro: 0.20
+  flow: 0.25
+  valuation: 0.10
+  volatility: 0.15
+
+thresholds:
+  up: 0.25
+  down: -0.25
+
+agents:
+  technical:
+    rule_version: technical@1.0.0
+    thresholds:
+      ma5_gap_up_min: 0.005
+      close_position_up_min: 0.60
+      return_5d_up_min: 0.010
+      ma5_gap_down_max: -0.005
+      close_position_down_max: 0.40
+      return_5d_down_max: -0.010
+
+  domestic_macro:
+    rule_version: domestic_macro@1.0.0
+    thresholds:
+      bok_rate_change_up_max: 0.00
+      usdkrw_return_5d_up_max: 0.010
+      bond_yield_change_30d_up_max: 0.05
+      bok_rate_change_down_min: 0.25
+      usdkrw_return_5d_down_min: 0.020
+      bond_yield_change_30d_down_min: 0.10
+      usdkrw_return_5d_mixed_pos_min: 0.015
+      usdkrw_return_5d_mixed_neg_max: -0.015
+      bond_yield_change_30d_mixed_pos_min: 0.05
+      bond_yield_change_30d_mixed_neg_max: 0.00
+
+  flow:
+    rule_version: flow@1.0.0
+    thresholds:
+      foreign_pct_up_min: 0.010
+      foreign_pct_down_max: -0.010
+      foreign_pct_neutral_abs_max: 0.003
+
+  valuation:
+    rule_version: valuation@1.0.0
+    thresholds:
+      per_percentile_up_max: 0.30
+      pbr_percentile_up_max: 0.30
+      per_percentile_down_min: 0.70
+      pbr_percentile_down_min: 0.70
+      fair_value_center: 0.50
+      fair_value_half_band: 0.10
+
+  volatility:
+    rule_version: volatility@1.0.0
+    thresholds:
+      realized_vol_20d_up_max: 0.18
+      realized_vol_pct_up_max: 0.30
+      atr_14d_up_max: 35.0
+      realized_vol_pct_down_min: 0.80
+      realized_vol_20d_down_min: 0.25
+      atr_14d_down_min: 45.0
+      realized_vol_pct_mid_low: 0.30
+      realized_vol_pct_mid_high: 0.80
+```

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -593,3 +593,5 @@ agents:
       realized_vol_pct_mid_low: 0.30
       realized_vol_pct_mid_high: 0.80
 ```
+
+--- 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -594,4 +594,4 @@ agents:
       realized_vol_pct_mid_high: 0.80
 ```
 
---- 
+---


### PR DESCRIPTION
## Summary
- land the binding §19-§24 rule spec in `docs/spec.md` and replace `apps/kr-kospi/config/agents.yaml` with the extended per-agent schema
- extend the shared config loader with frozen per-agent rule config parsing, keyset validation, semver rule-version checks, and immutable threshold mappings
- add RED/GREEN coverage for the new loader contract, including missing agents block, invalid rule versions, mismatched agent names, numeric validation, and immutability