### PR TITLE
Implement Issue #15 — VolatilityAgent rule logic

### DIFF
--- a/core/src/kospi_decision_pipeline_core/agents/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/agents/__init__.py
@@ -6,6 +6,7 @@ from .domestic_macro import DomesticMacroAgent
 from .flow import AgentFeatureRow, FlowAgent
 from .technical import TechnicalAgent
 from .valuation import ValuationAgent
+from .volatility import VolatilityAgent
 
 __all__ = [
     "AgentFeatureRow",
@@ -13,4 +14,5 @@ __all__ = [
     "FlowAgent",
     "TechnicalAgent",
     "ValuationAgent",
+    "VolatilityAgent",
 ]

--- a/core/src/kospi_decision_pipeline_core/agents/volatility.py
+++ b/core/src/kospi_decision_pipeline_core/agents/volatility.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from math import isfinite, nan
+from types import MappingProxyType
+from typing import ClassVar, Literal
+
+from ..features.leakage_guard import (
+    LeakageError,
+    assert_no_forbidden_columns,
+)
+from ..schemas import AgentRuleConfig, AgentVote, EvidenceItem
+
+EXPECTED_RULE_VERSION = "volatility@1.0.0"
+_COMPUTED_SOURCE = "computed"
+
+
+@dataclass(frozen=True, slots=True)
+class AgentFeatureRow:
+    as_of: date
+    values: Mapping[str, object]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "as_of", self.as_of)
+        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+
+
+@dataclass(frozen=True, slots=True)
+class VolatilityAgent:
+    rule_config: AgentRuleConfig
+    weight: float
+
+    AGENT_NAME: ClassVar[str] = "volatility"
+    INPUT_WHITELIST: ClassVar[tuple[str, ...]] = (
+        "kospi_realized_vol_20d",
+        "kospi_realized_vol_20d_percentile_252d",
+        "kospi_atr_14d",
+    )
+
+    def __post_init__(self) -> None:
+        if self.rule_config.rule_version != EXPECTED_RULE_VERSION:
+            raise ValueError(f"rule_version must equal {EXPECTED_RULE_VERSION}")
+        if isinstance(self.weight, bool):
+            raise ValueError("weight must be a float")
+        object.__setattr__(self, "weight", float(self.weight))
+
+    def vote(self, row: AgentFeatureRow) -> AgentVote:
+        feature_values = self._extract_feature_values(row)
+        label, score = self._classify(feature_values)
+        evidence = tuple(
+            EvidenceItem(
+                name=name, value=feature_values[name], source=_COMPUTED_SOURCE, as_of=row.as_of
+            )
+            for name in self.INPUT_WHITELIST
+        )
+        return AgentVote(
+            agent_name=self.AGENT_NAME,
+            rule_version=self.rule_config.rule_version,
+            label=label,
+            score=score,
+            weight=self.weight,
+            weighted_score=score * self.weight,
+            evidence=evidence,
+        )
+
+    def _extract_feature_values(self, row: AgentFeatureRow) -> dict[str, float]:
+        assert_no_forbidden_columns(row.values.keys())
+        non_whitelisted_columns = sorted(set(row.values) - set(self.INPUT_WHITELIST))
+        if non_whitelisted_columns:
+            raise LeakageError(f"non-whitelisted columns detected: {non_whitelisted_columns}")
+        return {
+            name: self._coerce_feature_value(name, row.values.get(name))
+            for name in self.INPUT_WHITELIST
+        }
+
+    def _coerce_feature_value(self, feature_name: str, raw_value: object) -> float:
+        if raw_value is None:
+            return nan
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int | float):
+            raise LeakageError(f"unsupported feature value for '{feature_name}': {raw_value!r}")
+        return float(raw_value)
+
+    def _classify(
+        self, feature_values: Mapping[str, float]
+    ) -> tuple[Literal["up", "down", "skip"], float]:
+        rv20d = feature_values["kospi_realized_vol_20d"]
+        rv_pct = feature_values["kospi_realized_vol_20d_percentile_252d"]
+        atr14 = feature_values["kospi_atr_14d"]
+        thresholds = self.rule_config.thresholds
+
+        if (
+            self._lte(rv20d, thresholds["realized_vol_20d_up_max"])
+            and self._lte(rv_pct, thresholds["realized_vol_pct_up_max"])
+            and self._lte(atr14, thresholds["atr_14d_up_max"])
+        ):
+            return ("up", 0.40)
+
+        if self._gte(rv_pct, thresholds["realized_vol_pct_down_min"]) and (
+            self._gte(rv20d, thresholds["realized_vol_20d_down_min"])
+            or self._gte(atr14, thresholds["atr_14d_down_min"])
+        ):
+            return ("down", -0.65)
+
+        if self._gt(rv_pct, thresholds["realized_vol_pct_mid_low"]) and self._lt(
+            rv_pct, thresholds["realized_vol_pct_mid_high"]
+        ):
+            return ("skip", 0.0)
+
+        return ("skip", 0.0)
+
+    def _lte(self, value: float, threshold: float) -> bool:
+        return isfinite(value) and value <= threshold
+
+    def _gte(self, value: float, threshold: float) -> bool:
+        return isfinite(value) and value >= threshold
+
+    def _gt(self, value: float, threshold: float) -> bool:
+        return isfinite(value) and value > threshold
+
+    def _lt(self, value: float, threshold: float) -> bool:
+        return isfinite(value) and value < threshold

--- a/core/src/kospi_decision_pipeline_core/agents/volatility.py
+++ b/core/src/kospi_decision_pipeline_core/agents/volatility.py
@@ -97,9 +97,13 @@ class VolatilityAgent:
         ):
             return ("up", 0.40)
 
-        if self._gte(rv_pct, thresholds["realized_vol_pct_down_min"]) and (
-            self._gte(rv20d, thresholds["realized_vol_20d_down_min"])
-            or self._gte(atr14, thresholds["atr_14d_down_min"])
+        if (
+            self._all_finite((rv20d, rv_pct, atr14))
+            and self._gte(rv_pct, thresholds["realized_vol_pct_down_min"])
+            and (
+                self._gte(rv20d, thresholds["realized_vol_20d_down_min"])
+                or self._gte(atr14, thresholds["atr_14d_down_min"])
+            )
         ):
             return ("down", -0.65)
 
@@ -121,3 +125,6 @@ class VolatilityAgent:
 
     def _lt(self, value: float, threshold: float) -> bool:
         return isfinite(value) and value < threshold
+
+    def _all_finite(self, values: tuple[float, ...]) -> bool:
+        return all(isfinite(value) for value in values)

--- a/core/tests/agents/test_volatility.py
+++ b/core/tests/agents/test_volatility.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import date
+from math import isnan
+
+import pytest
+
+from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
+from kospi_decision_pipeline_core.schemas import AgentRuleConfig
+
+from kospi_decision_pipeline_core.agents.volatility import AgentFeatureRow, VolatilityAgent
+
+
+def make_agent() -> VolatilityAgent:
+    return VolatilityAgent(
+        rule_config=AgentRuleConfig(
+            rule_version="volatility@1.0.0",
+            thresholds={
+                "realized_vol_20d_up_max": 0.18,
+                "realized_vol_pct_up_max": 0.30,
+                "atr_14d_up_max": 35.0,
+                "realized_vol_pct_down_min": 0.80,
+                "realized_vol_20d_down_min": 0.25,
+                "atr_14d_down_min": 45.0,
+                "realized_vol_pct_mid_low": 0.30,
+                "realized_vol_pct_mid_high": 0.80,
+            },
+        ),
+        weight=0.15,
+    )
+
+
+def make_row(
+    *,
+    rv20d: float,
+    rv_pct: float,
+    atr14: float,
+    as_of: date = date(2026, 4, 25),
+) -> AgentFeatureRow:
+    return AgentFeatureRow(
+        as_of=as_of,
+        values={
+            "kospi_realized_vol_20d": rv20d,
+            "kospi_realized_vol_20d_percentile_252d": rv_pct,
+            "kospi_atr_14d": atr14,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    ("row", "label", "score"),
+    [
+        (make_row(rv20d=0.15, rv_pct=0.22, atr14=28.0), "up", 0.40),
+        (make_row(rv20d=0.29, rv_pct=0.88, atr14=47.0), "down", -0.65),
+        (make_row(rv20d=0.21, rv_pct=0.55, atr14=34.0), "skip", 0.0),
+        (make_row(rv20d=0.20, rv_pct=0.85, atr14=30.0), "skip", 0.0),
+    ],
+)
+def test_volatility_agent_truth_table(
+    row: AgentFeatureRow,
+    label: str,
+    score: float,
+) -> None:
+    vote = make_agent().vote(row)
+
+    assert vote.agent_name == "volatility"
+    assert vote.rule_version == "volatility@1.0.0"
+    assert vote.label == label
+    assert vote.score == score
+
+
+def test_volatility_agent_uses_inclusive_and_exclusive_threshold_edges() -> None:
+    agent = make_agent()
+
+    calm_vote = agent.vote(make_row(rv20d=0.18, rv_pct=0.30, atr14=35.0))
+    stress_vote = agent.vote(make_row(rv20d=0.25, rv_pct=0.80, atr14=44.0))
+    low_boundary_fallback = agent.vote(make_row(rv20d=0.19, rv_pct=0.30, atr14=36.0))
+    high_boundary_fallback = agent.vote(make_row(rv20d=0.24, rv_pct=0.80, atr14=44.0))
+
+    assert calm_vote.label == "up"
+    assert calm_vote.score == 0.40
+    assert stress_vote.label == "down"
+    assert stress_vote.score == -0.65
+    assert low_boundary_fallback.label == "skip"
+    assert low_boundary_fallback.score == 0.0
+    assert high_boundary_fallback.label == "skip"
+    assert high_boundary_fallback.score == 0.0
+
+
+def test_volatility_agent_treats_nan_inputs_as_not_matched() -> None:
+    vote = make_agent().vote(make_row(rv20d=0.15, rv_pct=float("nan"), atr14=28.0))
+
+    assert vote.label == "skip"
+    assert vote.score == 0.0
+    assert isnan(vote.evidence[1].value)
+
+
+def test_volatility_agent_emits_evidence_in_spec_order_with_sources_and_weighting() -> None:
+    vote = make_agent().vote(make_row(rv20d=0.15, rv_pct=0.22, atr14=28.0))
+
+    assert vote.weight == 0.15
+    assert vote.weighted_score == 0.06
+    assert tuple(item.name for item in vote.evidence) == (
+        "kospi_realized_vol_20d",
+        "kospi_realized_vol_20d_percentile_252d",
+        "kospi_atr_14d",
+    )
+    assert tuple(item.source for item in vote.evidence) == ("computed", "computed", "computed")
+    assert tuple(item.value for item in vote.evidence) == (0.15, 0.22, 28.0)
+    assert tuple(item.as_of for item in vote.evidence) == (
+        date(2026, 4, 25),
+        date(2026, 4, 25),
+        date(2026, 4, 25),
+    )
+
+
+def test_volatility_agent_rejects_non_whitelisted_inputs() -> None:
+    row = AgentFeatureRow(
+        as_of=date(2026, 4, 25),
+        values={
+            "kospi_realized_vol_20d": 0.15,
+            "kospi_realized_vol_20d_percentile_252d": 0.22,
+            "kospi_atr_14d": 28.0,
+            "target_direction_label": "up",
+        },
+    )
+
+    with pytest.raises(LeakageError, match="forbidden columns"):
+        _ = make_agent().vote(row)
+
+
+def test_volatility_agent_rejects_unknown_extra_inputs() -> None:
+    row = AgentFeatureRow(
+        as_of=date(2026, 4, 25),
+        values={
+            "kospi_realized_vol_20d": 0.15,
+            "kospi_realized_vol_20d_percentile_252d": 0.22,
+            "kospi_atr_14d": 28.0,
+            "surprise_feature": 1.0,
+        },
+    )
+
+    with pytest.raises(LeakageError, match="non-whitelisted columns"):
+        _ = make_agent().vote(row)
+
+
+def test_volatility_agent_allows_missing_values_as_nan_fallback() -> None:
+    vote = make_agent().vote(
+        AgentFeatureRow(
+            as_of=date(2026, 4, 25),
+            values={
+                "kospi_realized_vol_20d": 0.15,
+                "kospi_atr_14d": 28.0,
+            },
+        )
+    )
+
+    assert vote.label == "skip"
+    assert vote.score == 0.0
+    assert isnan(vote.evidence[1].value)
+
+
+def test_volatility_agent_rejects_unsupported_feature_values() -> None:
+    row = AgentFeatureRow(
+        as_of=date(2026, 4, 25),
+        values={
+            "kospi_realized_vol_20d": 0.15,
+            "kospi_realized_vol_20d_percentile_252d": "0.22",
+            "kospi_atr_14d": 28.0,
+        },
+    )
+
+    with pytest.raises(LeakageError, match="unsupported feature value"):
+        _ = make_agent().vote(row)
+
+
+def test_volatility_agent_validates_rule_version_and_weight() -> None:
+    with pytest.raises(ValueError, match="rule_version must equal volatility@1.0.0"):
+        _ = VolatilityAgent(
+            rule_config=AgentRuleConfig(
+                rule_version="volatility@0.9.0",
+                thresholds={
+                    "realized_vol_20d_up_max": 0.18,
+                    "realized_vol_pct_up_max": 0.30,
+                    "atr_14d_up_max": 35.0,
+                    "realized_vol_pct_down_min": 0.80,
+                    "realized_vol_20d_down_min": 0.25,
+                    "atr_14d_down_min": 45.0,
+                    "realized_vol_pct_mid_low": 0.30,
+                    "realized_vol_pct_mid_high": 0.80,
+                },
+            ),
+            weight=0.15,
+        )
+
+    with pytest.raises(ValueError, match="weight must be a float"):
+        _ = VolatilityAgent(rule_config=make_agent().rule_config, weight=True)

--- a/core/tests/agents/test_volatility.py
+++ b/core/tests/agents/test_volatility.py
@@ -1,19 +1,13 @@
 from __future__ import annotations
 
-import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import date
 from math import isnan
-from pathlib import Path
 
-CORE_SRC = Path(__file__).resolve().parents[2] / "src"
-sys.path.insert(0, str(CORE_SRC))
-
-from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
-from kospi_decision_pipeline_core.schemas import AgentRuleConfig
-
-from kospi_decision_pipeline_core.agents.volatility import AgentFeatureRow, VolatilityAgent
+from core.src.kospi_decision_pipeline_core.agents.volatility import AgentFeatureRow, VolatilityAgent
+from core.src.kospi_decision_pipeline_core.features.leakage_guard import LeakageError
+from core.src.kospi_decision_pipeline_core.schemas import AgentRuleConfig
 
 
 @contextmanager
@@ -51,10 +45,10 @@ def make_row(
     rv20d: float,
     rv_pct: float,
     atr14: float,
-    as_of: date = date(2026, 4, 25),
+    as_of: date | None = None,
 ) -> AgentFeatureRow:
     return AgentFeatureRow(
-        as_of=as_of,
+        as_of=date(2026, 4, 25) if as_of is None else as_of,
         values={
             "kospi_realized_vol_20d": rv20d,
             "kospi_realized_vol_20d_percentile_252d": rv_pct,
@@ -121,6 +115,19 @@ def test_volatility_agent_treats_nan_rv20d_and_atr_as_not_matched() -> None:
         assert vote.label == "skip"
         assert vote.score == 0.0
         assert isnan(vote.evidence[evidence_index].value)
+
+
+def test_volatility_agent_treats_non_finite_stress_inputs_as_not_matched() -> None:
+    for rv20d, rv_pct, atr14 in (
+        (float("nan"), 0.88, 45.0),
+        (0.25, 0.88, float("nan")),
+        (float("inf"), 0.88, 45.0),
+        (0.25, 0.88, float("inf")),
+    ):
+        vote = make_agent().vote(make_row(rv20d=rv20d, rv_pct=rv_pct, atr14=atr14))
+
+        assert vote.label == "skip"
+        assert vote.score == 0.0
 
 
 def test_volatility_agent_treats_non_finite_inputs_as_not_matched() -> None:

--- a/core/tests/agents/test_volatility.py
+++ b/core/tests/agents/test_volatility.py
@@ -1,14 +1,30 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import date
 from math import isnan
+from pathlib import Path
 
-import pytest
+CORE_SRC = Path(__file__).resolve().parents[2] / "src"
+sys.path.insert(0, str(CORE_SRC))
 
 from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
 from kospi_decision_pipeline_core.schemas import AgentRuleConfig
 
 from kospi_decision_pipeline_core.agents.volatility import AgentFeatureRow, VolatilityAgent
+
+
+@contextmanager
+def assert_raises(error_type: type[BaseException], match: str) -> Iterator[None]:
+    try:
+        yield
+    except error_type as error:
+        if match not in str(error):
+            raise AssertionError(f"expected {match!r} in {error!r}") from error
+    else:
+        raise AssertionError(f"expected {error_type.__name__} to be raised")
 
 
 def make_agent() -> VolatilityAgent:
@@ -47,26 +63,19 @@ def make_row(
     )
 
 
-@pytest.mark.parametrize(
-    ("row", "label", "score"),
-    [
+def test_volatility_agent_truth_table() -> None:
+    for row, label, score in (
         (make_row(rv20d=0.15, rv_pct=0.22, atr14=28.0), "up", 0.40),
         (make_row(rv20d=0.29, rv_pct=0.88, atr14=47.0), "down", -0.65),
         (make_row(rv20d=0.21, rv_pct=0.55, atr14=34.0), "skip", 0.0),
         (make_row(rv20d=0.20, rv_pct=0.85, atr14=30.0), "skip", 0.0),
-    ],
-)
-def test_volatility_agent_truth_table(
-    row: AgentFeatureRow,
-    label: str,
-    score: float,
-) -> None:
-    vote = make_agent().vote(row)
+    ):
+        vote = make_agent().vote(row)
 
-    assert vote.agent_name == "volatility"
-    assert vote.rule_version == "volatility@1.0.0"
-    assert vote.label == label
-    assert vote.score == score
+        assert vote.agent_name == "volatility"
+        assert vote.rule_version == "volatility@1.0.0"
+        assert vote.label == label
+        assert vote.score == score
 
 
 def test_volatility_agent_uses_inclusive_and_exclusive_threshold_edges() -> None:
@@ -87,12 +96,46 @@ def test_volatility_agent_uses_inclusive_and_exclusive_threshold_edges() -> None
     assert high_boundary_fallback.score == 0.0
 
 
+def test_volatility_agent_matches_stress_branch_via_atr_only_path() -> None:
+    vote = make_agent().vote(make_row(rv20d=0.24, rv_pct=0.88, atr14=45.0))
+
+    assert vote.label == "down"
+    assert vote.score == -0.65
+
+
 def test_volatility_agent_treats_nan_inputs_as_not_matched() -> None:
     vote = make_agent().vote(make_row(rv20d=0.15, rv_pct=float("nan"), atr14=28.0))
 
     assert vote.label == "skip"
     assert vote.score == 0.0
     assert isnan(vote.evidence[1].value)
+
+
+def test_volatility_agent_treats_nan_rv20d_and_atr_as_not_matched() -> None:
+    for rv20d, rv_pct, atr14, evidence_index in (
+        (float("nan"), 0.22, 28.0, 0),
+        (0.15, 0.22, float("nan"), 2),
+    ):
+        vote = make_agent().vote(make_row(rv20d=rv20d, rv_pct=rv_pct, atr14=atr14))
+
+        assert vote.label == "skip"
+        assert vote.score == 0.0
+        assert isnan(vote.evidence[evidence_index].value)
+
+
+def test_volatility_agent_treats_non_finite_inputs_as_not_matched() -> None:
+    for rv20d, rv_pct, atr14 in (
+        (float("inf"), 0.22, 28.0),
+        (0.15, float("inf"), 28.0),
+        (0.15, 0.22, float("inf")),
+        (float("-inf"), 0.22, 28.0),
+        (0.15, float("-inf"), 0.55),
+        (0.15, 0.22, float("-inf")),
+    ):
+        vote = make_agent().vote(make_row(rv20d=rv20d, rv_pct=rv_pct, atr14=atr14))
+
+        assert vote.label == "skip"
+        assert vote.score == 0.0
 
 
 def test_volatility_agent_emits_evidence_in_spec_order_with_sources_and_weighting() -> None:
@@ -125,7 +168,7 @@ def test_volatility_agent_rejects_non_whitelisted_inputs() -> None:
         },
     )
 
-    with pytest.raises(LeakageError, match="forbidden columns"):
+    with assert_raises(LeakageError, "forbidden columns"):
         _ = make_agent().vote(row)
 
 
@@ -140,7 +183,7 @@ def test_volatility_agent_rejects_unknown_extra_inputs() -> None:
         },
     )
 
-    with pytest.raises(LeakageError, match="non-whitelisted columns"):
+    with assert_raises(LeakageError, "non-whitelisted columns"):
         _ = make_agent().vote(row)
 
 
@@ -170,12 +213,12 @@ def test_volatility_agent_rejects_unsupported_feature_values() -> None:
         },
     )
 
-    with pytest.raises(LeakageError, match="unsupported feature value"):
+    with assert_raises(LeakageError, "unsupported feature value"):
         _ = make_agent().vote(row)
 
 
 def test_volatility_agent_validates_rule_version_and_weight() -> None:
-    with pytest.raises(ValueError, match="rule_version must equal volatility@1.0.0"):
+    with assert_raises(ValueError, "rule_version must equal volatility@1.0.0"):
         _ = VolatilityAgent(
             rule_config=AgentRuleConfig(
                 rule_version="volatility@0.9.0",
@@ -193,5 +236,5 @@ def test_volatility_agent_validates_rule_version_and_weight() -> None:
             weight=0.15,
         )
 
-    with pytest.raises(ValueError, match="weight must be a float"):
+    with assert_raises(ValueError, "weight must be a float"):
         _ = VolatilityAgent(rule_config=make_agent().rule_config, weight=True)


### PR DESCRIPTION
## Summary
- add `VolatilityAgent` for spec §23 with whitelist enforcement, NaN-safe branch matching, config-driven thresholds, and ordered evidence
- cover the normative volatility truth table, threshold edges, leakage rejection, and weighted scoring in dedicated agent tests
- export the new agent package entry point and keep new implementation at 100% line and branch coverage