### PR TITLE
Implement Issue #16 — DecisionAgent weighted aggregation

### DIFF
--- a/core/src/kospi_decision_pipeline_core/agents/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/agents/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .decision import DecisionAgent, compute_config_signature
 from .domestic_macro import DomesticMacroAgent
 from .flow import AgentFeatureRow, FlowAgent
 from .technical import TechnicalAgent
@@ -10,9 +11,11 @@ from .volatility import VolatilityAgent
 
 __all__ = [
     "AgentFeatureRow",
+    "DecisionAgent",
     "DomesticMacroAgent",
     "FlowAgent",
     "TechnicalAgent",
     "ValuationAgent",
     "VolatilityAgent",
+    "compute_config_signature",
 ]

--- a/core/src/kospi_decision_pipeline_core/agents/decision.py
+++ b/core/src/kospi_decision_pipeline_core/agents/decision.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import ClassVar, cast
+
+import yaml
+
+from ..schemas.decisions import AgentVote, DecisionResult, ModelLabel
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionAgent:
+    threshold_up: float
+    threshold_down: float
+    config_signature: str
+
+    AGENT_NAME: ClassVar[str] = "decision"
+
+    def decide(
+        self,
+        *,
+        decision_date: date,
+        votes: Sequence[AgentVote],
+        snapshot_id: str,
+    ) -> DecisionResult:
+        votes_sorted = _sorted_unique_votes(votes)
+        aggregate_score = sum(vote.weight * _signed(vote.label) for vote in votes_sorted)
+        return DecisionResult(
+            decision_date=decision_date,
+            label=_decision_label(
+                aggregate_score=aggregate_score,
+                threshold_up=self.threshold_up,
+                threshold_down=self.threshold_down,
+            ),
+            aggregate_score=aggregate_score,
+            threshold_up=self.threshold_up,
+            threshold_down=self.threshold_down,
+            votes=votes_sorted,
+            config_signature=self.config_signature,
+            snapshot_id=snapshot_id,
+        )
+
+
+def compute_config_signature(yaml_path: Path) -> str:
+    canonical_payload = cast(object, yaml.safe_load(yaml_path.read_text(encoding="utf-8")))
+    canonical_text = yaml.safe_dump(
+        canonical_payload,
+        default_flow_style=False,
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical_text.encode("utf-8")).hexdigest()
+
+
+def _sorted_unique_votes(votes: Sequence[AgentVote]) -> tuple[AgentVote, ...]:
+    if len(votes) == 0:
+        raise ValueError("at least one vote required")
+
+    votes_sorted = tuple(sorted(votes, key=lambda vote: vote.agent_name))
+    for index in range(1, len(votes_sorted)):
+        previous_vote = votes_sorted[index - 1]
+        current_vote = votes_sorted[index]
+        if previous_vote.agent_name == current_vote.agent_name:
+            raise ValueError(f"duplicate agent_name: {current_vote.agent_name}")
+    return votes_sorted
+
+
+def _signed(label: ModelLabel) -> int:
+    if label == "up":
+        return 1
+    if label == "down":
+        return -1
+    return 0
+
+
+def _decision_label(
+    *,
+    aggregate_score: float,
+    threshold_up: float,
+    threshold_down: float,
+) -> ModelLabel:
+    if aggregate_score > threshold_up:
+        return "up"
+    if aggregate_score < threshold_down:
+        return "down"
+    return "skip"
+
+
+__all__ = ["DecisionAgent", "compute_config_signature"]

--- a/core/tests/agents/test_decision.py
+++ b/core/tests/agents/test_decision.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from kospi_decision_pipeline_core.agents import DecisionAgent, compute_config_signature
+from kospi_decision_pipeline_core.schemas.decisions import AgentVote, EvidenceItem
+
+
+DECISION_DATE = date(2026, 4, 25)
+CONFIG_SIGNATURE = "cfg:decision"
+SNAPSHOT_ID = "snapshot:2026-04-25"
+
+
+def make_vote(
+    agent_name: str,
+    label: Literal["up", "down", "skip"],
+    weight: float,
+    *,
+    score: float | None = None,
+) -> AgentVote:
+    resolved_score = score
+    if resolved_score is None:
+        if label == "up":
+            resolved_score = 0.70
+        elif label == "down":
+            resolved_score = -0.70
+        else:
+            resolved_score = 0.0
+
+    return AgentVote(
+        agent_name=agent_name,
+        rule_version=f"{agent_name}@1.0.0",
+        label=label,
+        score=resolved_score,
+        weight=weight,
+        weighted_score=resolved_score * weight,
+        evidence=(
+            EvidenceItem(
+                name=f"{agent_name}_signal",
+                value=resolved_score,
+                source="test",
+                as_of=DECISION_DATE,
+            ),
+        ),
+    )
+
+
+def make_agent(*, threshold_up: float = 0.25, threshold_down: float = -0.25) -> DecisionAgent:
+    return DecisionAgent(
+        threshold_up=threshold_up,
+        threshold_down=threshold_down,
+        config_signature=CONFIG_SIGNATURE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("votes", "expected_score", "expected_label"),
+    [
+        (
+            (
+                make_vote("technical", "up", 0.30),
+                make_vote("domestic_macro", "up", 0.20),
+                make_vote("flow", "up", 0.25),
+                make_vote("valuation", "up", 0.10),
+                make_vote("volatility", "up", 0.15),
+            ),
+            1.0,
+            "up",
+        ),
+        (
+            (
+                make_vote("technical", "down", 0.30),
+                make_vote("domestic_macro", "down", 0.20),
+                make_vote("flow", "down", 0.25),
+                make_vote("valuation", "down", 0.10),
+                make_vote("volatility", "down", 0.15),
+            ),
+            -1.0,
+            "down",
+        ),
+        (
+            (
+                make_vote("technical", "skip", 0.30),
+                make_vote("domestic_macro", "skip", 0.20),
+                make_vote("flow", "skip", 0.25),
+                make_vote("valuation", "skip", 0.10),
+                make_vote("volatility", "skip", 0.15),
+            ),
+            0.0,
+            "skip",
+        ),
+        (
+            (make_vote("alpha", "up", 0.25), make_vote("beta", "skip", 0.75)),
+            0.25,
+            "skip",
+        ),
+        (
+            (make_vote("alpha", "down", 0.25), make_vote("beta", "skip", 0.75)),
+            -0.25,
+            "skip",
+        ),
+        (
+            (make_vote("alpha", "up", 0.26), make_vote("beta", "skip", 0.74)),
+            0.26,
+            "up",
+        ),
+        (
+            (make_vote("alpha", "down", 0.26), make_vote("beta", "skip", 0.74)),
+            -0.26,
+            "down",
+        ),
+        (
+            (
+                make_vote("technical", "up", 0.30, score=0.70),
+                make_vote("flow", "up", 0.25, score=0.80),
+                make_vote("domestic_macro", "skip", 0.20),
+                make_vote("valuation", "skip", 0.10),
+                make_vote("volatility", "skip", 0.15),
+            ),
+            0.55,
+            "up",
+        ),
+        (
+            (
+                make_vote("technical", "up", 0.30, score=0.70),
+                make_vote("flow", "down", 0.25, score=-0.80),
+                make_vote("domestic_macro", "skip", 0.20),
+                make_vote("valuation", "skip", 0.10),
+                make_vote("volatility", "skip", 0.15),
+            ),
+            0.05,
+            "skip",
+        ),
+    ],
+)
+def test_decision_agent_aggregation_truth_table(
+    votes: tuple[AgentVote, ...],
+    expected_score: float,
+    expected_label: str,
+) -> None:
+    result = make_agent().decide(
+        decision_date=DECISION_DATE,
+        votes=votes,
+        snapshot_id=SNAPSHOT_ID,
+    )
+
+    assert abs(result.aggregate_score - expected_score) < 1e-12
+    assert result.label == expected_label
+
+
+def test_decision_agent_sorts_votes_and_populates_result_fields() -> None:
+    votes = (
+        make_vote("volatility", "skip", 0.15),
+        make_vote("technical", "up", 0.30),
+        make_vote("flow", "up", 0.25),
+        make_vote("valuation", "skip", 0.10),
+        make_vote("domestic_macro", "skip", 0.20),
+    )
+
+    result = make_agent().decide(
+        decision_date=DECISION_DATE,
+        votes=votes,
+        snapshot_id=SNAPSHOT_ID,
+    )
+
+    assert tuple(vote.agent_name for vote in result.votes) == (
+        "domestic_macro",
+        "flow",
+        "technical",
+        "valuation",
+        "volatility",
+    )
+    assert result.decision_date == DECISION_DATE
+    assert result.threshold_up == 0.25
+    assert result.threshold_down == -0.25
+    assert result.config_signature == CONFIG_SIGNATURE
+    assert result.snapshot_id == SNAPSHOT_ID
+
+
+def test_decision_agent_rejects_empty_votes() -> None:
+    with pytest.raises(ValueError, match="at least one vote required"):
+        _ = make_agent().decide(
+            decision_date=DECISION_DATE,
+            votes=(),
+            snapshot_id=SNAPSHOT_ID,
+        )
+
+
+def test_decision_agent_rejects_duplicate_agent_names() -> None:
+    with pytest.raises(ValueError, match="duplicate agent_name: technical"):
+        _ = make_agent().decide(
+            decision_date=DECISION_DATE,
+            votes=(
+                make_vote("technical", "up", 0.30),
+                make_vote("technical", "down", 0.70),
+            ),
+            snapshot_id=SNAPSHOT_ID,
+        )
+
+
+def test_decision_agent_is_deterministic_across_input_order() -> None:
+    first_votes = (
+        make_vote("volatility", "skip", 0.15),
+        make_vote("technical", "up", 0.30),
+        make_vote("flow", "up", 0.25),
+        make_vote("valuation", "skip", 0.10),
+        make_vote("domestic_macro", "skip", 0.20),
+    )
+    second_votes = (
+        make_vote("domestic_macro", "skip", 0.20),
+        make_vote("valuation", "skip", 0.10),
+        make_vote("flow", "up", 0.25),
+        make_vote("technical", "up", 0.30),
+        make_vote("volatility", "skip", 0.15),
+    )
+
+    first = make_agent().decide(
+        decision_date=DECISION_DATE,
+        votes=first_votes,
+        snapshot_id=SNAPSHOT_ID,
+    )
+    second = make_agent().decide(
+        decision_date=DECISION_DATE,
+        votes=second_votes,
+        snapshot_id=SNAPSHOT_ID,
+    )
+
+    assert first == second
+
+
+def test_compute_config_signature_is_stable_for_equal_yaml(tmp_path: Path) -> None:
+    left = tmp_path / "left.yaml"
+    right = tmp_path / "right.yaml"
+    _ = left.write_text(
+        "weights:\n  technical: 0.3\nthresholds:\n  up: 0.25\n  down: -0.25\n", encoding="utf-8"
+    )
+    _ = right.write_text(
+        "thresholds:\n  down: -0.25\n  up: 0.25\nweights:\n  technical: 0.3\n",
+        encoding="utf-8",
+    )
+
+    assert compute_config_signature(left) == compute_config_signature(right)
+
+
+def test_compute_config_signature_changes_when_yaml_changes(tmp_path: Path) -> None:
+    left = tmp_path / "left.yaml"
+    right = tmp_path / "right.yaml"
+    _ = left.write_text("thresholds:\n  up: 0.25\n  down: -0.25\n", encoding="utf-8")
+    _ = right.write_text("thresholds:\n  up: 0.26\n  down: -0.25\n", encoding="utf-8")
+
+    assert compute_config_signature(left) != compute_config_signature(right)
+
+
+def test_compute_config_signature_ignores_whitespace_only_differences(tmp_path: Path) -> None:
+    left = tmp_path / "left.yaml"
+    right = tmp_path / "right.yaml"
+    _ = left.write_text("weights:\n  technical: 0.3\n", encoding="utf-8")
+    _ = right.write_text("weights:\n\n  technical: 0.3\n\n", encoding="utf-8")
+
+    assert compute_config_signature(left) == compute_config_signature(right)


### PR DESCRIPTION
## Summary
- add `DecisionAgent` with deterministic vote ordering, label-based signed weighted aggregation, strict threshold handling, and populated `DecisionResult` metadata for #16
- add canonicalized YAML SHA-256 config signature support for `agents.yaml`
- cover aggregation truth table, threshold boundaries, duplicate/empty vote validation, deterministic ordering, and config-signature stability with 100% line+branch coverage on new code