### PR TITLE
Wire ABDP ScenarioRunner with rule agents and DecisionAgent (#17)

### DIFF
--- a/apps/kr-kospi/config/scenario.kospi.next_day.yaml
+++ b/apps/kr-kospi/config/scenario.kospi.next_day.yaml
@@ -7,3 +7,8 @@ agents:
   - valuation
   - volatility
   - decision
+
+runtime:
+  agents_config_path: apps/kr-kospi/config/agents.yaml
+  features_path: data/gold/features.parquet
+  output_dir: data/decisions

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -5,6 +5,8 @@ from datetime import date
 import os
 from pathlib import Path
 
+from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario
+
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry, LiveConnectorRegistry
 from .transforms.gold_features import GoldFeatureBuilder, gold_lookback_start, gold_sha256
 from .transforms.silver import DATASET_DEFINITIONS, SilverNormalizer, silver_sha256
@@ -111,6 +113,22 @@ def run_build_features_command(
     raise ValueError(f"unsupported feature layer: {layer}")
 
 
+def run_scenario_command(
+    *,
+    decision_date: str,
+    scenario: str,
+    features: str,
+    output_dir: str,
+) -> int:
+    _ = run_kospi_scenario(
+        Path(scenario),
+        parse_date(decision_date),
+        Path(features) if features != "" else None,
+        Path(output_dir) if output_dir != "" else None,
+    )
+    return 0
+
+
 class _CliArgs(argparse.Namespace):
     cmd: str | None = None
     layer: str = ""
@@ -121,6 +139,9 @@ class _CliArgs(argparse.Namespace):
     bronze_dir: str = "data/bronze"
     silver_dir: str = "data/silver"
     output_dir: str = ""
+    scenario: str = ""
+    features: str = ""
+    decision_date: str = ""
     live: bool = False
 
 
@@ -150,6 +171,14 @@ def main(argv: list[str] | None = None) -> int:
     _ = build_features_parser.add_argument("--bronze-dir", default="data/bronze")
     _ = build_features_parser.add_argument("--silver-dir", default="data/silver")
     _ = build_features_parser.add_argument("--out", dest="output_dir", default="")
+    run_scenario_parser = sub.add_parser("run-scenario", help="run ABDP next-day scenario")
+    _ = run_scenario_parser.add_argument("--date", dest="decision_date", required=True)
+    _ = run_scenario_parser.add_argument(
+        "--scenario",
+        default="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+    )
+    _ = run_scenario_parser.add_argument("--features", default="")
+    _ = run_scenario_parser.add_argument("--out", dest="output_dir", default="")
     for name in ("run", "backtest", "report"):
         _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
     args = parser.parse_args(argv, namespace=_CliArgs())
@@ -183,6 +212,13 @@ def main(argv: list[str] | None = None) -> int:
             bronze_dir=str(args.bronze_dir),
             silver_dir=str(args.silver_dir),
             output_dir=output_dir,
+        )
+    if cmd == "run-scenario":
+        return run_scenario_command(
+            decision_date=str(args.decision_date),
+            scenario=str(args.scenario),
+            features=str(args.features),
+            output_dir=str(args.output_dir),
         )
     print(f"{cmd}: not yet implemented")
     return 0

--- a/apps/kr-kospi/tests/integration/test_run_scenario.py
+++ b/apps/kr-kospi/tests/integration/test_run_scenario.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from kospi_decision_pipeline_app_kr_kospi.cli import main
+from kospi_decision_pipeline_core.schemas.serialization import parse_decision_result
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_features(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def test_run_scenario_cli_end_to_end(tmp_path: Path) -> None:
+    agents_path = tmp_path / "config" / "agents.yaml"
+    scenario_path = tmp_path / "config" / "scenario.yaml"
+    features_path = tmp_path / "data" / "gold" / "features.parquet"
+    output_root = tmp_path / "data" / "decisions"
+    _write_yaml(
+        agents_path,
+        {
+            "weights": {
+                "technical": 0.30,
+                "domestic_macro": 0.20,
+                "flow": 0.25,
+                "valuation": 0.10,
+                "volatility": 0.15,
+            },
+            "thresholds": {"up": 0.25, "down": -0.25},
+            "agents": {
+                "technical": {
+                    "rule_version": "technical@1.0.0",
+                    "thresholds": {
+                        "ma5_gap_up_min": 0.005,
+                        "close_position_up_min": 0.60,
+                        "return_5d_up_min": 0.010,
+                        "ma5_gap_down_max": -0.005,
+                        "close_position_down_max": 0.40,
+                        "return_5d_down_max": -0.010,
+                    },
+                },
+                "domestic_macro": {
+                    "rule_version": "domestic_macro@1.0.0",
+                    "thresholds": {
+                        "bok_rate_change_up_max": 0.00,
+                        "usdkrw_return_5d_up_max": 0.010,
+                        "bond_yield_change_30d_up_max": 0.05,
+                        "bok_rate_change_down_min": 0.25,
+                        "usdkrw_return_5d_down_min": 0.020,
+                        "bond_yield_change_30d_down_min": 0.10,
+                        "usdkrw_return_5d_mixed_pos_min": 0.015,
+                        "usdkrw_return_5d_mixed_neg_max": -0.015,
+                        "bond_yield_change_30d_mixed_pos_min": 0.05,
+                        "bond_yield_change_30d_mixed_neg_max": 0.00,
+                    },
+                },
+                "flow": {
+                    "rule_version": "flow@1.0.0",
+                    "thresholds": {
+                        "foreign_pct_up_min": 0.010,
+                        "foreign_pct_down_max": -0.010,
+                        "foreign_pct_neutral_abs_max": 0.003,
+                    },
+                },
+                "valuation": {
+                    "rule_version": "valuation@1.0.0",
+                    "thresholds": {
+                        "per_percentile_up_max": 0.30,
+                        "pbr_percentile_up_max": 0.30,
+                        "per_percentile_down_min": 0.70,
+                        "pbr_percentile_down_min": 0.70,
+                        "fair_value_center": 0.50,
+                        "fair_value_half_band": 0.10,
+                    },
+                },
+                "volatility": {
+                    "rule_version": "volatility@1.0.0",
+                    "thresholds": {
+                        "realized_vol_20d_up_max": 0.18,
+                        "realized_vol_pct_up_max": 0.30,
+                        "atr_14d_up_max": 35.0,
+                        "realized_vol_pct_down_min": 0.80,
+                        "realized_vol_20d_down_min": 0.25,
+                        "atr_14d_down_min": 45.0,
+                        "realized_vol_pct_mid_low": 0.30,
+                        "realized_vol_pct_mid_high": 0.80,
+                    },
+                },
+            },
+        },
+    )
+    _write_yaml(
+        scenario_path,
+        {
+            "scenario_id": "kospi.next_day",
+            "horizon": "next_day",
+            "agents": [
+                "technical",
+                "domestic_macro",
+                "flow",
+                "valuation",
+                "volatility",
+                "decision",
+            ],
+            "runtime": {
+                "agents_config_path": str(agents_path),
+                "features_path": str(features_path),
+                "output_dir": str(output_root),
+            },
+        },
+    )
+    _write_features(
+        features_path,
+        [
+            {
+                "as_of_date": date(2025, 2, 13),
+                "kospi_return_1d": 0.01,
+                "kospi_return_5d": 0.02,
+                "kospi_ma5_gap": 0.01,
+                "kospi_close_position": 0.75,
+                "bok_base_rate_change_30d": 0.0,
+                "usd_krw_return_5d": 0.0,
+                "kr_bond_yield_change_30d": 0.0,
+                "foreign_net_buy_krw_5d_sum": 10.0,
+                "institution_net_buy_krw_5d_sum": 5.0,
+                "individual_net_buy_krw_5d_sum": -15.0,
+                "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                "kospi_per": 10.0,
+                "kospi_pbr": 1.0,
+                "kospi_per_percentile_252d": 0.2,
+                "kospi_pbr_percentile_252d": 0.2,
+                "kospi_realized_vol_20d": 0.15,
+                "kospi_realized_vol_20d_percentile_252d": 0.2,
+                "kospi_atr_14d": 12.0,
+            }
+        ],
+    )
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "--date",
+                "2025-02-14",
+                "--scenario",
+                str(scenario_path),
+                "--features",
+                str(features_path),
+                "--out",
+                str(output_root),
+            ]
+        )
+        == 0
+    )
+
+    line = (output_root / "kospi.next_day" / "2025-02-14.jsonl").read_text(encoding="utf-8").strip()
+    assert parse_decision_result(line).decision_date == date(2025, 2, 14)

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -19,6 +19,7 @@ from kospi_decision_pipeline_app_kr_kospi.cli import (
     parse_date,
     run_build_features_command,
     run_ingest_command,
+    run_scenario_command,
 )
 from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import (
     BronzeIngestor,
@@ -406,6 +407,42 @@ def test_cli_main_routes_build_features_gold_args(monkeypatch: pytest.MonkeyPatc
     }
 
 
+def test_cli_main_routes_run_scenario_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_scenario_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_scenario_command",
+        fake_run_scenario_command,
+    )
+
+    assert (
+        main(
+            [
+                "run-scenario",
+                "--date",
+                "2025-02-14",
+                "--scenario",
+                "apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+                "--features",
+                "data/gold/features.parquet",
+                "--out",
+                "data/decisions",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "decision_date": "2025-02-14",
+        "scenario": "apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+        "features": "data/gold/features.parquet",
+        "output_dir": "data/decisions",
+    }
+
+
 def test_run_build_features_command_writes_silver_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -461,6 +498,47 @@ def test_run_build_features_command_rejects_unsupported_layer() -> None:
             silver_dir="tmp/silver",
             output_dir="tmp/output",
         )
+
+
+def test_run_scenario_command_returns_zero_after_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_kospi_scenario(
+        scenario_path: Path,
+        decision_date: date,
+        features_path: Path | None,
+        output_dir: Path | None,
+    ) -> object:
+        captured.update(
+            {
+                "scenario_path": scenario_path,
+                "decision_date": decision_date,
+                "features_path": features_path,
+                "output_dir": output_dir,
+            }
+        )
+        return object()
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_kospi_scenario",
+        fake_run_kospi_scenario,
+    )
+
+    assert (
+        run_scenario_command(
+            decision_date="2025-02-14",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            features="data/gold/features.parquet",
+            output_dir="data/decisions",
+        )
+        == 0
+    )
+    assert captured == {
+        "scenario_path": Path("apps/kr-kospi/config/scenario.kospi.next_day.yaml"),
+        "decision_date": date(2025, 2, 14),
+        "features_path": Path("data/gold/features.parquet"),
+        "output_dir": Path("data/decisions"),
+    }
 
 
 def test_parse_date_and_fixture_root_helpers() -> None:

--- a/core/src/kospi_decision_pipeline_core/runtime/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/runtime/__init__.py
@@ -1,0 +1,36 @@
+from .adapters import (
+    DecisionAgentAdapter,
+    DomesticMacroAgentAdapter,
+    FlowAgentAdapter,
+    TechnicalAgentAdapter,
+    ValuationAgentAdapter,
+    VolatilityAgentAdapter,
+)
+from .models import (
+    DecisionResultProposal,
+    KospiActionProposal,
+    KospiDecisionParticipant,
+    KospiDecisionSegment,
+    ProposalBatch,
+    VoteProposal,
+)
+from .scenario import KospiNextDayScenario, KospiScenarioResolver
+from .service import run_kospi_scenario
+
+__all__ = [
+    "DecisionAgentAdapter",
+    "DecisionResultProposal",
+    "DomesticMacroAgentAdapter",
+    "FlowAgentAdapter",
+    "KospiActionProposal",
+    "KospiDecisionParticipant",
+    "KospiDecisionSegment",
+    "KospiNextDayScenario",
+    "KospiScenarioResolver",
+    "ProposalBatch",
+    "TechnicalAgentAdapter",
+    "ValuationAgentAdapter",
+    "VolatilityAgentAdapter",
+    "VoteProposal",
+    "run_kospi_scenario",
+]

--- a/core/src/kospi_decision_pipeline_core/runtime/adapters.py
+++ b/core/src/kospi_decision_pipeline_core/runtime/adapters.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import cast
+
+from abdp.agents import AgentContext, AgentDecision
+
+from kospi_decision_pipeline_core.agents import (
+    DecisionAgent,
+    DomesticMacroAgent,
+    FlowAgent,
+    TechnicalAgent,
+    ValuationAgent,
+    VolatilityAgent,
+)
+from kospi_decision_pipeline_core.agents.domestic_macro import (
+    AgentFeatureRow as DomesticMacroFeatureRow,
+)
+from kospi_decision_pipeline_core.agents.flow import AgentFeatureRow as FlowFeatureRow
+from kospi_decision_pipeline_core.agents.technical import AgentFeatureRow as TechnicalFeatureRow
+from kospi_decision_pipeline_core.agents.valuation import AgentFeatureRow as ValuationFeatureRow
+from kospi_decision_pipeline_core.agents.volatility import AgentFeatureRow as VolatilityFeatureRow
+from kospi_decision_pipeline_core.features.agent_input import FeatureValue
+
+from .models import (
+    DecisionResultProposal,
+    KospiActionProposal,
+    KospiDecisionParticipant,
+    KospiDecisionSegment,
+    ProposalBatch,
+    VoteProposal,
+)
+
+
+@dataclass(slots=True)
+class KospiAgentDecision:
+    agent_id: str
+    proposals: ProposalBatch
+
+
+def _active_segment(
+    context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+) -> KospiDecisionSegment:
+    if len(context.state.segments) != 1:
+        raise ValueError("expected exactly one scenario segment")
+    return context.state.segments[0]
+
+
+def _subset_features(row: dict[str, object], columns: tuple[str, ...]) -> dict[str, object]:
+    return {column: row[column] for column in columns if column in row}
+
+
+def _extract_as_of_date(row: dict[str, object]) -> date:
+    raw_value = row.get("as_of_date", row.get("trade_date"))
+    if not isinstance(raw_value, date):
+        raise ValueError("features row must include as_of_date")
+    return raw_value
+
+
+@dataclass(slots=True)
+class TechnicalAgentAdapter:
+    agent: TechnicalAgent
+    agent_id: str = TechnicalAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "vote":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        vote = self.agent.vote(
+            cast(
+                TechnicalFeatureRow,
+                _feature_values_only(dict(segment.features_row), self.agent.INPUT_WHITELIST),
+            )
+        )
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(VoteProposal.from_vote(vote, step_index=context.step_index),),
+        )
+
+
+@dataclass(slots=True)
+class DomesticMacroAgentAdapter:
+    agent: DomesticMacroAgent
+    agent_id: str = DomesticMacroAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "vote":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        vote = self.agent.vote(
+            cast(
+                DomesticMacroFeatureRow,
+                _feature_values_only(dict(segment.features_row), self.agent.INPUT_WHITELIST),
+            )
+        )
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(VoteProposal.from_vote(vote, step_index=context.step_index),),
+        )
+
+
+@dataclass(slots=True)
+class FlowAgentAdapter:
+    agent: FlowAgent
+    agent_id: str = FlowAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "vote":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        row = dict(segment.features_row)
+        flow_row = FlowFeatureRow.from_mapping(
+            {
+                "as_of_date": _extract_as_of_date(row),
+                **_subset_features(row, self.agent.INPUT_WHITELIST),
+            }
+        )
+        vote = self.agent.vote(flow_row)
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(VoteProposal.from_vote(vote, step_index=context.step_index),),
+        )
+
+
+@dataclass(slots=True)
+class ValuationAgentAdapter:
+    agent: ValuationAgent
+    agent_id: str = ValuationAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "vote":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        vote = self.agent.vote(
+            cast(
+                ValuationFeatureRow,
+                _feature_values_only(dict(segment.features_row), self.agent.INPUT_WHITELIST),
+            )
+        )
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(VoteProposal.from_vote(vote, step_index=context.step_index),),
+        )
+
+
+@dataclass(slots=True)
+class VolatilityAgentAdapter:
+    agent: VolatilityAgent
+    agent_id: str = VolatilityAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "vote":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        row = dict(segment.features_row)
+        vote = self.agent.vote(
+            VolatilityFeatureRow(
+                as_of=_extract_as_of_date(row),
+                values=_subset_features(row, self.agent.INPUT_WHITELIST),
+            )
+        )
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(VoteProposal.from_vote(vote, step_index=context.step_index),),
+        )
+
+
+@dataclass(slots=True)
+class DecisionAgentAdapter:
+    agent: DecisionAgent
+    agent_id: str = DecisionAgent.AGENT_NAME
+
+    def decide(
+        self,
+        context: AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+    ) -> AgentDecision[KospiActionProposal]:
+        segment = _active_segment(context)
+        if segment.phase != "decide":
+            return KospiAgentDecision(agent_id=self.agent_id, proposals=())
+        decision_result = self.agent.decide(
+            decision_date=segment.decision_date,
+            votes=segment.votes,
+            snapshot_id=segment.snapshot_id,
+        )
+        return KospiAgentDecision(
+            agent_id=self.agent_id,
+            proposals=(
+                DecisionResultProposal.from_decision_result(
+                    decision_result,
+                    step_index=context.step_index,
+                ),
+            ),
+        )
+
+
+__all__ = [
+    "DecisionAgentAdapter",
+    "DomesticMacroAgentAdapter",
+    "FlowAgentAdapter",
+    "KospiAgentDecision",
+    "TechnicalAgentAdapter",
+    "ValuationAgentAdapter",
+    "VolatilityAgentAdapter",
+]
+
+
+def _feature_values_only(
+    row: dict[str, object], columns: tuple[str, ...]
+) -> dict[str, FeatureValue]:
+    filtered: dict[str, FeatureValue] = {}
+    for column in columns:
+        value = row.get(column)
+        if isinstance(value, bool) or not isinstance(value, (str, int, float)):
+            raise ValueError(f"{column} must be a feature value")
+        filtered[column] = value
+    return filtered

--- a/core/src/kospi_decision_pipeline_core/runtime/models.py
+++ b/core/src/kospi_decision_pipeline_core/runtime/models.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+from typing import Literal, cast
+
+from abdp.core.types import JsonObject
+
+from kospi_decision_pipeline_core.schemas import AgentVote, DecisionResult
+from kospi_decision_pipeline_core.schemas.serialization import to_jsonl_line
+
+type ScenarioPhase = Literal["vote", "decide", "done"]
+
+
+@dataclass(frozen=True, slots=True)
+class KospiDecisionParticipant:
+    participant_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class KospiDecisionSegment:
+    segment_id: str
+    participant_ids: tuple[str, ...]
+    phase: ScenarioPhase
+    decision_date: date
+    snapshot_id: str
+    features_row: Mapping[str, object]
+    votes: tuple[AgentVote, ...] = ()
+    decision_result: DecisionResult | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "features_row", MappingProxyType(dict(self.features_row)))
+
+
+@dataclass(frozen=True, slots=True)
+class VoteProposal:
+    proposal_id: str
+    actor_id: str
+    vote: AgentVote
+
+    action_key: Literal["vote"] = "vote"
+
+    @property
+    def payload(self) -> JsonObject:
+        return {"vote": cast(JsonObject, json.loads(to_jsonl_line(self.vote)))}
+
+    @classmethod
+    def from_vote(cls, vote: AgentVote, *, step_index: int) -> VoteProposal:
+        return cls(
+            proposal_id=f"vote:{vote.agent_name}:step{step_index}",
+            actor_id=vote.agent_name,
+            vote=vote,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionResultProposal:
+    proposal_id: str
+    actor_id: str
+    decision_result: DecisionResult
+
+    action_key: Literal["decision_result"] = "decision_result"
+
+    @property
+    def payload(self) -> JsonObject:
+        return {
+            "decision_result": cast(JsonObject, json.loads(to_jsonl_line(self.decision_result)))
+        }
+
+    @classmethod
+    def from_decision_result(
+        cls,
+        decision_result: DecisionResult,
+        *,
+        step_index: int,
+    ) -> DecisionResultProposal:
+        return cls(
+            proposal_id=f"decision:step{step_index}:{decision_result.snapshot_id}",
+            actor_id="decision",
+            decision_result=decision_result,
+        )
+
+
+type KospiActionProposal = VoteProposal | DecisionResultProposal
+type ProposalBatch = tuple[KospiActionProposal, ...]
+
+
+__all__ = [
+    "DecisionResultProposal",
+    "KospiActionProposal",
+    "KospiDecisionParticipant",
+    "KospiDecisionSegment",
+    "ProposalBatch",
+    "ScenarioPhase",
+    "VoteProposal",
+]

--- a/core/src/kospi_decision_pipeline_core/runtime/scenario.py
+++ b/core/src/kospi_decision_pipeline_core/runtime/scenario.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+from uuid import NAMESPACE_URL, uuid5
+
+from abdp.core.types import Seed
+from abdp.scenario import ActionResolver
+from abdp.simulation import ScenarioSpec, SimulationState, SnapshotRef
+
+from kospi_decision_pipeline_core.schemas import AgentVote
+
+from .models import (
+    DecisionResultProposal,
+    KospiActionProposal,
+    KospiDecisionParticipant,
+    KospiDecisionSegment,
+    ScenarioPhase,
+    VoteProposal,
+)
+
+RULE_AGENT_NAMES: tuple[str, ...] = (
+    "technical",
+    "domestic_macro",
+    "flow",
+    "valuation",
+    "volatility",
+)
+
+
+class KospiNextDayScenario(
+    ScenarioSpec[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]
+):
+    _scenario_key: str
+    _decision_date: date
+    _snapshot_id: str
+    _features_row: dict[str, object]
+    _seed: Seed
+    _initial_phase: ScenarioPhase
+    _votes: tuple[AgentVote, ...]
+    _storage_key: str
+
+    def __init__(
+        self,
+        *,
+        scenario_id: str,
+        decision_date: date,
+        snapshot_id: str,
+        features_row: dict[str, object],
+        seed: Seed = Seed(17),
+        initial_phase: ScenarioPhase = "vote",
+        votes: tuple[AgentVote, ...] = (),
+        storage_key: str | None = None,
+    ) -> None:
+        self._scenario_key = scenario_id
+        self._decision_date = decision_date
+        self._snapshot_id = snapshot_id
+        self._features_row = dict(features_row)
+        self._seed = seed
+        self._initial_phase = initial_phase
+        self._votes = votes
+        self._storage_key = snapshot_id if storage_key is None else storage_key
+
+    @property
+    def scenario_key(self) -> str:
+        return self._scenario_key
+
+    @property
+    def seed(self) -> Seed:
+        return self._seed
+
+    def build_initial_state(
+        self,
+    ) -> SimulationState[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]:
+        participant = KospiDecisionParticipant(participant_id="market-kospi")
+        segment = KospiDecisionSegment(
+            segment_id="segment-kospi",
+            participant_ids=(participant.participant_id,),
+            phase=self._initial_phase,
+            decision_date=self._decision_date,
+            snapshot_id=self._snapshot_id,
+            features_row=self._features_row,
+            votes=self._votes,
+            decision_result=None,
+        )
+        return SimulationState(
+            step_index=0 if self._initial_phase == "vote" else 1,
+            seed=self._seed,
+            snapshot_ref=SnapshotRef(
+                snapshot_id=uuid5(NAMESPACE_URL, self._snapshot_id),
+                tier="gold",
+                storage_key=self._storage_key,
+            ),
+            segments=(segment,),
+            participants=(participant,),
+            pending_actions=(),
+        )
+
+
+class KospiScenarioResolver(
+    ActionResolver[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]
+):
+    def resolve(
+        self,
+        state: SimulationState[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+        proposals: tuple[KospiActionProposal, ...],
+    ) -> SimulationState[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]:
+        if len(state.segments) != 1:
+            raise ValueError("expected exactly one scenario segment")
+        segment = state.segments[0]
+        if segment.phase == "vote":
+            next_segment = self._resolve_vote_phase(segment, proposals)
+        elif segment.phase == "decide":
+            next_segment = self._resolve_decide_phase(segment, proposals)
+        else:
+            raise ValueError(f"cannot resolve terminal phase: {segment.phase}")
+        return SimulationState(
+            step_index=state.step_index + 1,
+            seed=state.seed,
+            snapshot_ref=state.snapshot_ref,
+            segments=(next_segment,),
+            participants=state.participants,
+            pending_actions=(),
+        )
+
+    def _resolve_vote_phase(
+        self,
+        segment: KospiDecisionSegment,
+        proposals: tuple[KospiActionProposal, ...],
+    ) -> KospiDecisionSegment:
+        if any(isinstance(proposal, DecisionResultProposal) for proposal in proposals):
+            raise ValueError("vote phase must not receive DecisionResultProposal")
+        vote_proposals = tuple(
+            proposal for proposal in proposals if isinstance(proposal, VoteProposal)
+        )
+        unique_agent_names = {proposal.vote.agent_name for proposal in vote_proposals}
+        if len(vote_proposals) != 5 or unique_agent_names != set(RULE_AGENT_NAMES):
+            raise ValueError("vote phase requires exactly 5 unique VoteProposals")
+        votes = tuple(
+            sorted((proposal.vote for proposal in vote_proposals), key=lambda vote: vote.agent_name)
+        )
+        return replace(segment, phase="decide", votes=votes, decision_result=None)
+
+    def _resolve_decide_phase(
+        self,
+        segment: KospiDecisionSegment,
+        proposals: tuple[KospiActionProposal, ...],
+    ) -> KospiDecisionSegment:
+        decision_proposals = tuple(
+            proposal for proposal in proposals if isinstance(proposal, DecisionResultProposal)
+        )
+        if len(decision_proposals) != 1 or len(proposals) != 1:
+            raise ValueError("decide phase requires exactly 1 DecisionResultProposal")
+        return replace(
+            segment,
+            phase="done",
+            decision_result=decision_proposals[0].decision_result,
+        )
+
+
+__all__ = ["KospiNextDayScenario", "KospiScenarioResolver", "RULE_AGENT_NAMES"]

--- a/core/src/kospi_decision_pipeline_core/runtime/service.py
+++ b/core/src/kospi_decision_pipeline_core/runtime/service.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow.parquet as pq
+from abdp.agents import Agent
+from abdp.scenario import ActionResolver
+from abdp.scenario import ScenarioRunner
+
+from kospi_decision_pipeline_core.agents import (
+    DecisionAgent,
+    DomesticMacroAgent,
+    FlowAgent,
+    TechnicalAgent,
+    ValuationAgent,
+    VolatilityAgent,
+    compute_config_signature,
+)
+from kospi_decision_pipeline_core.features.leakage_guard import (
+    LeakageError,
+    assert_join_not_from_future,
+    assert_no_forbidden_columns,
+)
+from kospi_decision_pipeline_core.schemas import DecisionResult
+from kospi_decision_pipeline_core.schemas.config import load_agents_config, load_scenario_config
+from kospi_decision_pipeline_core.schemas.serialization import to_jsonl_line
+
+from .adapters import (
+    DecisionAgentAdapter,
+    DomesticMacroAgentAdapter,
+    FlowAgentAdapter,
+    TechnicalAgentAdapter,
+    ValuationAgentAdapter,
+    VolatilityAgentAdapter,
+)
+from .scenario import KospiNextDayScenario, KospiScenarioResolver
+from .models import KospiActionProposal, KospiDecisionParticipant, KospiDecisionSegment
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+
+
+def run_kospi_scenario(
+    scenario_path: Path | str,
+    decision_date: date,
+    features_path: Path | None = None,
+    output_dir: Path | None = None,
+) -> DecisionResult:
+    scenario_config_path = Path(scenario_path)
+    scenario_config = load_scenario_config(scenario_config_path)
+    runtime = scenario_config.runtime
+    resolved_agents_path = _resolve_path(
+        scenario_config_path,
+        runtime.agents_config_path,
+        override_path=None,
+    )
+    resolved_features_path = _resolve_path(
+        scenario_config_path,
+        runtime.features_path,
+        override_path=features_path,
+    )
+    resolved_output_dir = _resolve_path(
+        scenario_config_path,
+        runtime.output_dir,
+        override_path=output_dir,
+    )
+    agents_config = load_agents_config(resolved_agents_path)
+    features_row = _load_features_row(resolved_features_path, decision_date)
+    snapshot_id = _resolve_snapshot_id(features_row)
+
+    scenario = KospiNextDayScenario(
+        scenario_id=scenario_config.scenario_id,
+        decision_date=decision_date,
+        snapshot_id=snapshot_id,
+        features_row=features_row,
+        storage_key=str(resolved_features_path),
+    )
+    agents = cast(
+        tuple[Agent[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal], ...],
+        (
+            TechnicalAgentAdapter(
+                agent=TechnicalAgent(
+                    rule_config=agents_config.agents["technical"],
+                    weight=agents_config.weights.values["technical"],
+                )
+            ),
+            DomesticMacroAgentAdapter(
+                agent=DomesticMacroAgent(
+                    rule_config=agents_config.agents["domestic_macro"],
+                    weight=agents_config.weights.values["domestic_macro"],
+                )
+            ),
+            FlowAgentAdapter(
+                agent=FlowAgent(
+                    rule_config=agents_config.agents["flow"],
+                    weight=agents_config.weights.values["flow"],
+                )
+            ),
+            ValuationAgentAdapter(
+                agent=ValuationAgent(
+                    rule_config=agents_config.agents["valuation"],
+                    weight=agents_config.weights.values["valuation"],
+                )
+            ),
+            VolatilityAgentAdapter(
+                agent=VolatilityAgent(
+                    rule_config=agents_config.agents["volatility"],
+                    weight=agents_config.weights.values["volatility"],
+                )
+            ),
+            DecisionAgentAdapter(
+                agent=DecisionAgent(
+                    threshold_up=agents_config.thresholds.up,
+                    threshold_down=agents_config.thresholds.down,
+                    config_signature=compute_config_signature(resolved_agents_path),
+                )
+            ),
+        ),
+    )
+    resolver = cast(
+        ActionResolver[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal],
+        KospiScenarioResolver(),
+    )
+    runner = ScenarioRunner(
+        agents=agents,
+        resolver=resolver,
+        max_steps=2,
+    )
+    run = runner.run(scenario)
+    final_segment = run.final_state.segments[0]
+    if final_segment.decision_result is None:
+        raise ValueError("scenario did not produce a final decision result")
+    _persist_decision_result(
+        final_segment.decision_result, resolved_output_dir, scenario_config.scenario_id
+    )
+    return final_segment.decision_result
+
+
+def _resolve_path(base_path: Path, configured_path: str, override_path: Path | None) -> Path:
+    if override_path is not None:
+        return override_path
+    configured = Path(configured_path)
+    if configured.is_absolute():
+        return configured
+    return _workspace_root(base_path) / configured
+
+
+def _workspace_root(base_path: Path) -> Path:
+    resolved = base_path.resolve()
+    for parent in (resolved.parent, *resolved.parents):
+        if (parent / "pyproject.toml").is_file():
+            return parent
+    return resolved.parent
+
+
+def _load_features_row(features_path: Path, decision_date: date) -> dict[str, object]:
+    rows = READ_TABLE(features_path).to_pylist()
+    matching_rows = _matching_rows(rows, decision_date)
+    if len(matching_rows) != 1:
+        raise ValueError("expected exactly one features row for the requested decision_date")
+    row = dict(matching_rows[0])
+    _assert_lag_safe_row(row, decision_date)
+    assert_no_forbidden_columns(row.keys())
+    return row
+
+
+def _matching_rows(rows: list[dict[str, object]], decision_date: date) -> list[dict[str, object]]:
+    if rows and all("decision_date" in row for row in rows):
+        return [row for row in rows if row.get("decision_date") == decision_date]
+    target_as_of = _previous_trading_day(decision_date)
+    return [row for row in rows if row.get("as_of_date", row.get("trade_date")) == target_as_of]
+
+
+def _assert_lag_safe_row(row: dict[str, object], decision_date: date) -> None:
+    if "as_of_date" in row or "trade_date" in row:
+        joined_as_of = row.get("as_of_date", row.get("trade_date"))
+        if not isinstance(joined_as_of, date):
+            raise LeakageError("features row must include a valid as_of_date")
+        assert_join_not_from_future(joined_as_of=joined_as_of, decision_date=decision_date)
+        if joined_as_of >= decision_date:
+            raise LeakageError("features row must be strictly earlier than decision_date")
+
+
+def _previous_trading_day(decision_date: date) -> date:
+    current = decision_date - timedelta(days=1)
+    while current.weekday() >= 5:
+        current -= timedelta(days=1)
+    return current
+
+
+def _resolve_snapshot_id(row: dict[str, object]) -> str:
+    raw_snapshot_id = row.get("snapshot_id")
+    if isinstance(raw_snapshot_id, str) and raw_snapshot_id != "":
+        return raw_snapshot_id
+    canonical = "|".join(f"{key}={row[key]}" for key in sorted(row))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+    as_of_value = row.get("as_of_date", row.get("trade_date"))
+    if isinstance(as_of_value, date):
+        return f"gold:{as_of_value.isoformat()}:{digest}"
+    return f"gold:{digest}"
+
+
+def _persist_decision_result(result: DecisionResult, output_dir: Path, scenario_id: str) -> None:
+    output_path = output_dir / scenario_id / f"{result.decision_date.isoformat()}.jsonl"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = output_path.write_text(to_jsonl_line(result) + "\n", encoding="utf-8")
+
+
+__all__ = ["run_kospi_scenario"]

--- a/core/src/kospi_decision_pipeline_core/schemas/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/__init__.py
@@ -2,6 +2,7 @@ from .config import (
     AgentRuleConfig,
     AgentWeightConfig,
     AgentsConfig,
+    ScenarioRuntimeConfig,
     ScenarioConfig,
     ThresholdsConfig,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "GroundTruthLabel",
     "from_jsonl_line",
     "ModelLabel",
+    "ScenarioRuntimeConfig",
     "ScenarioConfig",
     "ThresholdsConfig",
     "to_csv_row",

--- a/core/src/kospi_decision_pipeline_core/schemas/config.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/config.py
@@ -115,6 +115,13 @@ class ScenarioConfigDict(TypedDict):
     scenario_id: str
     horizon: Literal["next_day"]
     agents: list[str]
+    runtime: "ScenarioRuntimeConfigDict"
+
+
+class ScenarioRuntimeConfigDict(TypedDict):
+    agents_config_path: str
+    features_path: str
+    output_dir: str
 
 
 class _AgentsConfigRequiredDict(TypedDict):
@@ -211,10 +218,42 @@ class AgentsConfig:
 
 
 @dataclass(frozen=True, slots=True)
+class ScenarioRuntimeConfig:
+    agents_config_path: str
+    features_path: str
+    output_dir: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "agents_config_path",
+            _ensure_non_empty_string(self.agents_config_path, context="agents_config_path"),
+        )
+        object.__setattr__(
+            self,
+            "features_path",
+            _ensure_non_empty_string(self.features_path, context="features_path"),
+        )
+        object.__setattr__(
+            self,
+            "output_dir",
+            _ensure_non_empty_string(self.output_dir, context="output_dir"),
+        )
+
+    def to_dict(self) -> ScenarioRuntimeConfigDict:
+        return {
+            "agents_config_path": self.agents_config_path,
+            "features_path": self.features_path,
+            "output_dir": self.output_dir,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class ScenarioConfig:
     scenario_id: str
     horizon: Literal["next_day"]
     agents: tuple[str, ...]
+    runtime: ScenarioRuntimeConfig
 
     def __post_init__(self) -> None:
         scenario_id = _ensure_string(self.scenario_id, context="scenario_id")
@@ -224,12 +263,15 @@ class ScenarioConfig:
         _validate_known_agent_ids(agent_ids, context="agents")
         object.__setattr__(self, "scenario_id", scenario_id)
         object.__setattr__(self, "agents", agent_ids)
+        if not isinstance(self.runtime, ScenarioRuntimeConfig):
+            raise ValueError("runtime must be a ScenarioRuntimeConfig")
 
     def to_dict(self) -> ScenarioConfigDict:
         return {
             "scenario_id": self.scenario_id,
             "horizon": self.horizon,
             "agents": list(self.agents),
+            "runtime": self.runtime.to_dict(),
         }
 
 
@@ -258,11 +300,17 @@ def load_agents_config(path: Path) -> AgentsConfig:
 def load_scenario_config(path: Path) -> ScenarioConfig:
     payload = _load_yaml_mapping(path)
     agents_payload = _require_sequence(payload, "agents")
+    runtime_payload = _require_mapping(payload, "runtime")
 
     return ScenarioConfig(
         scenario_id=_require_string(payload, "scenario_id"),
         horizon=_require_horizon(payload),
         agents=tuple(_normalize_string_sequence(agents_payload, context="agents")),
+        runtime=ScenarioRuntimeConfig(
+            agents_config_path=_require_string(runtime_payload, "agents_config_path"),
+            features_path=_require_string(runtime_payload, "features_path"),
+            output_dir=_require_string(runtime_payload, "output_dir"),
+        ),
     )
 
 
@@ -321,6 +369,13 @@ def _ensure_string(value: object, context: str) -> str:
     if not isinstance(value, str):
         raise ValueError(f"{context} must be a string")
     return value
+
+
+def _ensure_non_empty_string(value: object, context: str) -> str:
+    text = _ensure_string(value, context=context)
+    if text == "":
+        raise ValueError(f"{context} must be a non-empty string")
+    return text
 
 
 def _ensure_float(value: object, context: str) -> float:

--- a/core/tests/runtime/test_adapters.py
+++ b/core/tests/runtime/test_adapters.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+from datetime import date
+
+from abdp.agents import AgentContext
+from abdp.core.types import Seed
+from abdp.simulation import SimulationState, SnapshotRef
+import pytest
+
+from kospi_decision_pipeline_core.agents import (
+    DecisionAgent,
+    DomesticMacroAgent,
+    FlowAgent,
+    TechnicalAgent,
+    ValuationAgent,
+    VolatilityAgent,
+)
+from kospi_decision_pipeline_core.runtime.adapters import (
+    DecisionAgentAdapter,
+    DomesticMacroAgentAdapter,
+    FlowAgentAdapter,
+    TechnicalAgentAdapter,
+    ValuationAgentAdapter,
+    VolatilityAgentAdapter,
+)
+from kospi_decision_pipeline_core.runtime import adapters as adapter_module
+from kospi_decision_pipeline_core.runtime.models import (
+    KospiActionProposal,
+    KospiDecisionParticipant,
+    KospiDecisionSegment,
+    ScenarioPhase,
+)
+from kospi_decision_pipeline_core.schemas import AgentRuleConfig, AgentVote, ThresholdsConfig
+from uuid import UUID
+
+
+def _rule_config(rule_version: str, **thresholds: float) -> AgentRuleConfig:
+    return AgentRuleConfig(rule_version=rule_version, thresholds=thresholds)
+
+
+def _features_row() -> dict[str, object]:
+    return {
+        "as_of_date": date(2025, 2, 13),
+        "kospi_return_1d": 0.01,
+        "kospi_return_5d": 0.02,
+        "kospi_ma5_gap": 0.01,
+        "kospi_close_position": 0.75,
+        "bok_base_rate_change_30d": 0.0,
+        "usd_krw_return_5d": 0.0,
+        "kr_bond_yield_change_30d": 0.0,
+        "foreign_net_buy_krw_5d_sum": 10.0,
+        "institution_net_buy_krw_5d_sum": 5.0,
+        "individual_net_buy_krw_5d_sum": -15.0,
+        "foreign_net_buy_5d_pct_of_turnover": 0.02,
+        "kospi_per": 10.0,
+        "kospi_pbr": 1.0,
+        "kospi_per_percentile_252d": 0.2,
+        "kospi_pbr_percentile_252d": 0.2,
+        "kospi_realized_vol_20d": 0.15,
+        "kospi_realized_vol_20d_percentile_252d": 0.2,
+        "kospi_atr_14d": 12.0,
+    }
+
+
+def _segment(
+    *,
+    phase: ScenarioPhase,
+    votes: tuple[AgentVote, ...] = (),
+) -> KospiDecisionSegment:
+    return KospiDecisionSegment(
+        segment_id="segment-kospi",
+        participant_ids=("market-kospi",),
+        phase=phase,
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row=_features_row(),
+        votes=votes,
+        decision_result=None,
+    )
+
+
+def _state(
+    segment: KospiDecisionSegment,
+) -> SimulationState[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]:
+    return SimulationState(
+        step_index=0,
+        seed=Seed(7),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tier="gold",
+            storage_key="data/gold/features.parquet",
+        ),
+        segments=(segment,),
+        participants=(KospiDecisionParticipant(participant_id="market-kospi"),),
+        pending_actions=(),
+    )
+
+
+def _context(
+    segment: KospiDecisionSegment,
+    *,
+    step_index: int,
+) -> AgentContext[KospiDecisionSegment, KospiDecisionParticipant, KospiActionProposal]:
+    return AgentContext(
+        scenario_key="kospi.next_day",
+        agent_id="test-agent",
+        step_index=step_index,
+        seed=Seed(7),
+        state=_state(segment),
+    )
+
+
+def test_rule_adapters_emit_votes_only_during_vote_phase() -> None:
+    segment = _segment(phase="vote")
+    adapters = (
+        TechnicalAgentAdapter(
+            agent=TechnicalAgent(
+                rule_config=_rule_config(
+                    "technical@1.0.0",
+                    ma5_gap_up_min=0.005,
+                    close_position_up_min=0.60,
+                    return_5d_up_min=0.010,
+                    ma5_gap_down_max=-0.005,
+                    close_position_down_max=0.40,
+                    return_5d_down_max=-0.010,
+                ),
+                weight=0.30,
+            )
+        ),
+        DomesticMacroAgentAdapter(
+            agent=DomesticMacroAgent(
+                rule_config=_rule_config(
+                    "domestic_macro@1.0.0",
+                    bok_rate_change_up_max=0.00,
+                    usdkrw_return_5d_up_max=0.010,
+                    bond_yield_change_30d_up_max=0.05,
+                    bok_rate_change_down_min=0.25,
+                    usdkrw_return_5d_down_min=0.020,
+                    bond_yield_change_30d_down_min=0.10,
+                    usdkrw_return_5d_mixed_pos_min=0.015,
+                    usdkrw_return_5d_mixed_neg_max=-0.015,
+                    bond_yield_change_30d_mixed_pos_min=0.05,
+                    bond_yield_change_30d_mixed_neg_max=0.00,
+                ),
+                weight=0.20,
+            )
+        ),
+        FlowAgentAdapter(
+            agent=FlowAgent(
+                rule_config=_rule_config(
+                    "flow@1.0.0",
+                    foreign_pct_up_min=0.010,
+                    foreign_pct_down_max=-0.010,
+                    foreign_pct_neutral_abs_max=0.003,
+                ),
+                weight=0.25,
+            )
+        ),
+        ValuationAgentAdapter(
+            agent=ValuationAgent(
+                rule_config=_rule_config(
+                    "valuation@1.0.0",
+                    per_percentile_up_max=0.30,
+                    pbr_percentile_up_max=0.30,
+                    per_percentile_down_min=0.70,
+                    pbr_percentile_down_min=0.70,
+                    fair_value_center=0.50,
+                    fair_value_half_band=0.10,
+                ),
+                weight=0.10,
+            )
+        ),
+        VolatilityAgentAdapter(
+            agent=VolatilityAgent(
+                rule_config=_rule_config(
+                    "volatility@1.0.0",
+                    realized_vol_20d_up_max=0.18,
+                    realized_vol_pct_up_max=0.30,
+                    atr_14d_up_max=35.0,
+                    realized_vol_pct_down_min=0.80,
+                    realized_vol_20d_down_min=0.25,
+                    atr_14d_down_min=45.0,
+                    realized_vol_pct_mid_low=0.30,
+                    realized_vol_pct_mid_high=0.80,
+                ),
+                weight=0.15,
+            )
+        ),
+    )
+
+    for adapter in adapters:
+        decision = adapter.decide(_context(segment, step_index=0))
+        assert decision.agent_id == adapter.agent_id
+        assert len(decision.proposals) == 1
+        assert decision.proposals[0].actor_id == adapter.agent_id
+        assert decision.proposals[0].payload["vote"]
+
+
+def test_rule_adapters_emit_empty_proposals_outside_vote_phase() -> None:
+    adapter = TechnicalAgentAdapter(
+        agent=TechnicalAgent(
+            rule_config=_rule_config(
+                "technical@1.0.0",
+                ma5_gap_up_min=0.005,
+                close_position_up_min=0.60,
+                return_5d_up_min=0.010,
+                ma5_gap_down_max=-0.005,
+                close_position_down_max=0.40,
+                return_5d_down_max=-0.010,
+            ),
+            weight=0.30,
+        )
+    )
+
+    decision = adapter.decide(_context(_segment(phase="decide"), step_index=1))
+
+    assert decision.proposals == ()
+
+
+def test_decision_adapter_emits_decision_only_during_decide_phase() -> None:
+    votes = (
+        AgentVote("domestic_macro", "domestic_macro@1.0.0", "skip", 0.0, 0.2, 0.0, ()),
+        AgentVote("flow", "flow@1.0.0", "up", 0.8, 0.25, 0.2, ()),
+        AgentVote("technical", "technical@1.0.0", "up", 0.7, 0.3, 0.21, ()),
+        AgentVote("valuation", "valuation@1.0.0", "skip", 0.0, 0.1, 0.0, ()),
+        AgentVote("volatility", "volatility@1.0.0", "skip", 0.0, 0.15, 0.0, ()),
+    )
+    adapter = DecisionAgentAdapter(
+        agent=DecisionAgent(
+            threshold_up=ThresholdsConfig(up=0.25, down=-0.25).up,
+            threshold_down=ThresholdsConfig(up=0.25, down=-0.25).down,
+            config_signature="config-signature",
+        )
+    )
+
+    active = adapter.decide(_context(_segment(phase="decide", votes=votes), step_index=1))
+    inactive = adapter.decide(_context(_segment(phase="vote", votes=votes), step_index=0))
+
+    assert len(active.proposals) == 1
+    assert active.proposals[0].actor_id == "decision"
+    assert active.proposals[0].payload["decision_result"]
+    assert inactive.proposals == ()
+
+
+def test_adapter_helpers_reject_invalid_segment_shape_and_features() -> None:
+    invalid_state = SimulationState(
+        step_index=0,
+        seed=Seed(7),
+        snapshot_ref=SnapshotRef(
+            snapshot_id=UUID("11111111-1111-1111-1111-111111111111"),
+            tier="gold",
+            storage_key="data/gold/features.parquet",
+        ),
+        segments=(_segment(phase="vote"), _segment(phase="vote")),
+        participants=(KospiDecisionParticipant(participant_id="market-kospi"),),
+        pending_actions=(),
+    )
+    invalid_context = AgentContext(
+        scenario_key="kospi.next_day",
+        agent_id="test-agent",
+        step_index=0,
+        seed=Seed(7),
+        state=invalid_state,
+    )
+    missing_as_of_context = _context(
+        KospiDecisionSegment(
+            segment_id="segment-kospi",
+            participant_ids=("market-kospi",),
+            phase="vote",
+            decision_date=date(2025, 2, 14),
+            snapshot_id="snapshot-2025-02-13",
+            features_row={"foreign_net_buy_krw_5d_sum": 1.0},
+            votes=(),
+            decision_result=None,
+        ),
+        step_index=0,
+    )
+
+    with pytest.raises(ValueError, match="exactly one scenario segment"):
+        _ = adapter_module._active_segment(invalid_context)
+
+    with pytest.raises(ValueError, match="include as_of_date"):
+        _ = adapter_module._extract_as_of_date({})
+
+    with pytest.raises(ValueError, match="must be a feature value"):
+        _ = adapter_module._feature_values_only({"kospi_return_1d": object()}, ("kospi_return_1d",))
+
+    flow_adapter = FlowAgentAdapter(
+        agent=FlowAgent(
+            rule_config=_rule_config(
+                "flow@1.0.0",
+                foreign_pct_up_min=0.010,
+                foreign_pct_down_max=-0.010,
+                foreign_pct_neutral_abs_max=0.003,
+            ),
+            weight=0.25,
+        )
+    )
+    with pytest.raises(ValueError, match="include as_of_date"):
+        _ = flow_adapter.decide(missing_as_of_context)

--- a/core/tests/runtime/test_scenario.py
+++ b/core/tests/runtime/test_scenario.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from kospi_decision_pipeline_core.runtime.models import ScenarioPhase
+from kospi_decision_pipeline_core.schemas import (
+    AgentVote,
+    DecisionResult,
+    EvidenceItem,
+    ModelLabel,
+)
+from kospi_decision_pipeline_core.runtime.models import (
+    DecisionResultProposal,
+    KospiDecisionParticipant,
+    KospiDecisionSegment,
+    VoteProposal,
+)
+from kospi_decision_pipeline_core.runtime.scenario import (
+    KospiNextDayScenario,
+    KospiScenarioResolver,
+)
+
+
+def _evidence_item(name: str, value: float) -> EvidenceItem:
+    return EvidenceItem(name=name, value=value, source="computed", as_of=date(2025, 2, 13))
+
+
+def _vote(agent_name: str, label: ModelLabel = "skip") -> AgentVote:
+    return AgentVote(
+        agent_name=agent_name,
+        rule_version=f"{agent_name}@1.0.0",
+        label=label,
+        score=0.0,
+        weight=0.2,
+        weighted_score=0.0,
+        evidence=(_evidence_item("signal", 0.0),),
+    )
+
+
+def _decision_result(votes: tuple[AgentVote, ...]) -> DecisionResult:
+    return DecisionResult(
+        decision_date=date(2025, 2, 14),
+        label="up",
+        aggregate_score=0.55,
+        threshold_up=0.25,
+        threshold_down=-0.25,
+        votes=votes,
+        config_signature="config-signature",
+        snapshot_id="snapshot-2025-02-13",
+    )
+
+
+def _segment(
+    *,
+    phase: ScenarioPhase = "vote",
+    votes: tuple[AgentVote, ...] = (),
+) -> KospiDecisionSegment:
+    return KospiDecisionSegment(
+        segment_id="segment-kospi",
+        participant_ids=("market-kospi",),
+        phase=phase,
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+        votes=votes,
+        decision_result=None,
+    )
+
+
+def test_vote_phase_resolves_into_decide_phase_with_unique_votes() -> None:
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+    )
+    state = scenario.build_initial_state()
+    resolver = KospiScenarioResolver()
+    proposals = (
+        VoteProposal.from_vote(_vote("technical", "up"), step_index=0),
+        VoteProposal.from_vote(_vote("domestic_macro", "skip"), step_index=0),
+        VoteProposal.from_vote(_vote("flow", "up"), step_index=0),
+        VoteProposal.from_vote(_vote("valuation", "down"), step_index=0),
+        VoteProposal.from_vote(_vote("volatility", "skip"), step_index=0),
+    )
+
+    next_state = resolver.resolve(state, proposals)
+
+    assert next_state.step_index == 1
+    assert next_state.pending_actions == ()
+    assert next_state.segments[0].phase == "decide"
+    assert tuple(vote.agent_name for vote in next_state.segments[0].votes) == (
+        "domestic_macro",
+        "flow",
+        "technical",
+        "valuation",
+        "volatility",
+    )
+
+
+def test_vote_phase_rejects_duplicate_or_missing_rule_votes() -> None:
+    resolver = KospiScenarioResolver()
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+    )
+    state = scenario.build_initial_state()
+
+    duplicate_proposals = (
+        VoteProposal.from_vote(_vote("technical"), step_index=0),
+        VoteProposal.from_vote(_vote("technical"), step_index=0),
+        VoteProposal.from_vote(_vote("flow"), step_index=0),
+        VoteProposal.from_vote(_vote("valuation"), step_index=0),
+        VoteProposal.from_vote(_vote("volatility"), step_index=0),
+    )
+    missing_proposals = duplicate_proposals[1:]
+
+    with pytest.raises(ValueError, match="exactly 5 unique VoteProposals"):
+        _ = resolver.resolve(state, duplicate_proposals)
+
+    with pytest.raises(ValueError, match="exactly 5 unique VoteProposals"):
+        _ = resolver.resolve(state, missing_proposals)
+
+
+def test_vote_phase_rejects_decision_result_proposals() -> None:
+    resolver = KospiScenarioResolver()
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+    )
+    state = scenario.build_initial_state()
+    votes = tuple(
+        VoteProposal.from_vote(_vote(agent_name), step_index=0)
+        for agent_name in ("technical", "domestic_macro", "flow", "valuation", "volatility")
+    )
+    decision = DecisionResultProposal.from_decision_result(
+        _decision_result(tuple(proposal.vote for proposal in votes)),
+        step_index=0,
+    )
+
+    with pytest.raises(ValueError, match="DecisionResultProposal"):
+        _ = resolver.resolve(state, votes + (decision,))
+
+
+def test_decide_phase_resolves_into_done_phase_with_single_decision_result() -> None:
+    resolver = KospiScenarioResolver()
+    votes = (
+        _vote("technical", "up"),
+        _vote("domestic_macro", "skip"),
+        _vote("flow", "up"),
+        _vote("valuation", "down"),
+        _vote("volatility", "skip"),
+    )
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+        initial_phase="decide",
+        votes=votes,
+    )
+    state = scenario.build_initial_state()
+
+    next_state = resolver.resolve(
+        state,
+        (DecisionResultProposal.from_decision_result(_decision_result(votes), step_index=1),),
+    )
+
+    assert next_state.step_index == 2
+    assert next_state.pending_actions == ()
+    assert next_state.segments[0].phase == "done"
+    assert next_state.segments[0].decision_result == _decision_result(votes)
+
+
+def test_decide_phase_rejects_non_single_decision_result() -> None:
+    resolver = KospiScenarioResolver()
+    votes = (
+        _vote("technical"),
+        _vote("domestic_macro"),
+        _vote("flow"),
+        _vote("valuation"),
+        _vote("volatility"),
+    )
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+        initial_phase="decide",
+        votes=votes,
+    )
+    state = scenario.build_initial_state()
+    decision = DecisionResultProposal.from_decision_result(_decision_result(votes), step_index=1)
+
+    with pytest.raises(ValueError, match="exactly 1 DecisionResultProposal"):
+        _ = resolver.resolve(state, ())
+
+    with pytest.raises(ValueError, match="exactly 1 DecisionResultProposal"):
+        _ = resolver.resolve(state, (decision, decision))
+
+
+def test_scenario_builds_single_segment_and_participant() -> None:
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+    )
+
+    state = scenario.build_initial_state()
+
+    assert state.step_index == 0
+    assert state.participants == (KospiDecisionParticipant(participant_id="market-kospi"),)
+    assert state.segments[0] == _segment()
+
+
+def test_resolver_rejects_invalid_terminal_or_multi_segment_state() -> None:
+    resolver = KospiScenarioResolver()
+    scenario = KospiNextDayScenario(
+        scenario_id="kospi.next_day",
+        decision_date=date(2025, 2, 14),
+        snapshot_id="snapshot-2025-02-13",
+        features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+    )
+    state = scenario.build_initial_state()
+    done_state = state.__class__(
+        step_index=2,
+        seed=state.seed,
+        snapshot_ref=state.snapshot_ref,
+        segments=(
+            KospiDecisionSegment(
+                segment_id="segment-kospi",
+                participant_ids=("market-kospi",),
+                phase="done",
+                decision_date=date(2025, 2, 14),
+                snapshot_id="snapshot-2025-02-13",
+                features_row={"as_of_date": date(2025, 2, 13), "kospi_return_1d": 0.01},
+                votes=(),
+                decision_result=None,
+            ),
+        ),
+        participants=state.participants,
+        pending_actions=(),
+    )
+    multi_segment_state = state.__class__(
+        step_index=0,
+        seed=state.seed,
+        snapshot_ref=state.snapshot_ref,
+        segments=(state.segments[0], state.segments[0]),
+        participants=state.participants,
+        pending_actions=(),
+    )
+
+    with pytest.raises(ValueError, match="terminal phase"):
+        _ = resolver.resolve(done_state, ())
+
+    with pytest.raises(ValueError, match="exactly one scenario segment"):
+        _ = resolver.resolve(multi_segment_state, ())

--- a/core/tests/runtime/test_service.py
+++ b/core/tests/runtime/test_service.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import yaml
+
+from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario
+from kospi_decision_pipeline_core.runtime import service as service_module
+from kospi_decision_pipeline_core.schemas import DecisionResult
+from kospi_decision_pipeline_core.schemas.serialization import parse_decision_result
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_features(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _agents_payload() -> dict[str, object]:
+    return {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+        "agents": {
+            "technical": {
+                "rule_version": "technical@1.0.0",
+                "thresholds": {
+                    "ma5_gap_up_min": 0.005,
+                    "close_position_up_min": 0.60,
+                    "return_5d_up_min": 0.010,
+                    "ma5_gap_down_max": -0.005,
+                    "close_position_down_max": 0.40,
+                    "return_5d_down_max": -0.010,
+                },
+            },
+            "domestic_macro": {
+                "rule_version": "domestic_macro@1.0.0",
+                "thresholds": {
+                    "bok_rate_change_up_max": 0.00,
+                    "usdkrw_return_5d_up_max": 0.010,
+                    "bond_yield_change_30d_up_max": 0.05,
+                    "bok_rate_change_down_min": 0.25,
+                    "usdkrw_return_5d_down_min": 0.020,
+                    "bond_yield_change_30d_down_min": 0.10,
+                    "usdkrw_return_5d_mixed_pos_min": 0.015,
+                    "usdkrw_return_5d_mixed_neg_max": -0.015,
+                    "bond_yield_change_30d_mixed_pos_min": 0.05,
+                    "bond_yield_change_30d_mixed_neg_max": 0.00,
+                },
+            },
+            "flow": {
+                "rule_version": "flow@1.0.0",
+                "thresholds": {
+                    "foreign_pct_up_min": 0.010,
+                    "foreign_pct_down_max": -0.010,
+                    "foreign_pct_neutral_abs_max": 0.003,
+                },
+            },
+            "valuation": {
+                "rule_version": "valuation@1.0.0",
+                "thresholds": {
+                    "per_percentile_up_max": 0.30,
+                    "pbr_percentile_up_max": 0.30,
+                    "per_percentile_down_min": 0.70,
+                    "pbr_percentile_down_min": 0.70,
+                    "fair_value_center": 0.50,
+                    "fair_value_half_band": 0.10,
+                },
+            },
+            "volatility": {
+                "rule_version": "volatility@1.0.0",
+                "thresholds": {
+                    "realized_vol_20d_up_max": 0.18,
+                    "realized_vol_pct_up_max": 0.30,
+                    "atr_14d_up_max": 35.0,
+                    "realized_vol_pct_down_min": 0.80,
+                    "realized_vol_20d_down_min": 0.25,
+                    "atr_14d_down_min": 45.0,
+                    "realized_vol_pct_mid_low": 0.30,
+                    "realized_vol_pct_mid_high": 0.80,
+                },
+            },
+        },
+    }
+
+
+def _scenario_payload(root: Path) -> dict[str, object]:
+    return {
+        "scenario_id": "kospi.next_day",
+        "horizon": "next_day",
+        "agents": ["technical", "domestic_macro", "flow", "valuation", "volatility", "decision"],
+        "runtime": {
+            "agents_config_path": str(root / "config" / "agents.yaml"),
+            "features_path": str(root / "data" / "gold" / "features.parquet"),
+            "output_dir": str(root / "data" / "decisions"),
+        },
+    }
+
+
+def _feature_row(as_of_date: date) -> dict[str, object]:
+    return {
+        "as_of_date": as_of_date,
+        "kospi_return_1d": 0.01,
+        "kospi_return_5d": 0.02,
+        "kospi_ma5_gap": 0.01,
+        "kospi_close_position": 0.75,
+        "bok_base_rate_change_30d": 0.0,
+        "usd_krw_return_5d": 0.0,
+        "kr_bond_yield_change_30d": 0.0,
+        "foreign_net_buy_krw_5d_sum": 10.0,
+        "institution_net_buy_krw_5d_sum": 5.0,
+        "individual_net_buy_krw_5d_sum": -15.0,
+        "foreign_net_buy_5d_pct_of_turnover": 0.02,
+        "kospi_per": 10.0,
+        "kospi_pbr": 1.0,
+        "kospi_per_percentile_252d": 0.2,
+        "kospi_pbr_percentile_252d": 0.2,
+        "kospi_realized_vol_20d": 0.15,
+        "kospi_realized_vol_20d_percentile_252d": 0.2,
+        "kospi_atr_14d": 12.0,
+    }
+
+
+def test_run_kospi_scenario_writes_single_jsonl_and_round_trips(tmp_path: Path) -> None:
+    agents_path = _write_yaml(tmp_path / "config" / "agents.yaml", _agents_payload())
+    scenario_path = _write_yaml(tmp_path / "config" / "scenario.yaml", _scenario_payload(tmp_path))
+    features_path = tmp_path / "data" / "gold" / "features.parquet"
+    _write_features(features_path, [_feature_row(date(2025, 2, 13))])
+
+    result = run_kospi_scenario(scenario_path, date(2025, 2, 14))
+
+    output_path = tmp_path / "data" / "decisions" / "kospi.next_day" / "2025-02-14.jsonl"
+    assert isinstance(result, DecisionResult)
+    assert output_path.is_file()
+    lines = output_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert parse_decision_result(lines[0]) == result
+    assert tuple(vote.agent_name for vote in result.votes) == (
+        "domestic_macro",
+        "flow",
+        "technical",
+        "valuation",
+        "volatility",
+    )
+    assert result.snapshot_id
+    assert agents_path.is_file()
+
+
+def test_run_kospi_scenario_rejects_missing_or_duplicate_effective_feature_rows(
+    tmp_path: Path,
+) -> None:
+    _write_yaml(tmp_path / "config" / "agents.yaml", _agents_payload())
+    scenario_path = _write_yaml(tmp_path / "config" / "scenario.yaml", _scenario_payload(tmp_path))
+    features_path = tmp_path / "data" / "gold" / "features.parquet"
+
+    _write_features(features_path, [])
+    with pytest.raises(ValueError, match="expected exactly one features row"):
+        _ = run_kospi_scenario(scenario_path, date(2025, 2, 14))
+
+    _write_features(
+        features_path,
+        [_feature_row(date(2025, 2, 13)), _feature_row(date(2025, 2, 13))],
+    )
+    with pytest.raises(ValueError, match="expected exactly one features row"):
+        _ = run_kospi_scenario(scenario_path, date(2025, 2, 14))
+
+
+def test_run_kospi_scenario_rejects_leakage_before_persisting_output(tmp_path: Path) -> None:
+    _write_yaml(tmp_path / "config" / "agents.yaml", _agents_payload())
+    scenario_path = _write_yaml(tmp_path / "config" / "scenario.yaml", _scenario_payload(tmp_path))
+    features_path = tmp_path / "data" / "gold" / "features.parquet"
+    _write_features(features_path, [_feature_row(date(2025, 2, 14))])
+
+    with pytest.raises(ValueError, match="decision_date"):
+        _ = run_kospi_scenario(scenario_path, date(2025, 2, 14))
+
+    assert not (tmp_path / "data" / "decisions" / "kospi.next_day" / "2025-02-14.jsonl").exists()
+
+
+def test_service_helper_paths_and_feature_filters(tmp_path: Path) -> None:
+    project_root = tmp_path / "repo"
+    project_root.mkdir(parents=True)
+    _ = (project_root / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    scenario_path = project_root / "apps" / "kr-kospi" / "config" / "scenario.yaml"
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = scenario_path.write_text("scenario_id: demo\n", encoding="utf-8")
+
+    assert (
+        service_module._resolve_path(scenario_path, "data/gold/features.parquet", None)
+        == project_root / "data/gold/features.parquet"
+    )
+    assert service_module._workspace_root(scenario_path) == project_root
+    assert service_module._matching_rows(
+        [{"decision_date": date(2025, 2, 14), "value": 1.0}],
+        date(2025, 2, 14),
+    ) == [{"decision_date": date(2025, 2, 14), "value": 1.0}]
+    assert service_module._previous_trading_day(date(2025, 2, 17)) == date(2025, 2, 14)
+    assert (
+        service_module._resolve_path(
+            scenario_path,
+            "data/gold/features.parquet",
+            project_root / "override.parquet",
+        )
+        == project_root / "override.parquet"
+    )
+    assert service_module._resolve_snapshot_id({"value": 1.0}).startswith("gold:")
+
+
+def test_service_helper_fallback_root_and_snapshot_without_date(tmp_path: Path) -> None:
+    scenario_path = tmp_path / "scenario.yaml"
+    _ = scenario_path.write_text("scenario_id: demo\n", encoding="utf-8")
+
+    assert service_module._workspace_root(scenario_path) == tmp_path
+    assert service_module._resolve_snapshot_id({"other": object()}).startswith("gold:")
+
+
+def test_service_helper_validates_alignment_and_persistence_branches(tmp_path: Path) -> None:
+    service_module._assert_lag_safe_row({"decision_date": date(2025, 2, 14)}, date(2025, 2, 14))
+
+    with pytest.raises(ValueError, match="valid as_of_date"):
+        service_module._assert_lag_safe_row({"as_of_date": "2025-02-13"}, date(2025, 2, 14))
+
+    with pytest.raises(ValueError, match="strictly earlier than decision_date"):
+        service_module._assert_lag_safe_row({"as_of_date": date(2025, 2, 14)}, date(2025, 2, 14))
+
+    snapshot_id = service_module._resolve_snapshot_id({"snapshot_id": "explicit-snapshot"})
+    assert snapshot_id == "explicit-snapshot"
+
+    result = DecisionResult(
+        decision_date=date(2025, 2, 14),
+        label="skip",
+        aggregate_score=0.0,
+        threshold_up=0.25,
+        threshold_down=-0.25,
+        votes=(),
+        config_signature="config-signature",
+        snapshot_id="snapshot-id",
+    )
+    service_module._persist_decision_result(result, tmp_path / "out", "kospi.next_day")
+    assert (
+        parse_decision_result(
+            (tmp_path / "out" / "kospi.next_day" / "2025-02-14.jsonl")
+            .read_text(encoding="utf-8")
+            .strip()
+        )
+        == result
+    )
+
+
+def test_run_kospi_scenario_raises_if_runner_finishes_without_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_yaml(tmp_path / "config" / "agents.yaml", _agents_payload())
+    scenario_path = _write_yaml(tmp_path / "config" / "scenario.yaml", _scenario_payload(tmp_path))
+    features_path = tmp_path / "data" / "gold" / "features.parquet"
+    _write_features(features_path, [_feature_row(date(2025, 2, 13))])
+
+    class _FakeRun:
+        def __init__(self) -> None:
+            self.final_state = type(
+                "FinalState",
+                (),
+                {"segments": [type("Segment", (), {"decision_result": None})()]},
+            )()
+
+    class _FakeRunner:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def run(self, _scenario: object) -> _FakeRun:
+            return _FakeRun()
+
+    monkeypatch.setattr(service_module, "ScenarioRunner", _FakeRunner)
+
+    with pytest.raises(ValueError, match="did not produce a final decision result"):
+        _ = run_kospi_scenario(scenario_path, date(2025, 2, 14))

--- a/core/tests/unit/test_config.py
+++ b/core/tests/unit/test_config.py
@@ -11,6 +11,7 @@ from kospi_decision_pipeline_core.schemas.config import (
     AgentRuleConfig,
     AgentWeightConfig,
     AgentsConfig,
+    ScenarioRuntimeConfig,
     ScenarioConfig,
     ThresholdsConfig,
     load_agents_config,
@@ -112,6 +113,14 @@ def valid_agent_rules() -> dict[str, AgentRuleConfig]:
     }
 
 
+def valid_runtime_payload() -> dict[str, str]:
+    return {
+        "agents_config_path": "apps/kr-kospi/config/agents.yaml",
+        "features_path": "data/gold/features.parquet",
+        "output_dir": "data/decisions",
+    }
+
+
 def test_config_dataclasses_construct_and_serialize() -> None:
     weights = AgentWeightConfig(
         {
@@ -139,6 +148,7 @@ def test_config_dataclasses_construct_and_serialize() -> None:
             "volatility",
             "decision",
         ),
+        runtime=ScenarioRuntimeConfig(**valid_runtime_payload()),
     )
 
     assert config.to_dict() == {
@@ -163,6 +173,7 @@ def test_config_dataclasses_construct_and_serialize() -> None:
             "volatility",
             "decision",
         ],
+        "runtime": valid_runtime_payload(),
     }
 
 
@@ -230,6 +241,7 @@ def test_scenario_config_rejects_invalid_horizon_when_constructed_directly() -> 
             scenario_id="kospi.weekly",
             horizon=cast(Literal["next_day"], cast(object, "weekly")),
             agents=("technical", "decision"),
+            runtime=ScenarioRuntimeConfig(**valid_runtime_payload()),
         )
 
 
@@ -239,6 +251,40 @@ def test_scenario_config_rejects_non_string_scenario_id_when_constructed_directl
             scenario_id=cast(str, cast(object, 1)),
             horizon="next_day",
             agents=("technical", "decision"),
+            runtime=ScenarioRuntimeConfig(**valid_runtime_payload()),
+        )
+
+
+def test_scenario_runtime_config_rejects_empty_values() -> None:
+    with pytest.raises(ValueError, match="agents_config_path must be a non-empty string"):
+        _ = ScenarioRuntimeConfig(
+            agents_config_path="",
+            features_path="data/gold/features.parquet",
+            output_dir="data/decisions",
+        )
+
+    with pytest.raises(ValueError, match="features_path must be a non-empty string"):
+        _ = ScenarioRuntimeConfig(
+            agents_config_path="apps/kr-kospi/config/agents.yaml",
+            features_path="",
+            output_dir="data/decisions",
+        )
+
+    with pytest.raises(ValueError, match="output_dir must be a non-empty string"):
+        _ = ScenarioRuntimeConfig(
+            agents_config_path="apps/kr-kospi/config/agents.yaml",
+            features_path="data/gold/features.parquet",
+            output_dir="",
+        )
+
+
+def test_scenario_config_rejects_non_runtime_config_instance() -> None:
+    with pytest.raises(ValueError, match="runtime must be a ScenarioRuntimeConfig"):
+        _ = ScenarioConfig(
+            scenario_id="kospi.next_day",
+            horizon="next_day",
+            agents=("technical", "decision"),
+            runtime=cast(ScenarioRuntimeConfig, cast(object, "invalid")),
         )
 
 
@@ -283,6 +329,7 @@ def test_load_scenario_config_rejects_invalid_horizon(tmp_path: Path) -> None:
             "scenario_id": "kospi.weekly",
             "horizon": "weekly",
             "agents": ["technical", "decision"],
+            "runtime": valid_runtime_payload(),
         },
     )
 
@@ -297,6 +344,7 @@ def test_load_scenario_config_rejects_unknown_agent_ids(tmp_path: Path) -> None:
             "scenario_id": "kospi.next_day",
             "horizon": "next_day",
             "agents": ["technical", "mystery"],
+            "runtime": valid_runtime_payload(),
         },
     )
 
@@ -442,6 +490,7 @@ def test_load_scenario_config_rejects_non_string_scenario_id(tmp_path: Path) -> 
             "scenario_id": 1,
             "horizon": "next_day",
             "agents": ["technical", "decision"],
+            "runtime": valid_runtime_payload(),
         },
     )
 
@@ -455,6 +504,7 @@ def test_load_scenario_config_rejects_missing_scenario_id(tmp_path: Path) -> Non
         {
             "horizon": "next_day",
             "agents": ["technical", "decision"],
+            "runtime": valid_runtime_payload(),
         },
     )
 
@@ -469,6 +519,7 @@ def test_load_scenario_config_rejects_non_sequence_agents(tmp_path: Path) -> Non
             "scenario_id": "kospi.next_day",
             "horizon": "next_day",
             "agents": "technical",
+            "runtime": valid_runtime_payload(),
         },
     )
 
@@ -487,7 +538,11 @@ def test_load_scenario_config_rejects_non_sequence_agents(tmp_path: Path) -> Non
         ),
         (
             "scenario.yaml",
-            {"scenario_id": "kospi.next_day", "horizon": "next_day"},
+            {
+                "scenario_id": "kospi.next_day",
+                "horizon": "next_day",
+                "runtime": valid_runtime_payload(),
+            },
             load_scenario_config,
             "agents",
         ),
@@ -546,4 +601,36 @@ def test_default_config_files_load_successfully() -> None:
             "volatility",
             "decision",
         ],
+        "runtime": valid_runtime_payload(),
     }
+
+
+def test_load_scenario_config_rejects_missing_runtime_block(tmp_path: Path) -> None:
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": "kospi.next_day",
+            "horizon": "next_day",
+            "agents": ["technical", "decision"],
+        },
+    )
+
+    with pytest.raises(ValueError, match="runtime"):
+        _ = load_scenario_config(config_path)
+
+
+def test_load_scenario_config_rejects_missing_runtime_key(tmp_path: Path) -> None:
+    runtime = valid_runtime_payload()
+    del runtime["features_path"]
+    config_path = write_yaml(
+        tmp_path / "scenario.yaml",
+        {
+            "scenario_id": "kospi.next_day",
+            "horizon": "next_day",
+            "agents": ["technical", "decision"],
+            "runtime": runtime,
+        },
+    )
+
+    with pytest.raises(ValueError, match="features_path"):
+        _ = load_scenario_config(config_path)

--- a/core/tests/unit/test_core_modules.py
+++ b/core/tests/unit/test_core_modules.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from kospi_decision_pipeline_core import __version__
 from kospi_decision_pipeline_core.ids import dataset_id
 from kospi_decision_pipeline_core.io import ensure_directory
-from kospi_decision_pipeline_core.schemas import DecisionRecord, FeatureRecord, ScenarioConfig
+from kospi_decision_pipeline_core.schemas import (
+    DecisionRecord,
+    FeatureRecord,
+    ScenarioConfig,
+    ScenarioRuntimeConfig,
+)
 from kospi_decision_pipeline_core.types import Decision
 
 
@@ -37,6 +42,11 @@ def test_schema_stubs_are_instantiable() -> None:
             scenario_id="kospi.next_day",
             horizon="next_day",
             agents=("technical", "decision"),
+            runtime=ScenarioRuntimeConfig(
+                agents_config_path="apps/kr-kospi/config/agents.yaml",
+                features_path="data/gold/features.parquet",
+                output_dir="data/decisions",
+            ),
         ),
         ScenarioConfig,
     )


### PR DESCRIPTION
Closes #17.

## Summary
- implement a two-phase ABDP `ScenarioRunner` runtime that collects five rule-agent votes in step 0 and emits one `DecisionResult` in step 1
- add `run_kospi_scenario(...)`, runtime adapters/models/resolver, scenario runtime config loading, and JSONL persistence for deterministic next-day decisions
- wire the KOSPI CLI/config to `run-scenario` and add unit/integration coverage with 100% line+branch coverage on new runtime code

## Drift findings
- `core/src/kospi_decision_pipeline_core/features/agent_input.py` exports `FeatureValue` plus `build_agent_feature_row(...)`; there is no typed `AgentInput` dataclass on `main`
- the gold feature parquet currently carries `as_of_date` and does **not** include `decision_date` or `snapshot_id`; runtime therefore selects the previous trading day's lag-safe row for decision date `D` and derives a deterministic snapshot id when one is absent
- rule-agent vote signatures on `main` are:
  - `TechnicalAgent.vote(self, row: AgentFeatureRow) -> AgentVote`
  - `DomesticMacroAgent.vote(self, row: AgentFeatureRow) -> AgentVote`
  - `FlowAgent.vote(self, row: AgentFeatureRow) -> AgentVote`
  - `ValuationAgent.vote(self, row: AgentFeatureRow) -> AgentVote`
  - `VolatilityAgent.vote(self, row: AgentFeatureRow) -> AgentVote`

## Verification
- `uv run --python 3.12 --extra dev python -m pytest core/tests/runtime/test_scenario.py core/tests/runtime/test_adapters.py core/tests/runtime/test_service.py apps/kr-kospi/tests/integration/test_run_scenario.py apps/kr-kospi/tests/unit/test_cli_commands.py core/tests/unit/test_config.py core/tests/unit/test_core_modules.py --cov=core/src/kospi_decision_pipeline_core/runtime --cov-branch --cov-report=term-missing`
- `uv run --python 3.12 --extra dev python -m pytest`
- LSP diagnostics: clean for changed runtime/schema/CLI files and runtime tests