### PR TITLE
Implement Issue #11: TechnicalAgent rule logic

### DIFF
--- a/core/src/kospi_decision_pipeline_core/agents/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/agents/__init__.py
@@ -1,0 +1,7 @@
+"""Rule agents."""
+
+from __future__ import annotations
+
+from kospi_decision_pipeline_core.agents.technical import TechnicalAgent
+
+__all__ = ["TechnicalAgent"]

--- a/core/src/kospi_decision_pipeline_core/agents/technical.py
+++ b/core/src/kospi_decision_pipeline_core/agents/technical.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from math import isfinite, nan
+from typing import ClassVar, Literal
+
+from kospi_decision_pipeline_core.features.agent_input import build_agent_feature_row
+from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig
+from kospi_decision_pipeline_core.schemas.decisions import AgentVote, EvidenceItem
+
+AgentFeatureRow = Mapping[str, object]
+
+_EVIDENCE_ORDER: tuple[str, ...] = (
+    "kospi_ma5_gap",
+    "kospi_close_position",
+    "kospi_return_5d",
+    "kospi_return_1d",
+)
+_EVIDENCE_SOURCE = "computed"
+_EVIDENCE_AS_OF = date.min
+
+
+@dataclass(frozen=True, slots=True)
+class TechnicalAgent:
+    rule_config: AgentRuleConfig
+    weight: float
+
+    AGENT_NAME: ClassVar[str] = "technical"
+    INPUT_WHITELIST: ClassVar[tuple[str, ...]] = (
+        "kospi_return_1d",
+        "kospi_return_5d",
+        "kospi_ma5_gap",
+        "kospi_close_position",
+    )
+
+    def vote(self, row: AgentFeatureRow) -> AgentVote:
+        raw_values = _extract_whitelisted_values(row, allowed_columns=self.INPUT_WHITELIST)
+        return_1d = _finite_float_or_none(raw_values["kospi_return_1d"])
+        return_5d = _finite_float_or_none(raw_values["kospi_return_5d"])
+        ma5_gap = _finite_float_or_none(raw_values["kospi_ma5_gap"])
+        close_position = _finite_float_or_none(raw_values["kospi_close_position"])
+
+        label: Literal["up", "down", "skip"] = "skip"
+        score = 0.0
+
+        if any(value is None for value in (return_1d, return_5d, ma5_gap, close_position)):
+            label = "skip"
+            score = 0.0
+        elif (
+            ma5_gap is not None
+            and close_position is not None
+            and return_5d is not None
+            and ma5_gap >= self._threshold("ma5_gap_up_min")
+            and close_position >= self._threshold("close_position_up_min")
+            and return_5d >= self._threshold("return_5d_up_min")
+        ):
+            label = "up"
+            score = 0.70
+        elif (
+            ma5_gap is not None
+            and close_position is not None
+            and return_5d is not None
+            and ma5_gap <= self._threshold("ma5_gap_down_max")
+            and close_position <= self._threshold("close_position_down_max")
+            and return_5d <= self._threshold("return_5d_down_max")
+        ):
+            label = "down"
+            score = -0.70
+        elif (
+            return_1d is not None
+            and return_5d is not None
+            and ((return_1d > 0.0 and return_5d < 0.0) or (return_1d < 0.0 and return_5d > 0.0))
+        ):
+            label = "skip"
+            score = 0.0
+
+        return AgentVote(
+            agent_name=self.AGENT_NAME,
+            rule_version=self.rule_config.rule_version,
+            label=label,
+            score=score,
+            weight=self.weight,
+            weighted_score=score * self.weight,
+            evidence=_build_evidence(raw_values),
+        )
+
+    def _threshold(self, name: str) -> float:
+        threshold = self.rule_config.thresholds.get(name)
+        if threshold is None:
+            raise ValueError(f"missing threshold for technical rule: {name}")
+        return threshold
+
+
+def _extract_whitelisted_values(
+    row: AgentFeatureRow,
+    *,
+    allowed_columns: tuple[str, ...],
+) -> dict[str, object | None]:
+    _ = build_agent_feature_row(_coerce_nulls_for_sanitizer(row), allowed_columns)
+    return {column: row[column] if column in row else None for column in allowed_columns}
+
+
+def _coerce_nulls_for_sanitizer(row: AgentFeatureRow) -> dict[str, object]:
+    return {column: 0.0 if value is None else value for column, value in row.items()}
+
+
+def _finite_float_or_none(value: object | None) -> float | None:
+    if value is None or isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    numeric_value = float(value)
+    if not isfinite(numeric_value):
+        return None
+    return numeric_value
+
+
+def _evidence_value(value: object | None) -> float:
+    if value is None or isinstance(value, bool) or not isinstance(value, int | float):
+        return nan
+    return float(value)
+
+
+def _build_evidence(raw_values: Mapping[str, object | None]) -> tuple[EvidenceItem, ...]:
+    return tuple(
+        EvidenceItem(
+            name=name,
+            value=_evidence_value(raw_values[name]),
+            source=_EVIDENCE_SOURCE,
+            as_of=_EVIDENCE_AS_OF,
+        )
+        for name in _EVIDENCE_ORDER
+    )
+
+
+__all__ = ["TechnicalAgent"]

--- a/core/src/kospi_decision_pipeline_core/agents/technical.py
+++ b/core/src/kospi_decision_pipeline_core/agents/technical.py
@@ -45,10 +45,7 @@ class TechnicalAgent:
         label: Literal["up", "down", "skip"] = "skip"
         score = 0.0
 
-        if any(value is None for value in (return_1d, return_5d, ma5_gap, close_position)):
-            label = "skip"
-            score = 0.0
-        elif (
+        if (
             ma5_gap is not None
             and close_position is not None
             and return_5d is not None

--- a/core/tests/agents/test_technical.py
+++ b/core/tests/agents/test_technical.py
@@ -57,24 +57,38 @@ def test_technical_agent_emits_all_evidence_items_in_spec_order() -> None:
         )
 
 
-def test_technical_agent_nan_in_any_input_falls_back_to_skip() -> None:
-    for column in EXPECTED_EVIDENCE_NAMES:
-        row: dict[str, float] = {
-            "kospi_return_1d": 0.004,
+def test_technical_agent_invalid_return_1d_does_not_block_bullish_branch() -> None:
+    for value in (None, math.nan, math.inf, -math.inf):
+        row = {
+            "kospi_return_1d": value,
             "kospi_return_5d": 0.018,
             "kospi_ma5_gap": 0.008,
             "kospi_close_position": 0.72,
         }
-        row[column] = math.nan
 
         vote = make_agent().vote(row)
 
-        assert vote.label == "skip"
-        assert vote.score == 0.0
+        assert vote.label == "up"
+        assert vote.score == 0.70
 
 
-def test_technical_agent_non_finite_or_null_inputs_fall_back_to_skip() -> None:
-    for value in (None, math.inf, -math.inf):
+def test_technical_agent_invalid_return_1d_does_not_block_bearish_branch() -> None:
+    for value in (None, math.nan, math.inf, -math.inf):
+        row = {
+            "kospi_return_1d": value,
+            "kospi_return_5d": -0.015,
+            "kospi_ma5_gap": -0.009,
+            "kospi_close_position": 0.28,
+        }
+
+        vote = make_agent().vote(row)
+
+        assert vote.label == "down"
+        assert vote.score == -0.70
+
+
+def test_technical_agent_invalid_branch_input_falls_through_to_fallback_skip() -> None:
+    for value in (None, math.nan, math.inf, -math.inf):
         row = {
             "kospi_return_1d": 0.004,
             "kospi_return_5d": value,

--- a/core/tests/agents/test_technical.py
+++ b/core/tests/agents/test_technical.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from pathlib import Path
-
-import pytest
+from typing import Callable, Literal
 
 from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
 from kospi_decision_pipeline_core.agents import TechnicalAgent
-from kospi_decision_pipeline_core.schemas.config import load_agents_config
+from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig, load_agents_config
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 AGENTS_CONFIG_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "agents.yaml"
@@ -27,9 +27,125 @@ def make_agent() -> TechnicalAgent:
     )
 
 
-@pytest.mark.parametrize(
-    ("row", "expected_label", "expected_score"),
-    [
+def test_technical_agent_matches_spec_truth_table() -> None:
+    for row, expected_label, expected_score in _truth_table_rows():
+        vote = make_agent().vote(row)
+
+        assert vote.agent_name == "technical"
+        assert vote.rule_version == "technical@1.0.0"
+        assert vote.label == expected_label
+        assert vote.score == expected_score
+        assert vote.weighted_score == vote.score * vote.weight
+
+
+def test_technical_agent_emits_all_evidence_items_in_spec_order() -> None:
+    for row, _, _ in _truth_table_rows():
+        vote = make_agent().vote(row)
+
+        assert tuple(item.name for item in vote.evidence) == EXPECTED_EVIDENCE_NAMES
+        assert tuple(item.source for item in vote.evidence) == (
+            "computed",
+            "computed",
+            "computed",
+            "computed",
+        )
+        assert tuple(item.value for item in vote.evidence) == (
+            row["kospi_ma5_gap"],
+            row["kospi_close_position"],
+            row["kospi_return_5d"],
+            row["kospi_return_1d"],
+        )
+
+
+def test_technical_agent_nan_in_any_input_falls_back_to_skip() -> None:
+    for column in EXPECTED_EVIDENCE_NAMES:
+        row: dict[str, float] = {
+            "kospi_return_1d": 0.004,
+            "kospi_return_5d": 0.018,
+            "kospi_ma5_gap": 0.008,
+            "kospi_close_position": 0.72,
+        }
+        row[column] = math.nan
+
+        vote = make_agent().vote(row)
+
+        assert vote.label == "skip"
+        assert vote.score == 0.0
+
+
+def test_technical_agent_non_finite_or_null_inputs_fall_back_to_skip() -> None:
+    for value in (None, math.inf, -math.inf):
+        row = {
+            "kospi_return_1d": 0.004,
+            "kospi_return_5d": value,
+            "kospi_ma5_gap": 0.008,
+            "kospi_close_position": 0.72,
+        }
+
+        vote = make_agent().vote(row)
+
+        assert vote.label == "skip"
+        assert vote.score == 0.0
+
+
+def test_technical_agent_rejects_forbidden_target_columns() -> None:
+    row = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": 0.018,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+        "target_foo": 1.0,
+    }
+
+    assert_raises_leakage_error(make_agent().vote, row, "forbidden columns")
+
+
+def test_technical_agent_rejects_non_whitelisted_columns() -> None:
+    row = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": 0.018,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+        "other_feature": 1.0,
+    }
+
+    assert_raises_leakage_error(make_agent().vote, row, "non-whitelisted columns")
+
+
+def test_technical_agent_raises_when_required_threshold_is_missing() -> None:
+    agent = TechnicalAgent(
+        rule_config=AgentRuleConfig(
+            rule_version="technical@1.0.0",
+            thresholds={
+                "ma5_gap_up_min": 0.005,
+                "close_position_up_min": 0.60,
+                "return_5d_up_min": 0.010,
+                "ma5_gap_down_max": -0.005,
+                "close_position_down_max": 0.40,
+            },
+        ),
+        weight=0.30,
+    )
+
+    try:
+        _ = agent.vote(
+            {
+                "kospi_return_1d": -0.006,
+                "kospi_return_5d": -0.015,
+                "kospi_ma5_gap": -0.009,
+                "kospi_close_position": 0.28,
+            }
+        )
+    except ValueError as exc:
+        assert "return_5d_down_max" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing threshold")
+
+
+def _truth_table_rows() -> (
+    tuple[tuple[dict[str, float], Literal["up", "down", "skip"], float], ...]
+):
+    return (
         (
             {
                 "kospi_return_1d": 0.004,
@@ -70,123 +186,17 @@ def make_agent() -> TechnicalAgent:
             "skip",
             0.0,
         ),
-    ],
-)
-def test_technical_agent_matches_spec_truth_table(
-    row: dict[str, float],
-    expected_label: str,
-    expected_score: float,
-) -> None:
-    vote = make_agent().vote(row)
-
-    assert vote.agent_name == "technical"
-    assert vote.rule_version == "technical@1.0.0"
-    assert vote.label == expected_label
-    assert vote.score == expected_score
-    assert vote.weighted_score == vote.score * vote.weight
-
-
-@pytest.mark.parametrize(
-    "row",
-    [
-        {
-            "kospi_return_1d": 0.004,
-            "kospi_return_5d": 0.018,
-            "kospi_ma5_gap": 0.008,
-            "kospi_close_position": 0.72,
-        },
-        {
-            "kospi_return_1d": -0.006,
-            "kospi_return_5d": -0.015,
-            "kospi_ma5_gap": -0.009,
-            "kospi_close_position": 0.28,
-        },
-        {
-            "kospi_return_1d": 0.007,
-            "kospi_return_5d": -0.008,
-            "kospi_ma5_gap": 0.001,
-            "kospi_close_position": 0.55,
-        },
-        {
-            "kospi_return_1d": 0.002,
-            "kospi_return_5d": 0.006,
-            "kospi_ma5_gap": 0.002,
-            "kospi_close_position": 0.54,
-        },
-    ],
-)
-def test_technical_agent_emits_all_evidence_items_in_spec_order(
-    row: dict[str, float],
-) -> None:
-    vote = make_agent().vote(row)
-
-    assert tuple(item.name for item in vote.evidence) == EXPECTED_EVIDENCE_NAMES
-    assert tuple(item.source for item in vote.evidence) == (
-        "computed",
-        "computed",
-        "computed",
-        "computed",
-    )
-    assert tuple(item.value for item in vote.evidence) == (
-        row["kospi_ma5_gap"],
-        row["kospi_close_position"],
-        row["kospi_return_5d"],
-        row["kospi_return_1d"],
     )
 
 
-@pytest.mark.parametrize("column", EXPECTED_EVIDENCE_NAMES)
-def test_technical_agent_nan_in_any_input_falls_back_to_skip(column: str) -> None:
-    row: dict[str, float] = {
-        "kospi_return_1d": 0.004,
-        "kospi_return_5d": 0.018,
-        "kospi_ma5_gap": 0.008,
-        "kospi_close_position": 0.72,
-    }
-    row[column] = math.nan
-
-    vote = make_agent().vote(row)
-
-    assert vote.label == "skip"
-    assert vote.score == 0.0
-
-
-@pytest.mark.parametrize("value", [None, math.inf, -math.inf])
-def test_technical_agent_non_finite_or_null_inputs_fall_back_to_skip(value: object) -> None:
-    row = {
-        "kospi_return_1d": 0.004,
-        "kospi_return_5d": value,
-        "kospi_ma5_gap": 0.008,
-        "kospi_close_position": 0.72,
-    }
-
-    vote = make_agent().vote(row)
-
-    assert vote.label == "skip"
-    assert vote.score == 0.0
-
-
-def test_technical_agent_rejects_forbidden_target_columns() -> None:
-    row = {
-        "kospi_return_1d": 0.004,
-        "kospi_return_5d": 0.018,
-        "kospi_ma5_gap": 0.008,
-        "kospi_close_position": 0.72,
-        "target_foo": 1.0,
-    }
-
-    with pytest.raises(LeakageError, match="forbidden columns"):
-        _ = make_agent().vote(row)
-
-
-def test_technical_agent_rejects_non_whitelisted_columns() -> None:
-    row = {
-        "kospi_return_1d": 0.004,
-        "kospi_return_5d": 0.018,
-        "kospi_ma5_gap": 0.008,
-        "kospi_close_position": 0.72,
-        "other_feature": 1.0,
-    }
-
-    with pytest.raises(LeakageError, match="non-whitelisted columns"):
-        _ = make_agent().vote(row)
+def assert_raises_leakage_error(
+    func: Callable[[Mapping[str, object]], object],
+    row: Mapping[str, object],
+    message_fragment: str,
+) -> None:
+    try:
+        _ = func(row)
+    except LeakageError as exc:
+        assert message_fragment in str(exc)
+    else:
+        raise AssertionError("expected LeakageError")

--- a/core/tests/agents/test_technical.py
+++ b/core/tests/agents/test_technical.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
+from kospi_decision_pipeline_core.agents import TechnicalAgent
+from kospi_decision_pipeline_core.schemas.config import load_agents_config
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+AGENTS_CONFIG_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "agents.yaml"
+EXPECTED_EVIDENCE_NAMES = (
+    "kospi_ma5_gap",
+    "kospi_close_position",
+    "kospi_return_5d",
+    "kospi_return_1d",
+)
+
+
+def make_agent() -> TechnicalAgent:
+    config = load_agents_config(AGENTS_CONFIG_PATH)
+    return TechnicalAgent(
+        rule_config=config.agents["technical"],
+        weight=config.weights.values["technical"],
+    )
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_label", "expected_score"),
+    [
+        (
+            {
+                "kospi_return_1d": 0.004,
+                "kospi_return_5d": 0.018,
+                "kospi_ma5_gap": 0.008,
+                "kospi_close_position": 0.72,
+            },
+            "up",
+            0.70,
+        ),
+        (
+            {
+                "kospi_return_1d": -0.006,
+                "kospi_return_5d": -0.015,
+                "kospi_ma5_gap": -0.009,
+                "kospi_close_position": 0.28,
+            },
+            "down",
+            -0.70,
+        ),
+        (
+            {
+                "kospi_return_1d": 0.007,
+                "kospi_return_5d": -0.008,
+                "kospi_ma5_gap": 0.001,
+                "kospi_close_position": 0.55,
+            },
+            "skip",
+            0.0,
+        ),
+        (
+            {
+                "kospi_return_1d": 0.002,
+                "kospi_return_5d": 0.006,
+                "kospi_ma5_gap": 0.002,
+                "kospi_close_position": 0.54,
+            },
+            "skip",
+            0.0,
+        ),
+    ],
+)
+def test_technical_agent_matches_spec_truth_table(
+    row: dict[str, float],
+    expected_label: str,
+    expected_score: float,
+) -> None:
+    vote = make_agent().vote(row)
+
+    assert vote.agent_name == "technical"
+    assert vote.rule_version == "technical@1.0.0"
+    assert vote.label == expected_label
+    assert vote.score == expected_score
+    assert vote.weighted_score == vote.score * vote.weight
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        {
+            "kospi_return_1d": 0.004,
+            "kospi_return_5d": 0.018,
+            "kospi_ma5_gap": 0.008,
+            "kospi_close_position": 0.72,
+        },
+        {
+            "kospi_return_1d": -0.006,
+            "kospi_return_5d": -0.015,
+            "kospi_ma5_gap": -0.009,
+            "kospi_close_position": 0.28,
+        },
+        {
+            "kospi_return_1d": 0.007,
+            "kospi_return_5d": -0.008,
+            "kospi_ma5_gap": 0.001,
+            "kospi_close_position": 0.55,
+        },
+        {
+            "kospi_return_1d": 0.002,
+            "kospi_return_5d": 0.006,
+            "kospi_ma5_gap": 0.002,
+            "kospi_close_position": 0.54,
+        },
+    ],
+)
+def test_technical_agent_emits_all_evidence_items_in_spec_order(
+    row: dict[str, float],
+) -> None:
+    vote = make_agent().vote(row)
+
+    assert tuple(item.name for item in vote.evidence) == EXPECTED_EVIDENCE_NAMES
+    assert tuple(item.source for item in vote.evidence) == (
+        "computed",
+        "computed",
+        "computed",
+        "computed",
+    )
+    assert tuple(item.value for item in vote.evidence) == (
+        row["kospi_ma5_gap"],
+        row["kospi_close_position"],
+        row["kospi_return_5d"],
+        row["kospi_return_1d"],
+    )
+
+
+@pytest.mark.parametrize("column", EXPECTED_EVIDENCE_NAMES)
+def test_technical_agent_nan_in_any_input_falls_back_to_skip(column: str) -> None:
+    row: dict[str, float] = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": 0.018,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+    }
+    row[column] = math.nan
+
+    vote = make_agent().vote(row)
+
+    assert vote.label == "skip"
+    assert vote.score == 0.0
+
+
+@pytest.mark.parametrize("value", [None, math.inf, -math.inf])
+def test_technical_agent_non_finite_or_null_inputs_fall_back_to_skip(value: object) -> None:
+    row = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": value,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+    }
+
+    vote = make_agent().vote(row)
+
+    assert vote.label == "skip"
+    assert vote.score == 0.0
+
+
+def test_technical_agent_rejects_forbidden_target_columns() -> None:
+    row = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": 0.018,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+        "target_foo": 1.0,
+    }
+
+    with pytest.raises(LeakageError, match="forbidden columns"):
+        _ = make_agent().vote(row)
+
+
+def test_technical_agent_rejects_non_whitelisted_columns() -> None:
+    row = {
+        "kospi_return_1d": 0.004,
+        "kospi_return_5d": 0.018,
+        "kospi_ma5_gap": 0.008,
+        "kospi_close_position": 0.72,
+        "other_feature": 1.0,
+    }
+
+    with pytest.raises(LeakageError, match="non-whitelisted columns"):
+        _ = make_agent().vote(row)

--- a/core/tests/agents/test_technical.py
+++ b/core/tests/agents/test_technical.py
@@ -142,9 +142,9 @@ def test_technical_agent_raises_when_required_threshold_is_missing() -> None:
         raise AssertionError("expected ValueError for missing threshold")
 
 
-def _truth_table_rows() -> (
-    tuple[tuple[dict[str, float], Literal["up", "down", "skip"], float], ...]
-):
+def _truth_table_rows() -> tuple[
+    tuple[dict[str, float], Literal["up", "down", "skip"], float], ...
+]:
     return (
         (
             {


### PR DESCRIPTION
## Summary
- implement `TechnicalAgent` with strict whitelist gating, config-driven thresholds, ordered §19 rule evaluation, and deterministic evidence emission
- add normative RED/GREEN tests covering the truth table, evidence ordering, leakage rejection, invalid-input fallback, and missing-threshold guardrails
- export `TechnicalAgent` from the new `kospi_decision_pipeline_core.agents` package entrypoint

Closes #11