### PR TITLE
Implement FlowAgent rule logic (#13)

### DIFF
--- a/core/src/kospi_decision_pipeline_core/agents/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/agents/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
-from kospi_decision_pipeline_core.agents.technical import TechnicalAgent
+from .flow import AgentFeatureRow, FlowAgent
+from .technical import TechnicalAgent
 
-__all__ = ["TechnicalAgent"]
+__all__ = ["AgentFeatureRow", "FlowAgent", "TechnicalAgent"]

--- a/core/src/kospi_decision_pipeline_core/agents/flow.py
+++ b/core/src/kospi_decision_pipeline_core/agents/flow.py
@@ -11,7 +11,7 @@ from kospi_decision_pipeline_core.features.leakage_guard import (
     assert_no_forbidden_columns,
 )
 from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig
-from kospi_decision_pipeline_core.schemas.decisions import AgentVote, EvidenceItem
+from kospi_decision_pipeline_core.schemas.decisions import AgentVote, EvidenceItem, ModelLabel
 
 
 _AS_OF_DATE_COLUMN = "as_of_date"
@@ -72,6 +72,8 @@ class FlowAgent:
     )
 
     def vote(self, row: AgentFeatureRow) -> AgentVote:
+        label: ModelLabel
+
         if self._matches_aligned_demand(row):
             label = "up"
             score = 0.80

--- a/core/src/kospi_decision_pipeline_core/agents/flow.py
+++ b/core/src/kospi_decision_pipeline_core/agents/flow.py
@@ -1,16 +1,61 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date
+from math import isfinite
 from typing import ClassVar
 
+from kospi_decision_pipeline_core.features.leakage_guard import (
+    LeakageError,
+    assert_no_forbidden_columns,
+)
 from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig
-from kospi_decision_pipeline_core.schemas.decisions import AgentVote
+from kospi_decision_pipeline_core.schemas.decisions import AgentVote, EvidenceItem
+
+
+_AS_OF_DATE_COLUMN = "as_of_date"
 
 
 @dataclass(frozen=True, slots=True)
 class AgentFeatureRow:
     as_of_date: date
+    foreign_net_buy_krw_5d_sum: float
+    institution_net_buy_krw_5d_sum: float
+    individual_net_buy_krw_5d_sum: float
+    foreign_net_buy_5d_pct_of_turnover: float
+
+    @classmethod
+    def from_mapping(cls, row: Mapping[str, object]) -> AgentFeatureRow:
+        assert_no_forbidden_columns(row.keys())
+        allowed_columns = (_AS_OF_DATE_COLUMN,) + FlowAgent.INPUT_WHITELIST
+        non_whitelisted_columns = sorted(set(row) - set(allowed_columns))
+        if non_whitelisted_columns:
+            raise LeakageError(f"non-whitelisted columns detected: {non_whitelisted_columns}")
+
+        missing_columns = [column for column in allowed_columns if column not in row]
+        if missing_columns:
+            raise LeakageError(f"missing required columns: {missing_columns}")
+
+        return cls(
+            as_of_date=_require_date(row[_AS_OF_DATE_COLUMN], context=_AS_OF_DATE_COLUMN),
+            foreign_net_buy_krw_5d_sum=_require_float_feature(
+                row["foreign_net_buy_krw_5d_sum"],
+                context="foreign_net_buy_krw_5d_sum",
+            ),
+            institution_net_buy_krw_5d_sum=_require_float_feature(
+                row["institution_net_buy_krw_5d_sum"],
+                context="institution_net_buy_krw_5d_sum",
+            ),
+            individual_net_buy_krw_5d_sum=_require_float_feature(
+                row["individual_net_buy_krw_5d_sum"],
+                context="individual_net_buy_krw_5d_sum",
+            ),
+            foreign_net_buy_5d_pct_of_turnover=_require_float_feature(
+                row["foreign_net_buy_5d_pct_of_turnover"],
+                context="foreign_net_buy_5d_pct_of_turnover",
+            ),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,4 +72,117 @@ class FlowAgent:
     )
 
     def vote(self, row: AgentFeatureRow) -> AgentVote:
-        raise NotImplementedError
+        if self._matches_aligned_demand(row):
+            label = "up"
+            score = 0.80
+        elif self._matches_aligned_distribution(row):
+            label = "down"
+            score = -0.80
+        elif self._matches_divergent_or_weak_flow(row):
+            label = "skip"
+            score = 0.0
+        else:
+            label = "skip"
+            score = 0.0
+
+        return AgentVote(
+            agent_name=self.AGENT_NAME,
+            rule_version=self.rule_config.rule_version,
+            label=label,
+            score=score,
+            weight=self.weight,
+            weighted_score=score * self.weight,
+            evidence=self._build_evidence(row),
+        )
+
+    def _matches_aligned_demand(self, row: AgentFeatureRow) -> bool:
+        if not _all_finite(
+            row.foreign_net_buy_krw_5d_sum,
+            row.institution_net_buy_krw_5d_sum,
+            row.individual_net_buy_krw_5d_sum,
+            row.foreign_net_buy_5d_pct_of_turnover,
+        ):
+            return False
+
+        return (
+            row.foreign_net_buy_krw_5d_sum > 0.0
+            and row.institution_net_buy_krw_5d_sum >= 0.0
+            and row.individual_net_buy_krw_5d_sum <= 0.0
+            and row.foreign_net_buy_5d_pct_of_turnover
+            >= self.rule_config.thresholds["foreign_pct_up_min"]
+        )
+
+    def _matches_aligned_distribution(self, row: AgentFeatureRow) -> bool:
+        if not _all_finite(
+            row.foreign_net_buy_krw_5d_sum,
+            row.institution_net_buy_krw_5d_sum,
+            row.individual_net_buy_krw_5d_sum,
+            row.foreign_net_buy_5d_pct_of_turnover,
+        ):
+            return False
+
+        return (
+            row.foreign_net_buy_krw_5d_sum < 0.0
+            and row.institution_net_buy_krw_5d_sum <= 0.0
+            and row.individual_net_buy_krw_5d_sum >= 0.0
+            and row.foreign_net_buy_5d_pct_of_turnover
+            <= self.rule_config.thresholds["foreign_pct_down_max"]
+        )
+
+    def _matches_divergent_or_weak_flow(self, row: AgentFeatureRow) -> bool:
+        if not _all_finite(
+            row.foreign_net_buy_krw_5d_sum,
+            row.institution_net_buy_krw_5d_sum,
+            row.foreign_net_buy_5d_pct_of_turnover,
+        ):
+            return False
+
+        return (
+            row.foreign_net_buy_krw_5d_sum * row.institution_net_buy_krw_5d_sum < 0.0
+            or abs(row.foreign_net_buy_5d_pct_of_turnover)
+            < self.rule_config.thresholds["foreign_pct_neutral_abs_max"]
+        )
+
+    def _build_evidence(self, row: AgentFeatureRow) -> tuple[EvidenceItem, ...]:
+        return (
+            EvidenceItem(
+                name="foreign_net_buy_krw_5d_sum",
+                value=row.foreign_net_buy_krw_5d_sum,
+                source="KRX",
+                as_of=row.as_of_date,
+            ),
+            EvidenceItem(
+                name="institution_net_buy_krw_5d_sum",
+                value=row.institution_net_buy_krw_5d_sum,
+                source="KRX",
+                as_of=row.as_of_date,
+            ),
+            EvidenceItem(
+                name="individual_net_buy_krw_5d_sum",
+                value=row.individual_net_buy_krw_5d_sum,
+                source="KRX",
+                as_of=row.as_of_date,
+            ),
+            EvidenceItem(
+                name="foreign_net_buy_5d_pct_of_turnover",
+                value=row.foreign_net_buy_5d_pct_of_turnover,
+                source="computed",
+                as_of=row.as_of_date,
+            ),
+        )
+
+
+def _all_finite(*values: float) -> bool:
+    return all(isfinite(value) for value in values)
+
+
+def _require_date(value: object, *, context: str) -> date:
+    if not isinstance(value, date):
+        raise LeakageError(f"{context} must be a date")
+    return value
+
+
+def _require_float_feature(value: object, *, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise LeakageError(f"{context} must be a float")
+    return float(value)

--- a/core/src/kospi_decision_pipeline_core/agents/flow.py
+++ b/core/src/kospi_decision_pipeline_core/agents/flow.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import ClassVar
+
+from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig
+from kospi_decision_pipeline_core.schemas.decisions import AgentVote
+
+
+@dataclass(frozen=True, slots=True)
+class AgentFeatureRow:
+    as_of_date: date
+
+
+@dataclass(frozen=True, slots=True)
+class FlowAgent:
+    rule_config: AgentRuleConfig
+    weight: float
+
+    AGENT_NAME: ClassVar[str] = "flow"
+    INPUT_WHITELIST: ClassVar[tuple[str, ...]] = (
+        "foreign_net_buy_krw_5d_sum",
+        "institution_net_buy_krw_5d_sum",
+        "individual_net_buy_krw_5d_sum",
+        "foreign_net_buy_5d_pct_of_turnover",
+    )
+
+    def vote(self, row: AgentFeatureRow) -> AgentVote:
+        raise NotImplementedError

--- a/core/tests/agents/test_flow.py
+++ b/core/tests/agents/test_flow.py
@@ -31,8 +31,11 @@ def make_row(
     institution_5d: float,
     individual_5d: float,
     foreign_pct: float,
-    as_of_date: date = date(2026, 4, 24),
+    as_of_date: date | None = None,
 ) -> AgentFeatureRow:
+    if as_of_date is None:
+        as_of_date = date(2026, 4, 24)
+
     return AgentFeatureRow.from_mapping(
         {
             "as_of_date": as_of_date,
@@ -198,6 +201,43 @@ def test_agent_feature_row_rejects_non_whitelisted_columns() -> None:
                 "institution_net_buy_5d_pct_of_turnover": 0.01,
             }
         )
+
+
+def test_agent_feature_row_rejects_missing_required_columns() -> None:
+    with pytest.raises(LeakageError, match="missing required columns"):
+        _ = AgentFeatureRow.from_mapping(
+            {
+                "as_of_date": date(2026, 4, 24),
+                "foreign_net_buy_krw_5d_sum": 1.0,
+                "institution_net_buy_krw_5d_sum": 0.0,
+                "individual_net_buy_krw_5d_sum": -1.0,
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("as_of_date", "2026-04-24", "as_of_date must be a date"),
+        ("foreign_net_buy_krw_5d_sum", True, "foreign_net_buy_krw_5d_sum must be a float"),
+    ],
+)
+def test_agent_feature_row_rejects_invalid_scalar_types(
+    field: str,
+    value: object,
+    match: str,
+) -> None:
+    payload: dict[str, object] = {
+        "as_of_date": date(2026, 4, 24),
+        "foreign_net_buy_krw_5d_sum": 1.0,
+        "institution_net_buy_krw_5d_sum": 0.0,
+        "individual_net_buy_krw_5d_sum": -1.0,
+        "foreign_net_buy_5d_pct_of_turnover": 0.02,
+    }
+    payload[field] = value
+
+    with pytest.raises(LeakageError, match=match):
+        _ = AgentFeatureRow.from_mapping(payload)
 
 
 def test_flow_agent_exposes_spec_whitelist_verbatim() -> None:

--- a/core/tests/agents/test_flow.py
+++ b/core/tests/agents/test_flow.py
@@ -256,6 +256,68 @@ def test_flow_agent_respects_spec_threshold_boundaries(
     assert vote.score == pytest.approx(expected_score)
 
 
+@pytest.mark.parametrize(
+    ("institution_5d", "individual_5d", "expected_label", "expected_score"),
+    [
+        (0.0, -1500000000000, "up", 0.80),
+        (300000000000, 0.0, "up", 0.80),
+        (0.0, 1200000000000, "down", -0.80),
+        (-200000000000, 0.0, "down", -0.80),
+    ],
+)
+def test_flow_agent_honors_zero_sign_boundaries(
+    institution_5d: float,
+    individual_5d: float,
+    expected_label: str,
+    expected_score: float,
+) -> None:
+    foreign_5d = 1200000000000 if expected_label == "up" else -1000000000000
+    foreign_pct = 0.012 if expected_label == "up" else -0.013
+
+    vote = make_agent().vote(
+        make_row(
+            foreign_5d=foreign_5d,
+            institution_5d=institution_5d,
+            individual_5d=individual_5d,
+            foreign_pct=foreign_pct,
+        )
+    )
+
+    assert vote.label == expected_label
+    assert vote.score == pytest.approx(expected_score)
+
+
+def test_flow_agent_treats_zero_foreign_flow_as_fallback_skip() -> None:
+    vote = make_agent().vote(
+        make_row(
+            foreign_5d=0.0,
+            institution_5d=300000000000,
+            individual_5d=-1500000000000,
+            foreign_pct=0.012,
+        )
+    )
+
+    assert vote.label == "skip"
+    assert vote.score == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize("individual_5d", [inf, -inf])
+def test_flow_agent_ignores_non_finite_individual_flow_in_branch_three_predicate(
+    individual_5d: float,
+) -> None:
+    vote = make_agent().vote(
+        make_row(
+            foreign_5d=500000000000,
+            institution_5d=-100000000000,
+            individual_5d=individual_5d,
+            foreign_pct=0.006,
+        )
+    )
+
+    assert vote.label == "skip"
+    assert vote.score == pytest.approx(0.0)
+
+
 def test_agent_feature_row_rejects_forbidden_target_columns() -> None:
     with pytest.raises(LeakageError, match="forbidden columns"):
         _ = AgentFeatureRow.from_mapping(

--- a/core/tests/agents/test_flow.py
+++ b/core/tests/agents/test_flow.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import date
-from math import nan
+from math import inf, nan
 
 import pytest
 
@@ -146,6 +146,51 @@ def test_flow_agent_preserves_specified_evidence_order_sources_and_weighted_scor
     )
 
 
+def test_flow_agent_uses_negative_weighted_score_for_down_vote() -> None:
+    vote = make_agent(weight=0.25).vote(
+        make_row(
+            foreign_5d=-1000000000000,
+            institution_5d=-200000000000,
+            individual_5d=1200000000000,
+            foreign_pct=-0.013,
+        )
+    )
+
+    assert vote.label == "down"
+    assert vote.score == pytest.approx(-0.80)
+    assert vote.weighted_score == pytest.approx(-0.20)
+
+
+@pytest.mark.parametrize(
+    ("foreign_5d", "institution_5d", "individual_5d", "foreign_pct"),
+    [
+        (inf, 300000000000, -1500000000000, 0.012),
+        (-inf, -200000000000, 1200000000000, -0.013),
+        (1200000000000, inf, -1500000000000, 0.012),
+        (1200000000000, 300000000000, -1500000000000, inf),
+        (1200000000000, 300000000000, -1500000000000, -inf),
+    ],
+)
+def test_flow_agent_treats_any_non_finite_predicate_input_as_not_matched(
+    foreign_5d: float,
+    institution_5d: float,
+    individual_5d: float,
+    foreign_pct: float,
+) -> None:
+    vote = make_agent().vote(
+        make_row(
+            foreign_5d=foreign_5d,
+            institution_5d=institution_5d,
+            individual_5d=individual_5d,
+            foreign_pct=foreign_pct,
+        )
+    )
+
+    assert vote.label == "skip"
+    assert vote.score == pytest.approx(0.0)
+    assert vote.weighted_score == pytest.approx(0.0)
+
+
 @pytest.mark.parametrize(
     ("foreign_5d", "institution_5d", "individual_5d", "foreign_pct"),
     [
@@ -173,6 +218,42 @@ def test_flow_agent_treats_any_nan_predicate_input_as_not_matched(
     assert vote.label == "skip"
     assert vote.score == pytest.approx(0.0)
     assert vote.weighted_score == pytest.approx(0.0)
+
+
+@pytest.mark.parametrize(
+    ("foreign_pct", "expected_label", "expected_score"),
+    [
+        (0.010, "up", 0.80),
+        (-0.010, "down", -0.80),
+        (0.003, "skip", 0.0),
+        (-0.003, "skip", 0.0),
+        (0.0029, "skip", 0.0),
+    ],
+)
+def test_flow_agent_respects_spec_threshold_boundaries(
+    foreign_pct: float,
+    expected_label: str,
+    expected_score: float,
+) -> None:
+    if foreign_pct >= 0.0:
+        row = make_row(
+            foreign_5d=1200000000000,
+            institution_5d=300000000000,
+            individual_5d=-1500000000000,
+            foreign_pct=foreign_pct,
+        )
+    else:
+        row = make_row(
+            foreign_5d=-1000000000000,
+            institution_5d=-200000000000,
+            individual_5d=1200000000000,
+            foreign_pct=foreign_pct,
+        )
+
+    vote = make_agent().vote(row)
+
+    assert vote.label == expected_label
+    assert vote.score == pytest.approx(expected_score)
 
 
 def test_agent_feature_row_rejects_forbidden_target_columns() -> None:

--- a/core/tests/agents/test_flow.py
+++ b/core/tests/agents/test_flow.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import date
+from math import nan
+
+import pytest
+
+from kospi_decision_pipeline_core.agents.flow import AgentFeatureRow, FlowAgent
+from kospi_decision_pipeline_core.features.leakage_guard import LeakageError
+from kospi_decision_pipeline_core.schemas.config import AgentRuleConfig
+
+
+def make_rule_config() -> AgentRuleConfig:
+    return AgentRuleConfig(
+        rule_version="flow@1.0.0",
+        thresholds={
+            "foreign_pct_up_min": 0.010,
+            "foreign_pct_down_max": -0.010,
+            "foreign_pct_neutral_abs_max": 0.003,
+        },
+    )
+
+
+def make_agent(*, weight: float = 0.25) -> FlowAgent:
+    return FlowAgent(rule_config=make_rule_config(), weight=weight)
+
+
+def make_row(
+    *,
+    foreign_5d: float,
+    institution_5d: float,
+    individual_5d: float,
+    foreign_pct: float,
+    as_of_date: date = date(2026, 4, 24),
+) -> AgentFeatureRow:
+    return AgentFeatureRow.from_mapping(
+        {
+            "as_of_date": as_of_date,
+            "foreign_net_buy_krw_5d_sum": foreign_5d,
+            "institution_net_buy_krw_5d_sum": institution_5d,
+            "individual_net_buy_krw_5d_sum": individual_5d,
+            "foreign_net_buy_5d_pct_of_turnover": foreign_pct,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("row", "expected_label", "expected_score"),
+    [
+        (
+            make_row(
+                foreign_5d=1200000000000,
+                institution_5d=300000000000,
+                individual_5d=-1500000000000,
+                foreign_pct=0.012,
+            ),
+            "up",
+            0.80,
+        ),
+        (
+            make_row(
+                foreign_5d=-1000000000000,
+                institution_5d=-200000000000,
+                individual_5d=1200000000000,
+                foreign_pct=-0.013,
+            ),
+            "down",
+            -0.80,
+        ),
+        (
+            make_row(
+                foreign_5d=500000000000,
+                institution_5d=-100000000000,
+                individual_5d=-400000000000,
+                foreign_pct=0.006,
+            ),
+            "skip",
+            0.0,
+        ),
+        (
+            make_row(
+                foreign_5d=400000000000,
+                institution_5d=100000000000,
+                individual_5d=-500000000000,
+                foreign_pct=0.005,
+            ),
+            "skip",
+            0.0,
+        ),
+    ],
+)
+def test_flow_agent_truth_table(
+    row: AgentFeatureRow,
+    expected_label: str,
+    expected_score: float,
+) -> None:
+    vote = make_agent().vote(row)
+
+    assert vote.agent_name == "flow"
+    assert vote.rule_version == "flow@1.0.0"
+    assert vote.label == expected_label
+    assert vote.score == pytest.approx(expected_score)
+
+
+def test_flow_agent_preserves_specified_evidence_order_sources_and_weighted_score() -> None:
+    row = make_row(
+        foreign_5d=1200000000000,
+        institution_5d=300000000000,
+        individual_5d=-1500000000000,
+        foreign_pct=0.012,
+        as_of_date=date(2026, 4, 25),
+    )
+
+    vote = make_agent(weight=0.25).vote(row)
+
+    assert vote.weight == pytest.approx(0.25)
+    assert vote.weighted_score == pytest.approx(0.20)
+    assert tuple((item.name, item.source, item.value, item.as_of) for item in vote.evidence) == (
+        (
+            "foreign_net_buy_krw_5d_sum",
+            "KRX",
+            1200000000000,
+            date(2026, 4, 25),
+        ),
+        (
+            "institution_net_buy_krw_5d_sum",
+            "KRX",
+            300000000000,
+            date(2026, 4, 25),
+        ),
+        (
+            "individual_net_buy_krw_5d_sum",
+            "KRX",
+            -1500000000000,
+            date(2026, 4, 25),
+        ),
+        (
+            "foreign_net_buy_5d_pct_of_turnover",
+            "computed",
+            0.012,
+            date(2026, 4, 25),
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("foreign_5d", "institution_5d", "individual_5d", "foreign_pct"),
+    [
+        (nan, 300000000000, -1500000000000, 0.012),
+        (1200000000000, nan, -1500000000000, 0.012),
+        (1200000000000, 300000000000, nan, 0.012),
+        (1200000000000, 300000000000, -1500000000000, nan),
+    ],
+)
+def test_flow_agent_treats_any_nan_predicate_input_as_not_matched(
+    foreign_5d: float,
+    institution_5d: float,
+    individual_5d: float,
+    foreign_pct: float,
+) -> None:
+    vote = make_agent().vote(
+        make_row(
+            foreign_5d=foreign_5d,
+            institution_5d=institution_5d,
+            individual_5d=individual_5d,
+            foreign_pct=foreign_pct,
+        )
+    )
+
+    assert vote.label == "skip"
+    assert vote.score == pytest.approx(0.0)
+    assert vote.weighted_score == pytest.approx(0.0)
+
+
+def test_agent_feature_row_rejects_forbidden_target_columns() -> None:
+    with pytest.raises(LeakageError, match="forbidden columns"):
+        _ = AgentFeatureRow.from_mapping(
+            {
+                "as_of_date": date(2026, 4, 24),
+                "foreign_net_buy_krw_5d_sum": 1.0,
+                "institution_net_buy_krw_5d_sum": 0.0,
+                "individual_net_buy_krw_5d_sum": -1.0,
+                "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                "target_direction_label": "up",
+            }
+        )
+
+
+def test_agent_feature_row_rejects_non_whitelisted_columns() -> None:
+    with pytest.raises(LeakageError, match="non-whitelisted columns"):
+        _ = AgentFeatureRow.from_mapping(
+            {
+                "as_of_date": date(2026, 4, 24),
+                "foreign_net_buy_krw_5d_sum": 1.0,
+                "institution_net_buy_krw_5d_sum": 0.0,
+                "individual_net_buy_krw_5d_sum": -1.0,
+                "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                "institution_net_buy_5d_pct_of_turnover": 0.01,
+            }
+        )
+
+
+def test_flow_agent_exposes_spec_whitelist_verbatim() -> None:
+    assert FlowAgent.INPUT_WHITELIST == (
+        "foreign_net_buy_krw_5d_sum",
+        "institution_net_buy_krw_5d_sum",
+        "individual_net_buy_krw_5d_sum",
+        "foreign_net_buy_5d_pct_of_turnover",
+    )


### PR DESCRIPTION
## Summary
- add `FlowAgent` and strict `AgentFeatureRow` parsing for the §21 `flow@1.0.0` rules, config thresholds, evidence ordering, and weighted scores
- cover the spec truth table plus NaN handling, leakage rejection, whitelist enforcement, and evidence/source contracts in `core/tests/agents/test_flow.py`
- keep the change scoped to the owned FlowAgent files and use RED/GREEN commits referencing #13