### PR TITLE
[#18] Add target labels and walk-forward backtest dataset

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from datetime import date
+from math import isclose, log
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from .gold_features import assert_no_forbidden_gold_columns
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+    def slice(self, offset: int, length: int | None = None) -> _ArrowTable: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+BOUNDARY_TOLERANCE = 1e-12
+FEATURE_COLUMNS = (
+    "kospi_close",
+    "kospi_return_1d",
+    "kospi_return_3d",
+    "kospi_return_5d",
+    "kospi_ma5",
+    "kospi_ma20",
+    "kospi_ma5_gap",
+    "kospi_close_position",
+    "bok_base_rate",
+    "bok_base_rate_change_30d",
+    "usd_krw_close",
+    "usd_krw_return_5d",
+    "kr_bond_yield_3y",
+    "kr_bond_yield_change_30d",
+    "foreign_net_buy_krw_5d_sum",
+    "institution_net_buy_krw_5d_sum",
+    "individual_net_buy_krw_5d_sum",
+    "foreign_net_buy_5d_pct_of_turnover",
+    "kospi_per",
+    "kospi_pbr",
+    "kospi_per_percentile_252d",
+    "kospi_pbr_percentile_252d",
+    "kospi_realized_vol_20d",
+    "kospi_realized_vol_20d_percentile_252d",
+    "kospi_atr_14d",
+)
+TARGET_COLUMNS = (
+    "target_next_day_simple_return",
+    "target_next_day_log_return",
+    "target_direction_label",
+)
+OUTPUT_COLUMNS = ("trade_date", *FEATURE_COLUMNS, *TARGET_COLUMNS)
+EMPTY_ROW = {
+    "trade_date": date(1970, 1, 1),
+    **{column_name: 0.0 for column_name in FEATURE_COLUMNS},
+    "target_next_day_simple_return": 0.0,
+    "target_next_day_log_return": 0.0,
+    "target_direction_label": "",
+}
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    if rows:
+        return factory.from_pylist(rows)
+    return factory.from_pylist([cast(dict[str, object], EMPTY_ROW)]).slice(0, 0)
+
+
+def _float_value(row: dict[str, object], field_name: str) -> float | None:
+    value = row.get(field_name)
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int | float | Decimal | str):
+        return float(value)
+    return None
+
+
+def _trade_date_value(row: dict[str, object]) -> date:
+    value = row.get("trade_date", row.get("as_of_date"))
+    if not isinstance(value, date):
+        raise ValueError(f"missing or invalid trade date: {value}")
+    return value
+
+
+def _read_gold_rows(gold_dir: Path) -> list[dict[str, object]]:
+    if gold_dir.is_file():
+        parquet_paths = (gold_dir,)
+    else:
+        parquet_paths = tuple(sorted(gold_dir.rglob("*.parquet")))
+    rows: list[dict[str, object]] = []
+    for parquet_path in parquet_paths:
+        table = READ_TABLE(parquet_path)
+        parquet_rows = table.to_pylist()
+        assert_no_forbidden_gold_columns(parquet_rows[0].keys() if parquet_rows else ())
+        rows.extend(parquet_rows)
+    return rows
+
+
+def _sorted_gold_rows(gold_rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    sorted_rows = sorted(gold_rows, key=_trade_date_value)
+    for index in range(1, len(sorted_rows)):
+        if _trade_date_value(sorted_rows[index]) == _trade_date_value(sorted_rows[index - 1]):
+            raise ValueError("duplicate trade_date in gold dataset")
+    return sorted_rows
+
+
+def _build_output_row(
+    current_row: dict[str, object],
+    *,
+    target_next_day_simple_return: float,
+    target_next_day_log_return: float,
+    target_direction_label: str,
+) -> dict[str, object]:
+    output_row: dict[str, object] = {"trade_date": _trade_date_value(current_row)}
+    for column_name in FEATURE_COLUMNS:
+        output_row[column_name] = current_row[column_name]
+    output_row["target_next_day_simple_return"] = target_next_day_simple_return
+    output_row["target_next_day_log_return"] = target_next_day_log_return
+    output_row["target_direction_label"] = target_direction_label
+    return output_row
+
+
+def build_backtest_dataset(
+    gold_dir: Path,
+    output_path: Path,
+    *,
+    flat_band_abs_log_return: float = 0.001,
+) -> Path:
+    gold_rows = _sorted_gold_rows(_read_gold_rows(gold_dir))
+    backtest_rows: list[dict[str, object]] = []
+    for index, current_row in enumerate(gold_rows[:-1]):
+        next_row = gold_rows[index + 1]
+        current_close = _float_value(current_row, "kospi_close")
+        next_close = _float_value(next_row, "kospi_close")
+        if current_close is None or next_close is None or current_close <= 0.0 or next_close <= 0.0:
+            continue
+        target_next_day_simple_return = (next_close / current_close) - 1.0
+        target_next_day_log_return = log(next_close / current_close)
+        if target_next_day_log_return >= flat_band_abs_log_return or isclose(
+            target_next_day_log_return,
+            flat_band_abs_log_return,
+            abs_tol=BOUNDARY_TOLERANCE,
+        ):
+            target_direction_label = "up"
+        elif target_next_day_log_return <= -flat_band_abs_log_return or isclose(
+            target_next_day_log_return,
+            -flat_band_abs_log_return,
+            abs_tol=BOUNDARY_TOLERANCE,
+        ):
+            target_direction_label = "down"
+        else:
+            target_direction_label = "flat"
+        backtest_rows.append(
+            _build_output_row(
+                current_row,
+                target_next_day_simple_return=target_next_day_simple_return,
+                target_next_day_log_return=target_next_day_log_return,
+                target_direction_label=target_direction_label,
+            )
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(backtest_rows), output_path, compression="snappy")
+    return output_path
+
+
+__all__ = [
+    "FEATURE_COLUMNS",
+    "OUTPUT_COLUMNS",
+    "TARGET_COLUMNS",
+    "build_backtest_dataset",
+]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 from datetime import date
-from math import isclose, log
+from math import log
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -32,7 +32,6 @@ class _WriteTable(Protocol):
 
 READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
 WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
-BOUNDARY_TOLERANCE = 1e-12
 FEATURE_COLUMNS = (
     "kospi_close",
     "kospi_return_1d",
@@ -98,6 +97,18 @@ def _trade_date_value(row: dict[str, object]) -> date:
     return value
 
 
+def _target_direction_label(
+    target_next_day_log_return: float,
+    *,
+    flat_band_abs_log_return: float,
+) -> str:
+    if target_next_day_log_return >= flat_band_abs_log_return:
+        return "up"
+    if target_next_day_log_return <= -flat_band_abs_log_return:
+        return "down"
+    return "flat"
+
+
 def _read_gold_rows(gold_dir: Path) -> list[dict[str, object]]:
     if gold_dir.is_file():
         parquet_paths = (gold_dir,)
@@ -152,26 +163,15 @@ def build_backtest_dataset(
             continue
         target_next_day_simple_return = (next_close / current_close) - 1.0
         target_next_day_log_return = log(next_close / current_close)
-        if target_next_day_log_return >= flat_band_abs_log_return or isclose(
-            target_next_day_log_return,
-            flat_band_abs_log_return,
-            abs_tol=BOUNDARY_TOLERANCE,
-        ):
-            target_direction_label = "up"
-        elif target_next_day_log_return <= -flat_band_abs_log_return or isclose(
-            target_next_day_log_return,
-            -flat_band_abs_log_return,
-            abs_tol=BOUNDARY_TOLERANCE,
-        ):
-            target_direction_label = "down"
-        else:
-            target_direction_label = "flat"
         backtest_rows.append(
             _build_output_row(
                 current_row,
                 target_next_day_simple_return=target_next_day_simple_return,
                 target_next_day_log_return=target_next_day_log_return,
-                target_direction_label=target_direction_label,
+                target_direction_label=_target_direction_label(
+                    target_next_day_log_return,
+                    flat_band_abs_log_return=flat_band_abs_log_return,
+                ),
             )
         )
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/transforms/target_labels.py
@@ -78,7 +78,7 @@ def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
     factory = cast(_ArrowTableFactory, pa.Table)
     if rows:
         return factory.from_pylist(rows)
-    return factory.from_pylist([cast(dict[str, object], EMPTY_ROW)]).slice(0, 0)
+    return factory.from_pylist([EMPTY_ROW]).slice(0, 0)
 
 
 def _float_value(row: dict[str, object], field_name: str) -> float | None:
@@ -110,6 +110,7 @@ def _target_direction_label(
 
 
 def _read_gold_rows(gold_dir: Path) -> list[dict[str, object]]:
+    parquet_paths: tuple[Path, ...]
     if gold_dir.is_file():
         parquet_paths = (gold_dir,)
     else:

--- a/apps/kr-kospi/tests/contract/test_target_labels.py
+++ b/apps/kr-kospi/tests/contract/test_target_labels.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from math import exp, log
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.transforms import target_labels
+from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import (
+    build_backtest_dataset,
+)
+
+
+class _ArrowTable(Protocol):
+    @property
+    def column_names(self) -> list[str]: ...
+
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+class _FloatValue(Protocol):
+    def __call__(self, row: dict[str, object], field_name: str) -> float | None: ...
+
+
+class _TradeDateValue(Protocol):
+    def __call__(self, row: dict[str, object]) -> date: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+EXPECTED_COLUMNS = [
+    "trade_date",
+    "kospi_close",
+    "kospi_return_1d",
+    "kospi_return_3d",
+    "kospi_return_5d",
+    "kospi_ma5",
+    "kospi_ma20",
+    "kospi_ma5_gap",
+    "kospi_close_position",
+    "bok_base_rate",
+    "bok_base_rate_change_30d",
+    "usd_krw_close",
+    "usd_krw_return_5d",
+    "kr_bond_yield_3y",
+    "kr_bond_yield_change_30d",
+    "foreign_net_buy_krw_5d_sum",
+    "institution_net_buy_krw_5d_sum",
+    "individual_net_buy_krw_5d_sum",
+    "foreign_net_buy_5d_pct_of_turnover",
+    "kospi_per",
+    "kospi_pbr",
+    "kospi_per_percentile_252d",
+    "kospi_pbr_percentile_252d",
+    "kospi_realized_vol_20d",
+    "kospi_realized_vol_20d_percentile_252d",
+    "kospi_atr_14d",
+    "target_next_day_simple_return",
+    "target_next_day_log_return",
+    "target_direction_label",
+]
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_gold_rows(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _read_rows(path: Path) -> list[dict[str, object]]:
+    return READ_TABLE(path).to_pylist()
+
+
+def _feature_row(trade_date: date, close: float) -> dict[str, object]:
+    return {
+        "as_of_date": trade_date,
+        "kospi_close": close,
+        "kospi_return_1d": 0.01,
+        "kospi_return_3d": 0.02,
+        "kospi_return_5d": 0.03,
+        "kospi_ma5": close - 1.0,
+        "kospi_ma20": close - 2.0,
+        "kospi_ma5_gap": 0.001,
+        "kospi_close_position": 0.5,
+        "bok_base_rate": 3.5,
+        "bok_base_rate_change_30d": 0.1,
+        "usd_krw_close": 1320.0,
+        "usd_krw_return_5d": -0.01,
+        "kr_bond_yield_3y": 3.1,
+        "kr_bond_yield_change_30d": 0.05,
+        "foreign_net_buy_krw_5d_sum": 10.0,
+        "institution_net_buy_krw_5d_sum": 11.0,
+        "individual_net_buy_krw_5d_sum": -21.0,
+        "foreign_net_buy_5d_pct_of_turnover": 0.02,
+        "kospi_per": 10.5,
+        "kospi_pbr": 1.1,
+        "kospi_per_percentile_252d": 0.4,
+        "kospi_pbr_percentile_252d": 0.5,
+        "kospi_realized_vol_20d": 0.16,
+        "kospi_realized_vol_20d_percentile_252d": 0.6,
+        "kospi_atr_14d": 12.0,
+    }
+
+
+def test_build_backtest_dataset_computes_targets_with_spec_column_order(tmp_path: Path) -> None:
+    gold_dir = tmp_path / "data" / "gold" / "decision_features"
+    output_path = tmp_path / "data" / "gold" / "backtest_dataset.parquet"
+    start = date(2024, 1, 2)
+    closes = [
+        100.0,
+        100.0 * exp(0.001),
+        100.0,
+        100.0 * exp(0.0005),
+        100.0 * exp(0.0025),
+    ]
+    source_rows = [
+        _feature_row(start + timedelta(days=index), close) for index, close in enumerate(closes)
+    ]
+    assert all(not column.startswith("target_") for column in source_rows[0])
+    _write_gold_rows(gold_dir / "part-000.parquet", list(reversed(source_rows)))
+
+    written_path = build_backtest_dataset(gold_dir, output_path)
+
+    rows = _read_rows(written_path)
+    table = READ_TABLE(written_path)
+
+    assert written_path == output_path
+    assert table.column_names == EXPECTED_COLUMNS
+    assert [row["trade_date"] for row in rows] == [
+        start,
+        start + timedelta(days=1),
+        start + timedelta(days=2),
+        start + timedelta(days=3),
+    ]
+    assert [row["target_direction_label"] for row in rows] == ["up", "down", "flat", "up"]
+    assert abs(cast(float, rows[0]["target_next_day_log_return"]) - 0.001) < 1e-12
+    assert abs(cast(float, rows[1]["target_next_day_log_return"]) + 0.001) < 1e-12
+    assert abs(cast(float, rows[2]["target_next_day_log_return"]) - 0.0005) < 1e-12
+    assert abs(cast(float, rows[0]["target_next_day_simple_return"]) - (exp(0.001) - 1.0)) < 1e-12
+    assert abs(cast(float, rows[1]["target_next_day_simple_return"]) - (exp(-0.001) - 1.0)) < 1e-12
+    assert abs(cast(float, rows[2]["target_next_day_simple_return"]) - (exp(0.0005) - 1.0)) < 1e-12
+    assert all(not key.startswith("future_") for key in rows[0])
+    assert sorted(key for key in rows[0] if key.startswith("target_")) == [
+        "target_direction_label",
+        "target_next_day_log_return",
+        "target_next_day_simple_return",
+    ]
+
+
+def test_build_backtest_dataset_drops_rows_with_missing_next_day_target_inputs(
+    tmp_path: Path,
+) -> None:
+    gold_dir = tmp_path / "gold" / "decision_features"
+    output_path = tmp_path / "gold" / "backtest_dataset.parquet"
+    start = date(2024, 1, 2)
+    source_rows = [
+        _feature_row(start, 100.0),
+        _feature_row(start + timedelta(days=1), 101.0),
+        _feature_row(start + timedelta(days=2), 0.0),
+    ]
+
+    _write_gold_rows(gold_dir / "part-000.parquet", source_rows)
+
+    rows = _read_rows(build_backtest_dataset(gold_dir, output_path))
+
+    assert [row["trade_date"] for row in rows] == [start]
+    assert abs(cast(float, rows[0]["target_next_day_log_return"]) - log(101.0 / 100.0)) < 1e-12
+
+
+def test_build_backtest_dataset_accepts_single_parquet_file_and_writes_empty_output_schema(
+    tmp_path: Path,
+) -> None:
+    gold_file = tmp_path / "decision_features.parquet"
+    output_path = tmp_path / "backtest_dataset.parquet"
+
+    _write_gold_rows(gold_file, [_feature_row(date(2024, 1, 2), 100.0)])
+
+    written_path = build_backtest_dataset(gold_file, output_path)
+    table = READ_TABLE(written_path)
+
+    assert table.column_names == EXPECTED_COLUMNS
+    assert table.to_pylist() == []
+
+
+def test_target_label_helpers_handle_invalid_numeric_and_trade_date_inputs() -> None:
+    float_value = cast(_FloatValue, getattr(target_labels, "_float_value"))
+    trade_date_value = cast(_TradeDateValue, getattr(target_labels, "_trade_date_value"))
+
+    assert float_value({"kospi_close": None}, "kospi_close") is None
+    assert float_value({"kospi_close": True}, "kospi_close") is None
+    assert float_value({"kospi_close": object()}, "kospi_close") is None
+    with pytest.raises(ValueError, match="^missing or invalid trade date: None$"):
+        _ = trade_date_value({})
+
+
+def test_build_backtest_dataset_raises_for_duplicate_trade_dates(tmp_path: Path) -> None:
+    gold_dir = tmp_path / "gold" / "decision_features"
+    duplicate_day = date(2024, 1, 2)
+
+    _write_gold_rows(
+        gold_dir / "part-000.parquet",
+        [
+            _feature_row(duplicate_day, 100.0),
+            _feature_row(duplicate_day, 101.0),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="^duplicate trade_date in gold dataset$"):
+        _ = build_backtest_dataset(gold_dir, tmp_path / "gold" / "backtest_dataset.parquet")

--- a/apps/kr-kospi/tests/contract/test_target_labels.py
+++ b/apps/kr-kospi/tests/contract/test_target_labels.py
@@ -42,6 +42,12 @@ class _TradeDateValue(Protocol):
     def __call__(self, row: dict[str, object]) -> date: ...
 
 
+class _TargetDirectionLabel(Protocol):
+    def __call__(
+        self, target_next_day_log_return: float, *, flat_band_abs_log_return: float
+    ) -> str: ...
+
+
 READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
 WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
 
@@ -130,10 +136,10 @@ def test_build_backtest_dataset_computes_targets_with_spec_column_order(tmp_path
     start = date(2024, 1, 2)
     closes = [
         100.0,
-        100.0 * exp(0.001),
-        100.0,
-        100.0 * exp(0.0005),
-        100.0 * exp(0.0025),
+        100.0 * exp(0.0012),
+        100.0 * exp(0.0012) * exp(-0.0012),
+        100.0 * exp(0.0012) * exp(-0.0012) * exp(0.0005),
+        100.0 * exp(0.0012) * exp(-0.0012) * exp(0.0005) * exp(0.002),
     ]
     source_rows = [
         _feature_row(start + timedelta(days=index), close) for index, close in enumerate(closes)
@@ -155,11 +161,11 @@ def test_build_backtest_dataset_computes_targets_with_spec_column_order(tmp_path
         start + timedelta(days=3),
     ]
     assert [row["target_direction_label"] for row in rows] == ["up", "down", "flat", "up"]
-    assert abs(cast(float, rows[0]["target_next_day_log_return"]) - 0.001) < 1e-12
-    assert abs(cast(float, rows[1]["target_next_day_log_return"]) + 0.001) < 1e-12
+    assert abs(cast(float, rows[0]["target_next_day_log_return"]) - 0.0012) < 1e-12
+    assert abs(cast(float, rows[1]["target_next_day_log_return"]) + 0.0012) < 1e-12
     assert abs(cast(float, rows[2]["target_next_day_log_return"]) - 0.0005) < 1e-12
-    assert abs(cast(float, rows[0]["target_next_day_simple_return"]) - (exp(0.001) - 1.0)) < 1e-12
-    assert abs(cast(float, rows[1]["target_next_day_simple_return"]) - (exp(-0.001) - 1.0)) < 1e-12
+    assert abs(cast(float, rows[0]["target_next_day_simple_return"]) - (exp(0.0012) - 1.0)) < 1e-12
+    assert abs(cast(float, rows[1]["target_next_day_simple_return"]) - (exp(-0.0012) - 1.0)) < 1e-12
     assert abs(cast(float, rows[2]["target_next_day_simple_return"]) - (exp(0.0005) - 1.0)) < 1e-12
     assert all(not key.startswith("future_") for key in rows[0])
     assert sorted(key for key in rows[0] if key.startswith("target_")) == [
@@ -207,10 +213,17 @@ def test_build_backtest_dataset_accepts_single_parquet_file_and_writes_empty_out
 def test_target_label_helpers_handle_invalid_numeric_and_trade_date_inputs() -> None:
     float_value = cast(_FloatValue, getattr(target_labels, "_float_value"))
     trade_date_value = cast(_TradeDateValue, getattr(target_labels, "_trade_date_value"))
+    target_direction_label = cast(
+        _TargetDirectionLabel,
+        getattr(target_labels, "_target_direction_label"),
+    )
 
     assert float_value({"kospi_close": None}, "kospi_close") is None
     assert float_value({"kospi_close": True}, "kospi_close") is None
     assert float_value({"kospi_close": object()}, "kospi_close") is None
+    assert target_direction_label(0.001, flat_band_abs_log_return=0.001) == "up"
+    assert target_direction_label(-0.001, flat_band_abs_log_return=0.001) == "down"
+    assert target_direction_label(0.0, flat_band_abs_log_return=0.001) == "flat"
     with pytest.raises(ValueError, match="^missing or invalid trade date: None$"):
         _ = trade_date_value({})
 

--- a/core/src/kospi_decision_pipeline_core/backtest/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .walk_forward import WalkForwardFold, WalkForwardSplitter
+
+__all__ = ["WalkForwardFold", "WalkForwardSplitter"]

--- a/core/src/kospi_decision_pipeline_core/backtest/walk_forward.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/walk_forward.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from datetime import date
+
+
+@dataclass(frozen=True, slots=True)
+class WalkForwardFold:
+    fold_id: int
+    train_cutoff: date
+    train_indices: tuple[int, ...]
+    test_indices: tuple[int, ...]
+
+
+class WalkForwardSplitter:
+    _min_train_rows: int
+    _test_fold_size: int
+    _gap_days: int
+
+    def __init__(
+        self,
+        *,
+        min_train_rows: int = 252,
+        test_fold_size: int = 20,
+        gap_days: int = 0,
+    ) -> None:
+        self._min_train_rows = min_train_rows
+        self._test_fold_size = test_fold_size
+        self._gap_days = gap_days
+
+    def split(self, trade_dates: Sequence[date]) -> Iterator[WalkForwardFold]:
+        sorted_trade_dates = tuple(sorted(trade_dates))
+        if len(sorted_trade_dates) <= self._min_train_rows + self._gap_days:
+            return
+        train_indices = tuple(range(self._min_train_rows))
+        fold_id = 1
+        while True:
+            train_cutoff = sorted_trade_dates[train_indices[-1]]
+            test_start = train_indices[-1] + 1 + self._gap_days
+            if test_start >= len(sorted_trade_dates):
+                return
+            test_stop = min(test_start + self._test_fold_size, len(sorted_trade_dates))
+            test_indices = tuple(range(test_start, test_stop))
+            for test_index in test_indices:
+                if sorted_trade_dates[test_index] <= train_cutoff:
+                    raise ValueError("test row date must be strictly greater than train_cutoff")
+            yield WalkForwardFold(
+                fold_id=fold_id,
+                train_cutoff=train_cutoff,
+                train_indices=train_indices,
+                test_indices=test_indices,
+            )
+            train_indices = (*train_indices, *test_indices)
+            fold_id += 1

--- a/core/src/kospi_decision_pipeline_core/backtest/walk_forward.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/walk_forward.py
@@ -25,31 +25,37 @@ class WalkForwardSplitter:
         test_fold_size: int = 20,
         gap_days: int = 0,
     ) -> None:
+        if min_train_rows <= 0:
+            raise ValueError("min_train_rows must be positive")
+        if test_fold_size <= 0:
+            raise ValueError("test_fold_size must be positive")
+        if gap_days < 0:
+            raise ValueError("gap_days must be non-negative")
         self._min_train_rows = min_train_rows
         self._test_fold_size = test_fold_size
         self._gap_days = gap_days
 
     def split(self, trade_dates: Sequence[date]) -> Iterator[WalkForwardFold]:
-        sorted_trade_dates = tuple(sorted(trade_dates))
-        if len(sorted_trade_dates) <= self._min_train_rows + self._gap_days:
+        sorted_positions = tuple(sorted(range(len(trade_dates)), key=trade_dates.__getitem__))
+        if len(sorted_positions) <= self._min_train_rows + self._gap_days:
             return
-        train_indices = tuple(range(self._min_train_rows))
+        train_positions = tuple(range(self._min_train_rows))
         fold_id = 1
         while True:
-            train_cutoff = sorted_trade_dates[train_indices[-1]]
-            test_start = train_indices[-1] + 1 + self._gap_days
-            if test_start >= len(sorted_trade_dates):
+            train_cutoff = trade_dates[sorted_positions[train_positions[-1]]]
+            test_start = train_positions[-1] + 1 + self._gap_days
+            if test_start >= len(sorted_positions):
                 return
-            test_stop = min(test_start + self._test_fold_size, len(sorted_trade_dates))
-            test_indices = tuple(range(test_start, test_stop))
-            for test_index in test_indices:
-                if sorted_trade_dates[test_index] <= train_cutoff:
+            test_stop = min(test_start + self._test_fold_size, len(sorted_positions))
+            test_positions = tuple(range(test_start, test_stop))
+            for test_position in test_positions:
+                if trade_dates[sorted_positions[test_position]] <= train_cutoff:
                     raise ValueError("test row date must be strictly greater than train_cutoff")
             yield WalkForwardFold(
                 fold_id=fold_id,
                 train_cutoff=train_cutoff,
-                train_indices=train_indices,
-                test_indices=test_indices,
+                train_indices=tuple(sorted_positions[position] for position in train_positions),
+                test_indices=tuple(sorted_positions[position] for position in test_positions),
             )
-            train_indices = (*train_indices, *test_indices)
+            train_positions = (*train_positions, *test_positions)
             fold_id += 1

--- a/core/tests/backtest/test_walk_forward.py
+++ b/core/tests/backtest/test_walk_forward.py
@@ -105,3 +105,33 @@ def test_walk_forward_splitter_raises_when_test_row_date_is_not_strictly_greater
 
 def test_walk_forward_splitter_yields_no_folds_when_rows_are_insufficient() -> None:
     assert list(WalkForwardSplitter().split(_trade_dates(251))) == []
+
+
+def test_walk_forward_splitter_returns_original_indices_for_unsorted_inputs() -> None:
+    trade_dates = _trade_dates(273)
+    unsorted_trade_dates = [*trade_dates[1:252], trade_dates[0], *trade_dates[252:]]
+
+    folds = list(WalkForwardSplitter().split(unsorted_trade_dates))
+
+    assert folds[0] == WalkForwardFold(
+        fold_id=1,
+        train_cutoff=trade_dates[251],
+        train_indices=tuple([251, *range(251)]),
+        test_indices=tuple(range(252, 272)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"min_train_rows": 0}, "^min_train_rows must be positive$"),
+        ({"test_fold_size": 0}, "^test_fold_size must be positive$"),
+        ({"gap_days": -1}, "^gap_days must be non-negative$"),
+    ],
+)
+def test_walk_forward_splitter_validates_constructor_inputs(
+    kwargs: dict[str, int],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        _ = WalkForwardSplitter(**kwargs)

--- a/core/tests/backtest/test_walk_forward.py
+++ b/core/tests/backtest/test_walk_forward.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from datetime import date, timedelta
+from importlib import import_module
+from typing import Protocol, cast
+
+import pytest
+
+_walk_forward = import_module("kospi_decision_pipeline_core.backtest.walk_forward")
+
+
+class _WalkForwardFoldCtor(Protocol):
+    def __call__(
+        self,
+        *,
+        fold_id: int,
+        train_cutoff: date,
+        train_indices: tuple[int, ...],
+        test_indices: tuple[int, ...],
+    ) -> object: ...
+
+
+class _WalkForwardSplitterInstance(Protocol):
+    def split(self, trade_dates: Sequence[date]) -> Iterator[object]: ...
+
+
+class _WalkForwardSplitterCtor(Protocol):
+    def __call__(
+        self,
+        *,
+        min_train_rows: int = 252,
+        test_fold_size: int = 20,
+        gap_days: int = 0,
+    ) -> _WalkForwardSplitterInstance: ...
+
+
+WalkForwardFold = cast(_WalkForwardFoldCtor, getattr(_walk_forward, "WalkForwardFold"))
+WalkForwardSplitter = cast(_WalkForwardSplitterCtor, getattr(_walk_forward, "WalkForwardSplitter"))
+
+
+def _trade_dates(count: int) -> list[date]:
+    start = date(2024, 1, 1)
+    return [start + timedelta(days=index) for index in range(count)]
+
+
+def test_walk_forward_splitter_yields_expanding_window_folds_with_final_partial() -> None:
+    trade_dates = _trade_dates(313)
+
+    folds = list(WalkForwardSplitter().split(trade_dates))
+
+    assert folds == [
+        WalkForwardFold(
+            fold_id=1,
+            train_cutoff=trade_dates[251],
+            train_indices=tuple(range(252)),
+            test_indices=tuple(range(252, 272)),
+        ),
+        WalkForwardFold(
+            fold_id=2,
+            train_cutoff=trade_dates[271],
+            train_indices=tuple(range(272)),
+            test_indices=tuple(range(272, 292)),
+        ),
+        WalkForwardFold(
+            fold_id=3,
+            train_cutoff=trade_dates[291],
+            train_indices=tuple(range(292)),
+            test_indices=tuple(range(292, 312)),
+        ),
+        WalkForwardFold(
+            fold_id=4,
+            train_cutoff=trade_dates[311],
+            train_indices=tuple(range(312)),
+            test_indices=(312,),
+        ),
+    ]
+
+
+def test_walk_forward_splitter_respects_gap_days() -> None:
+    trade_dates = _trade_dates(254)
+
+    folds = list(WalkForwardSplitter(test_fold_size=1, gap_days=1).split(trade_dates))
+
+    assert folds == [
+        WalkForwardFold(
+            fold_id=1,
+            train_cutoff=trade_dates[251],
+            train_indices=tuple(range(252)),
+            test_indices=(253,),
+        )
+    ]
+
+
+def test_walk_forward_splitter_raises_when_test_row_date_is_not_strictly_greater() -> None:
+    trade_dates = _trade_dates(252)
+    trade_dates.append(trade_dates[-1])
+
+    with pytest.raises(
+        ValueError,
+        match="^test row date must be strictly greater than train_cutoff$",
+    ):
+        _ = list(WalkForwardSplitter(test_fold_size=1).split(trade_dates))
+
+
+def test_walk_forward_splitter_yields_no_folds_when_rows_are_insufficient() -> None:
+    assert list(WalkForwardSplitter().split(_trade_dates(251))) == []


### PR DESCRIPTION
## Summary
- add a deterministic backtest dataset builder that joins Gold feature rows with next-day simple/log return targets and up/down/flat labels
- add an expanding-window walk-forward splitter with strict date-cutoff validation and gap-day handling
- cover the new contracts with 100% line and branch coverage on the new modules

## Verification
- ./.venv/bin/python -m pytest apps/kr-kospi/tests/contract/test_target_labels.py core/tests/backtest/test_walk_forward.py --cov=kospi_decision_pipeline_app_kr_kospi.transforms.target_labels --cov=kospi_decision_pipeline_core.backtest --cov-report=term-missing
- ./.venv/bin/python -m pytest core/tests apps/kr-kospi/tests
- ./.venv/bin/python -m build

Closes #18