### PR TITLE
feat(#14): implement ValuationAgent per §22

### DIFF
--- a/core/src/kospi_decision_pipeline_core/agents/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/agents/__init__.py
@@ -5,5 +5,12 @@ from __future__ import annotations
 from .domestic_macro import DomesticMacroAgent
 from .flow import AgentFeatureRow, FlowAgent
 from .technical import TechnicalAgent
+from .valuation import ValuationAgent
 
-__all__ = ["AgentFeatureRow", "DomesticMacroAgent", "FlowAgent", "TechnicalAgent"]
+__all__ = [
+    "AgentFeatureRow",
+    "DomesticMacroAgent",
+    "FlowAgent",
+    "TechnicalAgent",
+    "ValuationAgent",
+]

--- a/core/src/kospi_decision_pipeline_core/agents/valuation.py
+++ b/core/src/kospi_decision_pipeline_core/agents/valuation.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from math import isfinite
+from typing import ClassVar, TypeAlias
+
+from kospi_decision_pipeline_core.schemas import (
+    AgentRuleConfig,
+    AgentVote,
+    EvidenceItem,
+    ModelLabel,
+)
+
+AgentFeatureRow: TypeAlias = Mapping[str, object]
+
+_EVIDENCE_AS_OF = date(1970, 1, 1)
+_EVIDENCE_SOURCES: tuple[tuple[str, str], ...] = (
+    ("kospi_per", "KRX"),
+    ("kospi_pbr", "KRX"),
+    ("kospi_per_percentile_252d", "computed"),
+    ("kospi_pbr_percentile_252d", "computed"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ValuationAgent:
+    rule_config: AgentRuleConfig
+    weight: float
+
+    AGENT_NAME: ClassVar[str] = "valuation"
+    INPUT_WHITELIST: ClassVar[tuple[str, ...]] = (
+        "kospi_per",
+        "kospi_pbr",
+        "kospi_per_percentile_252d",
+        "kospi_pbr_percentile_252d",
+    )
+
+    def vote(self, row: AgentFeatureRow) -> AgentVote:
+        _validate_row(row, self.INPUT_WHITELIST)
+
+        per = _read_feature(row, "kospi_per")
+        pbr = _read_feature(row, "kospi_pbr")
+        per_pct = _read_feature(row, "kospi_per_percentile_252d")
+        pbr_pct = _read_feature(row, "kospi_pbr_percentile_252d")
+
+        thresholds = self.rule_config.thresholds
+        per_percentile_up_max = _read_threshold(thresholds, "per_percentile_up_max")
+        pbr_percentile_up_max = _read_threshold(thresholds, "pbr_percentile_up_max")
+        per_percentile_down_min = _read_threshold(thresholds, "per_percentile_down_min")
+        pbr_percentile_down_min = _read_threshold(thresholds, "pbr_percentile_down_min")
+        fair_value_center = _read_threshold(thresholds, "fair_value_center")
+        fair_value_half_band = _read_threshold(thresholds, "fair_value_half_band")
+
+        label: ModelLabel
+        score: float
+        if (
+            _is_positive_finite(per)
+            and _is_positive_finite(pbr)
+            and _is_finite_at_most(per_pct, per_percentile_up_max)
+            and _is_finite_at_most(pbr_pct, pbr_percentile_up_max)
+        ):
+            label = "up"
+            score = 0.55
+        elif (
+            _is_positive_finite(per)
+            and _is_positive_finite(pbr)
+            and _is_finite_at_least(per_pct, per_percentile_down_min)
+            and _is_finite_at_least(pbr_pct, pbr_percentile_down_min)
+        ):
+            label = "down"
+            score = -0.55
+        elif _is_fair_value_band_match(
+            per_pct, fair_value_center, fair_value_half_band
+        ) and _is_fair_value_band_match(
+            pbr_pct,
+            fair_value_center,
+            fair_value_half_band,
+        ):
+            label = "skip"
+            score = 0.0
+        else:
+            label = "skip"
+            score = 0.0
+
+        evidence = tuple(
+            EvidenceItem(
+                name=name, value=_read_feature(row, name), source=source, as_of=_EVIDENCE_AS_OF
+            )
+            for name, source in _EVIDENCE_SOURCES
+        )
+        weight = _ensure_numeric(self.weight, context="weight")
+        return AgentVote(
+            agent_name=self.AGENT_NAME,
+            rule_version=self.rule_config.rule_version,
+            label=label,
+            score=score,
+            weight=weight,
+            weighted_score=score * weight,
+            evidence=evidence,
+        )
+
+
+def _validate_row(row: AgentFeatureRow, whitelist: tuple[str, ...]) -> None:
+    non_whitelisted_inputs = tuple(sorted(set(row) - set(whitelist)))
+    if non_whitelisted_inputs:
+        raise ValueError(f"non-whitelisted inputs: {non_whitelisted_inputs}")
+
+    missing_required_inputs = tuple(name for name in whitelist if name not in row)
+    if missing_required_inputs:
+        raise ValueError(f"missing required inputs: {missing_required_inputs}")
+
+
+def _read_feature(row: AgentFeatureRow, name: str) -> float:
+    return _ensure_numeric(row[name], context=name)
+
+
+def _read_threshold(thresholds: Mapping[str, float], name: str) -> float:
+    return _ensure_numeric(thresholds[name], context=name)
+
+
+def _ensure_numeric(value: object, *, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{context} must be numeric")
+    return float(value)
+
+
+def _is_positive_finite(value: float) -> bool:
+    return isfinite(value) and value > 0.0
+
+
+def _is_finite_at_most(value: float, ceiling: float) -> bool:
+    return isfinite(value) and value <= ceiling
+
+
+def _is_finite_at_least(value: float, floor: float) -> bool:
+    return isfinite(value) and value >= floor
+
+
+def _is_fair_value_band_match(value: float, center: float, half_band: float) -> bool:
+    return isfinite(value) and abs(value - center) <= half_band
+
+
+__all__ = ["AgentFeatureRow", "ValuationAgent"]

--- a/core/tests/agents/test_valuation.py
+++ b/core/tests/agents/test_valuation.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from math import nan
+from typing import TYPE_CHECKING
+
+import pytest
+
+from kospi_decision_pipeline_core.schemas import AgentRuleConfig
+
+if TYPE_CHECKING:
+    from kospi_decision_pipeline_core.agents.valuation import ValuationAgent
+
+
+def _make_rule_config() -> AgentRuleConfig:
+    return AgentRuleConfig(
+        rule_version="valuation@1.0.0",
+        thresholds={
+            "per_percentile_up_max": 0.30,
+            "pbr_percentile_up_max": 0.30,
+            "per_percentile_down_min": 0.70,
+            "pbr_percentile_down_min": 0.70,
+            "fair_value_center": 0.50,
+            "fair_value_half_band": 0.10,
+        },
+    )
+
+
+def _make_agent(weight: float = 0.10) -> ValuationAgent:
+    from kospi_decision_pipeline_core.agents.valuation import ValuationAgent
+
+    return ValuationAgent(rule_config=_make_rule_config(), weight=weight)
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_label", "expected_score"),
+    [
+        pytest.param(
+            {
+                "kospi_per": 9.8,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": 0.18,
+                "kospi_pbr_percentile_252d": 0.22,
+            },
+            "up",
+            0.55,
+            id="v1-cheap-market",
+        ),
+        pytest.param(
+            {
+                "kospi_per": 13.8,
+                "kospi_pbr": 1.18,
+                "kospi_per_percentile_252d": 0.82,
+                "kospi_pbr_percentile_252d": 0.76,
+            },
+            "down",
+            -0.55,
+            id="v2-expensive-market",
+        ),
+        pytest.param(
+            {
+                "kospi_per": 11.5,
+                "kospi_pbr": 0.98,
+                "kospi_per_percentile_252d": 0.54,
+                "kospi_pbr_percentile_252d": 0.47,
+            },
+            "skip",
+            0.0,
+            id="v3-fair-value-abstain",
+        ),
+        pytest.param(
+            {
+                "kospi_per": 10.9,
+                "kospi_pbr": 1.05,
+                "kospi_per_percentile_252d": 0.20,
+                "kospi_pbr_percentile_252d": 0.65,
+            },
+            "skip",
+            0.0,
+            id="v4-fallback",
+        ),
+    ],
+)
+def test_valuation_agent_truth_table(
+    row: dict[str, float], expected_label: str, expected_score: float
+) -> None:
+    vote = _make_agent().vote(row)
+
+    assert vote.agent_name == "valuation"
+    assert vote.rule_version == "valuation@1.0.0"
+    assert vote.label == expected_label
+    assert vote.score == expected_score
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        pytest.param(
+            {
+                "kospi_per": 9.8,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": nan,
+                "kospi_pbr_percentile_252d": 0.22,
+            },
+            id="nan-percentile-falls-through",
+        ),
+        pytest.param(
+            {
+                "kospi_per": -9.8,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": 0.18,
+                "kospi_pbr_percentile_252d": 0.22,
+            },
+            id="negative-per-falls-through",
+        ),
+        pytest.param(
+            {
+                "kospi_per": 9.8,
+                "kospi_pbr": -0.86,
+                "kospi_per_percentile_252d": 0.18,
+                "kospi_pbr_percentile_252d": 0.22,
+            },
+            id="negative-pbr-falls-through",
+        ),
+    ],
+)
+def test_valuation_agent_non_matching_inputs_fall_through_to_skip(row: dict[str, float]) -> None:
+    vote = _make_agent().vote(row)
+
+    assert vote.label == "skip"
+    assert vote.score == 0.0
+    assert vote.weighted_score == 0.0
+
+
+def test_valuation_agent_emits_evidence_in_spec_order_with_weighted_score() -> None:
+    vote = _make_agent(weight=0.10).vote(
+        {
+            "kospi_per": 9.8,
+            "kospi_pbr": 0.86,
+            "kospi_per_percentile_252d": 0.18,
+            "kospi_pbr_percentile_252d": 0.22,
+        }
+    )
+
+    assert vote.weight == 0.10
+    assert vote.weighted_score == pytest.approx(0.055)
+    assert tuple((item.name, item.source, item.value) for item in vote.evidence) == (
+        ("kospi_per", "KRX", 9.8),
+        ("kospi_pbr", "KRX", 0.86),
+        ("kospi_per_percentile_252d", "computed", 0.18),
+        ("kospi_pbr_percentile_252d", "computed", 0.22),
+    )
+
+
+def test_valuation_agent_rejects_non_whitelisted_inputs() -> None:
+    with pytest.raises(ValueError, match="non-whitelisted inputs"):
+        _ = _make_agent().vote(
+            {
+                "kospi_per": 9.8,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": 0.18,
+                "kospi_pbr_percentile_252d": 0.22,
+                "future_hint": 1.0,
+            }
+        )
+
+
+def test_valuation_agent_rejects_missing_required_inputs() -> None:
+    with pytest.raises(ValueError, match="missing required inputs"):
+        _ = _make_agent().vote(
+            {
+                "kospi_per": 9.8,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": 0.18,
+            }
+        )
+
+
+def test_valuation_agent_rejects_non_numeric_inputs() -> None:
+    with pytest.raises(ValueError, match="kospi_per must be numeric"):
+        _ = _make_agent().vote(
+            {
+                "kospi_per": True,
+                "kospi_pbr": 0.86,
+                "kospi_per_percentile_252d": 0.18,
+                "kospi_pbr_percentile_252d": 0.22,
+            }
+        )
+
+
+def test_valuation_agent_constants_match_spec() -> None:
+    from kospi_decision_pipeline_core.agents import ValuationAgent
+
+    assert ValuationAgent.AGENT_NAME == "valuation"
+    assert ValuationAgent.INPUT_WHITELIST == (
+        "kospi_per",
+        "kospi_pbr",
+        "kospi_per_percentile_252d",
+        "kospi_pbr_percentile_252d",
+    )


### PR DESCRIPTION
## Summary
- add `ValuationAgent` with strict whitelist validation, ordered §22 rule evaluation, fixed labels/scores, and spec-ordered valuation evidence
- add RED/contract coverage for the §22 truth table, NaN and negative fallthrough, weighted score, evidence ordering, and leakage rejection
- export the new agent module from `kospi_decision_pipeline_core.agents` with 100% coverage on the new code

## Verification
- `.venv/bin/python -m pytest core/tests/agents/test_valuation.py --cov=kospi_decision_pipeline_core.agents.valuation --cov=kospi_decision_pipeline_core.agents --cov-branch --cov-report=term-missing`
- `.venv/bin/ruff check core/src/kospi_decision_pipeline_core/agents/valuation.py core/src/kospi_decision_pipeline_core/agents/__init__.py core/tests/agents/test_valuation.py`
- `.venv/bin/mypy core/src/kospi_decision_pipeline_core/agents/valuation.py core/src/kospi_decision_pipeline_core/agents/__init__.py core/tests/agents/test_valuation.py`