### PR TITLE
Add walk-forward backtest runner with reports (#19)

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from datetime import date
 import os
 from pathlib import Path
+from typing import cast
 
+import yaml
+
+from kospi_decision_pipeline_core.backtest import BacktestRunner, WalkForwardSplitter
 from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario
 
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry, LiveConnectorRegistry
@@ -129,6 +134,55 @@ def run_scenario_command(
     return 0
 
 
+def run_backtest_command(
+    *,
+    dataset: str,
+    scenario: str,
+    output_dir: str,
+    folds_config: str,
+) -> int:
+    runner = BacktestRunner(
+        splitter=_load_backtest_splitter(folds_config),
+        scenario_path=Path(scenario),
+        output_dir=Path(output_dir),
+    )
+    _ = runner.run(dataset_path=Path(dataset))
+    return 0
+
+
+def _load_backtest_splitter(folds_config: str) -> WalkForwardSplitter:
+    if folds_config == "":
+        return WalkForwardSplitter()
+    loaded = cast(object, yaml.safe_load(Path(folds_config).read_text(encoding="utf-8")))
+    payload = _ensure_mapping(loaded)
+    min_train_rows = _require_int(payload, "min_train_rows")
+    test_fold_size = _require_int(payload, "test_fold_size")
+    gap_days = _require_int(payload, "gap_days")
+    return WalkForwardSplitter(
+        min_train_rows=min_train_rows,
+        test_fold_size=test_fold_size,
+        gap_days=gap_days,
+    )
+
+
+def _require_int(payload: Mapping[str, object], key: str) -> int:
+    if key not in payload:
+        raise ValueError(f"missing required key: {key}")
+    value = payload[key]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an int")
+    return value
+
+
+def _ensure_mapping(value: object) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError("folds config must be a mapping")
+    for key in cast(Mapping[object, object], value):
+        if not isinstance(key, str):
+            raise ValueError("folds config keys must be strings")
+    return cast(Mapping[str, object], value)
+
+
 class _CliArgs(argparse.Namespace):
     cmd: str | None = None
     layer: str = ""
@@ -142,6 +196,7 @@ class _CliArgs(argparse.Namespace):
     scenario: str = ""
     features: str = ""
     decision_date: str = ""
+    folds_config: str = ""
     live: bool = False
 
 
@@ -179,6 +234,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     _ = run_scenario_parser.add_argument("--features", default="")
     _ = run_scenario_parser.add_argument("--out", dest="output_dir", default="")
+    run_backtest_parser = sub.add_parser("run-backtest", help="run walk-forward backtest")
+    _ = run_backtest_parser.add_argument("--dataset", default="data/gold/backtest_dataset.parquet")
+    _ = run_backtest_parser.add_argument(
+        "--scenario",
+        default="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+    )
+    _ = run_backtest_parser.add_argument("--out", dest="output_dir", required=True)
+    _ = run_backtest_parser.add_argument("--folds-config", default="")
     for name in ("run", "backtest", "report"):
         _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
     args = parser.parse_args(argv, namespace=_CliArgs())
@@ -219,6 +282,13 @@ def main(argv: list[str] | None = None) -> int:
             scenario=str(args.scenario),
             features=str(args.features),
             output_dir=str(args.output_dir),
+        )
+    if cmd == "run-backtest":
+        return run_backtest_command(
+            dataset=str(args.dataset),
+            scenario=str(args.scenario),
+            output_dir=str(args.output_dir),
+            folds_config=str(args.folds_config),
         )
     print(f"{cmd}: not yet implemented")
     return 0

--- a/apps/kr-kospi/tests/integration/test_run_backtest.py
+++ b/apps/kr-kospi/tests/integration/test_run_backtest.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from kospi_decision_pipeline_app_kr_kospi.cli import main
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_dataset(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _agents_payload() -> dict[str, object]:
+    return {
+        "weights": {
+            "technical": 0.30,
+            "domestic_macro": 0.20,
+            "flow": 0.25,
+            "valuation": 0.10,
+            "volatility": 0.15,
+        },
+        "thresholds": {"up": 0.25, "down": -0.25},
+        "agents": {
+            "technical": {
+                "rule_version": "technical@1.0.0",
+                "thresholds": {
+                    "ma5_gap_up_min": 0.005,
+                    "close_position_up_min": 0.60,
+                    "return_5d_up_min": 0.010,
+                    "ma5_gap_down_max": -0.005,
+                    "close_position_down_max": 0.40,
+                    "return_5d_down_max": -0.010,
+                },
+            },
+            "domestic_macro": {
+                "rule_version": "domestic_macro@1.0.0",
+                "thresholds": {
+                    "bok_rate_change_up_max": 0.00,
+                    "usdkrw_return_5d_up_max": 0.010,
+                    "bond_yield_change_30d_up_max": 0.05,
+                    "bok_rate_change_down_min": 0.25,
+                    "usdkrw_return_5d_down_min": 0.020,
+                    "bond_yield_change_30d_down_min": 0.10,
+                    "usdkrw_return_5d_mixed_pos_min": 0.015,
+                    "usdkrw_return_5d_mixed_neg_max": -0.015,
+                    "bond_yield_change_30d_mixed_pos_min": 0.05,
+                    "bond_yield_change_30d_mixed_neg_max": 0.00,
+                },
+            },
+            "flow": {
+                "rule_version": "flow@1.0.0",
+                "thresholds": {
+                    "foreign_pct_up_min": 0.010,
+                    "foreign_pct_down_max": -0.010,
+                    "foreign_pct_neutral_abs_max": 0.003,
+                },
+            },
+            "valuation": {
+                "rule_version": "valuation@1.0.0",
+                "thresholds": {
+                    "per_percentile_up_max": 0.30,
+                    "pbr_percentile_up_max": 0.30,
+                    "per_percentile_down_min": 0.70,
+                    "pbr_percentile_down_min": 0.70,
+                    "fair_value_center": 0.50,
+                    "fair_value_half_band": 0.10,
+                },
+            },
+            "volatility": {
+                "rule_version": "volatility@1.0.0",
+                "thresholds": {
+                    "realized_vol_20d_up_max": 0.18,
+                    "realized_vol_pct_up_max": 0.30,
+                    "atr_14d_up_max": 35.0,
+                    "realized_vol_pct_down_min": 0.80,
+                    "realized_vol_20d_down_min": 0.25,
+                    "atr_14d_down_min": 45.0,
+                    "realized_vol_pct_mid_low": 0.30,
+                    "realized_vol_pct_mid_high": 0.80,
+                },
+            },
+        },
+    }
+
+
+def _scenario_payload(agents_path: Path, dataset_path: Path, output_dir: Path) -> dict[str, object]:
+    return {
+        "scenario_id": "kospi.next_day",
+        "horizon": "next_day",
+        "agents": ["technical", "domestic_macro", "flow", "valuation", "volatility", "decision"],
+        "runtime": {
+            "agents_config_path": str(agents_path),
+            "features_path": str(dataset_path),
+            "output_dir": str(output_dir),
+        },
+    }
+
+
+def _backtest_dataset_rows() -> list[dict[str, object]]:
+    start = date(2025, 2, 3)
+    targets = ["down", "down", "up", "down", "up"]
+    rows: list[dict[str, object]] = []
+    for index, target in enumerate(targets):
+        trade_date = start + timedelta(days=index)
+        rows.append(
+            {
+                "trade_date": trade_date,
+                "kospi_return_1d": 0.01,
+                "kospi_return_3d": 0.015,
+                "kospi_return_5d": 0.02,
+                "kospi_ma5": 100.0 + index,
+                "kospi_ma20": 98.0 + index,
+                "kospi_ma5_gap": 0.01,
+                "kospi_close_position": 0.75,
+                "bok_base_rate": 3.0,
+                "bok_base_rate_change_30d": 0.0,
+                "usd_krw_close": 1300.0,
+                "usd_krw_return_5d": 0.0,
+                "kr_bond_yield_3y": 2.5,
+                "kr_bond_yield_change_30d": 0.0,
+                "foreign_net_buy_krw_5d_sum": 10.0,
+                "institution_net_buy_krw_5d_sum": 5.0,
+                "individual_net_buy_krw_5d_sum": -15.0,
+                "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                "kospi_per": 10.0,
+                "kospi_pbr": 1.0,
+                "kospi_per_percentile_252d": 0.2,
+                "kospi_pbr_percentile_252d": 0.2,
+                "kospi_realized_vol_20d": 0.15,
+                "kospi_realized_vol_20d_percentile_252d": 0.2,
+                "kospi_atr_14d": 12.0,
+                "target_next_day_simple_return": 0.01,
+                "target_next_day_log_return": 0.01,
+                "target_direction_label": target,
+            }
+        )
+    return rows
+
+
+def test_run_backtest_cli_end_to_end(tmp_path: Path) -> None:
+    agents_path = tmp_path / "config" / "agents.yaml"
+    dataset_path = tmp_path / "data" / "gold" / "backtest_dataset.parquet"
+    first_output_dir = tmp_path / "out-first"
+    second_output_dir = tmp_path / "out-second"
+    scenario_path = tmp_path / "config" / "scenario.yaml"
+    folds_path = tmp_path / "config" / "folds.yaml"
+    _write_yaml(agents_path, _agents_payload())
+    _write_dataset(dataset_path, _backtest_dataset_rows())
+    _write_yaml(scenario_path, _scenario_payload(agents_path, dataset_path, first_output_dir))
+    _write_yaml(folds_path, {"min_train_rows": 2, "test_fold_size": 2, "gap_days": 0})
+
+    assert (
+        main(
+            [
+                "run-backtest",
+                "--dataset",
+                str(dataset_path),
+                "--scenario",
+                str(scenario_path),
+                "--out",
+                str(first_output_dir),
+                "--folds-config",
+                str(folds_path),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "run-backtest",
+                "--dataset",
+                str(dataset_path),
+                "--scenario",
+                str(scenario_path),
+                "--out",
+                str(second_output_dir),
+                "--folds-config",
+                str(folds_path),
+            ]
+        )
+        == 0
+    )
+
+    assert (first_output_dir / "rows.jsonl").is_file()
+    assert (first_output_dir / "metrics.json").is_file()
+    assert (first_output_dir / "metrics.csv").is_file()
+    assert (first_output_dir / "rows.jsonl").read_bytes() == (
+        second_output_dir / "rows.jsonl"
+    ).read_bytes()
+    assert (first_output_dir / "metrics.json").read_bytes() == (
+        second_output_dir / "metrics.json"
+    ).read_bytes()
+
+    rows_payload = [
+        json.loads(line)
+        for line in (first_output_dir / "rows.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [
+        {
+            "fold_id": row["fold_id"],
+            "decision_date": row["decision_date"],
+            "label": row["label"],
+            "target_label": row["target_label"],
+            "correct": row["correct"],
+        }
+        for row in rows_payload
+    ] == [
+        {
+            "fold_id": 1,
+            "decision_date": "2025-02-06",
+            "label": "up",
+            "target_label": "up",
+            "correct": True,
+        },
+        {
+            "fold_id": 1,
+            "decision_date": "2025-02-07",
+            "label": "up",
+            "target_label": "down",
+            "correct": False,
+        },
+        {
+            "fold_id": 2,
+            "decision_date": "2025-02-10",
+            "label": "up",
+            "target_label": "up",
+            "correct": True,
+        },
+    ]
+    assert all(
+        isinstance(row["snapshot_id"], str) and row["snapshot_id"] != "" for row in rows_payload
+    )
+    assert all(
+        row["config_signature"] == rows_payload[0]["config_signature"] for row in rows_payload
+    )
+
+    metrics_payload = json.loads((first_output_dir / "metrics.json").read_text(encoding="utf-8"))
+    assert metrics_payload["overall"] == {
+        "fold_count": 2,
+        "period_start": "2025-02-06",
+        "period_end": "2025-02-10",
+        "decision_count": 3,
+        "hit_rate": 2 / 3,
+        "precision_up": 2 / 3,
+        "precision_down": None,
+        "recall_up": 1.0,
+        "recall_down": 0.0,
+        "skip_rate": 0.0,
+        "flat_rate": 0.0,
+    }
+    assert metrics_payload["folds"] == [
+        {
+            "fold_id": 1,
+            "fold_start": "2025-02-06",
+            "fold_end": "2025-02-07",
+            "decision_count": 2,
+            "hit_rate": 0.5,
+            "precision_up": 0.5,
+            "precision_down": None,
+            "recall_up": 1.0,
+            "recall_down": 0.0,
+            "skip_rate": 0.0,
+            "flat_rate": 0.0,
+        },
+        {
+            "fold_id": 2,
+            "fold_start": "2025-02-10",
+            "fold_end": "2025-02-10",
+            "decision_count": 1,
+            "hit_rate": 1.0,
+            "precision_up": 1.0,
+            "precision_down": None,
+            "recall_up": 1.0,
+            "recall_down": None,
+            "skip_rate": 0.0,
+            "flat_rate": 0.0,
+        },
+    ]

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -17,6 +17,7 @@ from kospi_decision_pipeline_app_kr_kospi.cli import (
     fixtures_root,
     main,
     parse_date,
+    run_backtest_command,
     run_build_features_command,
     run_ingest_command,
     run_scenario_command,
@@ -443,6 +444,42 @@ def test_cli_main_routes_run_scenario_args(monkeypatch: pytest.MonkeyPatch) -> N
     }
 
 
+def test_cli_main_routes_run_backtest_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_backtest_command(**kwargs: object) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.cli.run_backtest_command",
+        fake_run_backtest_command,
+    )
+
+    assert (
+        main(
+            [
+                "run-backtest",
+                "--dataset",
+                "data/gold/backtest_dataset.parquet",
+                "--scenario",
+                "apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+                "--out",
+                "data/backtest/run-1",
+                "--folds-config",
+                "config/folds.yaml",
+            ]
+        )
+        == 0
+    )
+    assert captured == {
+        "dataset": "data/gold/backtest_dataset.parquet",
+        "scenario": "apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+        "output_dir": "data/backtest/run-1",
+        "folds_config": "config/folds.yaml",
+    }
+
+
 def test_run_build_features_command_writes_silver_output(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -539,6 +576,81 @@ def test_run_scenario_command_returns_zero_after_execution(monkeypatch: pytest.M
         "features_path": Path("data/gold/features.parquet"),
         "output_dir": Path("data/decisions"),
     }
+
+
+def test_run_backtest_command_returns_zero_after_execution(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeRunner:
+        def __init__(self, *, splitter: object, scenario_path: Path, output_dir: Path) -> None:
+            captured.update(
+                {
+                    "splitter": splitter,
+                    "scenario_path": scenario_path,
+                    "output_dir": output_dir,
+                }
+            )
+
+        def run(self, *, dataset_path: Path) -> object:
+            captured["dataset_path"] = dataset_path
+            return object()
+
+    monkeypatch.setattr("kospi_decision_pipeline_app_kr_kospi.cli.BacktestRunner", FakeRunner)
+
+    assert (
+        run_backtest_command(
+            dataset="data/gold/backtest_dataset.parquet",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            output_dir="data/backtest/run-1",
+            folds_config="",
+        )
+        == 0
+    )
+    assert captured["scenario_path"] == Path("apps/kr-kospi/config/scenario.kospi.next_day.yaml")
+    assert captured["output_dir"] == Path("data/backtest/run-1")
+    assert captured["dataset_path"] == Path("data/gold/backtest_dataset.parquet")
+
+
+def test_run_backtest_command_validates_folds_config(tmp_path: Path) -> None:
+    invalid_path = tmp_path / "folds.yaml"
+    _ = invalid_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="folds config must be a mapping"):
+        _ = run_backtest_command(
+            dataset="data/gold/backtest_dataset.parquet",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            output_dir="data/backtest/run-1",
+            folds_config=str(invalid_path),
+        )
+
+    _ = invalid_path.write_text(
+        "min_train_rows: true\ntest_fold_size: 2\ngap_days: 0\n", encoding="utf-8"
+    )
+    with pytest.raises(ValueError, match="min_train_rows must be an int"):
+        _ = run_backtest_command(
+            dataset="data/gold/backtest_dataset.parquet",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            output_dir="data/backtest/run-1",
+            folds_config=str(invalid_path),
+        )
+
+    _ = invalid_path.write_text("min_train_rows: 2\ntest_fold_size: 2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="missing required key: gap_days"):
+        _ = run_backtest_command(
+            dataset="data/gold/backtest_dataset.parquet",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            output_dir="data/backtest/run-1",
+            folds_config=str(invalid_path),
+        )
+
+    _ = invalid_path.write_text("1: 2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="folds config keys must be strings"):
+        _ = run_backtest_command(
+            dataset="data/gold/backtest_dataset.parquet",
+            scenario="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+            output_dir="data/backtest/run-1",
+            folds_config=str(invalid_path),
+        )
 
 
 def test_parse_date_and_fixture_root_helpers() -> None:

--- a/core/src/kospi_decision_pipeline_core/backtest/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import annotations
 
+from .metrics import compute_fold_metrics, compute_overall_metrics
+from .reports import write_backtest_jsonl, write_metrics_csv, write_metrics_json
+from .runner import BacktestRunner
 from .walk_forward import WalkForwardFold, WalkForwardSplitter
 
-__all__ = ["WalkForwardFold", "WalkForwardSplitter"]
+__all__ = [
+    "BacktestRunner",
+    "WalkForwardFold",
+    "WalkForwardSplitter",
+    "compute_fold_metrics",
+    "compute_overall_metrics",
+    "write_backtest_jsonl",
+    "write_metrics_csv",
+    "write_metrics_json",
+]

--- a/core/src/kospi_decision_pipeline_core/backtest/metrics.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/metrics.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow, FoldMetrics, OverallMetrics
+
+
+def compute_fold_metrics(rows: Sequence[BacktestRow]) -> FoldMetrics:
+    normalized_rows = _normalize_rows(rows)
+    fold_ids = {row.fold_id for row in normalized_rows}
+    if len(fold_ids) != 1:
+        raise ValueError("fold metrics require rows from exactly one fold")
+    fold_id = normalized_rows[0].fold_id
+    return FoldMetrics(
+        fold_id=fold_id,
+        fold_start=min(row.decision_date for row in normalized_rows),
+        fold_end=max(row.decision_date for row in normalized_rows),
+        decision_count=len(normalized_rows),
+        hit_rate=_safe_ratio(_correct_count(normalized_rows), _non_skip_count(normalized_rows)),
+        precision_up=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="up"),
+            _predicted_count(normalized_rows, label="up"),
+        ),
+        precision_down=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="down"),
+            _predicted_count(normalized_rows, label="down"),
+        ),
+        recall_up=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="up"),
+            _target_count(normalized_rows, target_label="up"),
+        ),
+        recall_down=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="down"),
+            _target_count(normalized_rows, target_label="down"),
+        ),
+        skip_rate=_safe_ratio(_label_count(normalized_rows, label="skip"), len(normalized_rows)),
+        flat_rate=_safe_ratio(
+            _target_count(normalized_rows, target_label="flat"), len(normalized_rows)
+        ),
+    )
+
+
+def compute_overall_metrics(rows: Sequence[BacktestRow]) -> OverallMetrics:
+    normalized_rows = _normalize_rows(rows)
+    return OverallMetrics(
+        fold_count=len({row.fold_id for row in normalized_rows}),
+        period_start=min(row.decision_date for row in normalized_rows),
+        period_end=max(row.decision_date for row in normalized_rows),
+        decision_count=len(normalized_rows),
+        hit_rate=_safe_ratio(_correct_count(normalized_rows), _non_skip_count(normalized_rows)),
+        precision_up=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="up"),
+            _predicted_count(normalized_rows, label="up"),
+        ),
+        precision_down=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="down"),
+            _predicted_count(normalized_rows, label="down"),
+        ),
+        recall_up=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="up"),
+            _target_count(normalized_rows, target_label="up"),
+        ),
+        recall_down=_safe_ratio(
+            _predicted_target_matches(normalized_rows, label="down"),
+            _target_count(normalized_rows, target_label="down"),
+        ),
+        skip_rate=_safe_ratio(_label_count(normalized_rows, label="skip"), len(normalized_rows)),
+        flat_rate=_safe_ratio(
+            _target_count(normalized_rows, target_label="flat"), len(normalized_rows)
+        ),
+    )
+
+
+def _normalize_rows(rows: Sequence[BacktestRow]) -> tuple[BacktestRow, ...]:
+    if len(rows) == 0:
+        raise ValueError("rows must not be empty")
+    return tuple(rows)
+
+
+def _correct_count(rows: Sequence[BacktestRow]) -> int:
+    return sum(1 for row in rows if row.correct)
+
+
+def _non_skip_count(rows: Sequence[BacktestRow]) -> int:
+    return sum(1 for row in rows if row.label != "skip")
+
+
+def _predicted_target_matches(rows: Sequence[BacktestRow], *, label: str) -> int:
+    return sum(1 for row in rows if row.label == label and row.target_label == label)
+
+
+def _predicted_count(rows: Sequence[BacktestRow], *, label: str) -> int:
+    return sum(1 for row in rows if row.label == label)
+
+
+def _target_count(rows: Sequence[BacktestRow], *, target_label: str) -> int:
+    return sum(1 for row in rows if row.target_label == target_label)
+
+
+def _label_count(rows: Sequence[BacktestRow], *, label: str) -> int:
+    return sum(1 for row in rows if row.label == label)
+
+
+def _safe_ratio(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return None
+    return numerator / denominator
+
+
+__all__ = ["compute_fold_metrics", "compute_overall_metrics"]

--- a/core/src/kospi_decision_pipeline_core/backtest/reports.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/reports.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import csv
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from kospi_decision_pipeline_core.schemas.backtest import (
+    BacktestRow,
+    FoldMetrics,
+    OverallMetrics,
+    backtest_row_to_mapping,
+    fold_metrics_to_mapping,
+    overall_metrics_to_mapping,
+)
+
+
+def write_backtest_jsonl(path: Path, rows: Sequence[object]) -> Path:
+    sorted_rows = _normalize_backtest_rows(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(
+        "".join(_json_line(backtest_row_to_mapping(row)) for row in sorted_rows),
+        encoding="utf-8",
+    )
+    return path
+
+
+def write_metrics_json(path: Path, metrics: object) -> Path:
+    normalized_metrics = _normalize_overall_metrics(metrics)
+    payload = {
+        "folds": [fold_metrics_to_mapping(fold) for fold in normalized_metrics.folds],
+        "overall": {
+            key: value
+            for key, value in overall_metrics_to_mapping(normalized_metrics).items()
+            if key != "folds"
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    return path
+
+
+def write_metrics_csv(path: Path, metrics: object) -> Path:
+    normalized_metrics = _normalize_overall_metrics(metrics)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(_CSV_FIELDS)
+        for fold in normalized_metrics.folds:
+            writer.writerow(_csv_row_values(_fold_csv_row(fold)))
+        writer.writerow(_csv_row_values(_overall_csv_row(normalized_metrics)))
+    return path
+
+
+_CSV_FIELDS = (
+    "scope",
+    "fold_id",
+    "fold_start",
+    "fold_end",
+    "decision_count",
+    "hit_rate",
+    "precision_up",
+    "precision_down",
+    "recall_up",
+    "recall_down",
+    "skip_rate",
+    "flat_rate",
+)
+
+
+def _json_line(payload: dict[str, object]) -> str:
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False) + "\n"
+
+
+def _fold_csv_row(metrics: FoldMetrics) -> dict[str, str]:
+    return {
+        "scope": "fold",
+        "fold_id": str(metrics.fold_id),
+        "fold_start": metrics.fold_start.isoformat(),
+        "fold_end": metrics.fold_end.isoformat(),
+        "decision_count": str(metrics.decision_count),
+        "hit_rate": _stringify_optional_float(metrics.hit_rate),
+        "precision_up": _stringify_optional_float(metrics.precision_up),
+        "precision_down": _stringify_optional_float(metrics.precision_down),
+        "recall_up": _stringify_optional_float(metrics.recall_up),
+        "recall_down": _stringify_optional_float(metrics.recall_down),
+        "skip_rate": _stringify_optional_float(metrics.skip_rate),
+        "flat_rate": _stringify_optional_float(metrics.flat_rate),
+    }
+
+
+def _overall_csv_row(metrics: OverallMetrics) -> dict[str, str]:
+    return {
+        "scope": "overall",
+        "fold_id": "",
+        "fold_start": metrics.period_start.isoformat(),
+        "fold_end": metrics.period_end.isoformat(),
+        "decision_count": str(metrics.decision_count),
+        "hit_rate": _stringify_optional_float(metrics.hit_rate),
+        "precision_up": _stringify_optional_float(metrics.precision_up),
+        "precision_down": _stringify_optional_float(metrics.precision_down),
+        "recall_up": _stringify_optional_float(metrics.recall_up),
+        "recall_down": _stringify_optional_float(metrics.recall_down),
+        "skip_rate": _stringify_optional_float(metrics.skip_rate),
+        "flat_rate": _stringify_optional_float(metrics.flat_rate),
+    }
+
+
+def _stringify_optional_float(value: float | None) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _csv_row_values(row: dict[str, str]) -> list[str]:
+    return [row[field] for field in _CSV_FIELDS]
+
+
+def _normalize_backtest_rows(rows: Sequence[object]) -> tuple[BacktestRow, ...]:
+    normalized_rows: list[BacktestRow] = []
+    for row in rows:
+        if not isinstance(row, BacktestRow):
+            raise ValueError("rows must contain only BacktestRow values")
+        normalized_rows.append(row)
+    return tuple(sorted(normalized_rows, key=lambda row: (row.fold_id, row.decision_date)))
+
+
+def _normalize_overall_metrics(metrics: object) -> OverallMetrics:
+    if not isinstance(metrics, OverallMetrics):
+        raise ValueError("metrics must be OverallMetrics")
+    return metrics
+
+
+__all__ = ["write_backtest_jsonl", "write_metrics_csv", "write_metrics_json"]

--- a/core/src/kospi_decision_pipeline_core/backtest/runner.py
+++ b/core/src/kospi_decision_pipeline_core/backtest/runner.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import date, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario
+from kospi_decision_pipeline_core.schemas import DecisionResult
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow, OverallMetrics
+from kospi_decision_pipeline_core.schemas.decisions import GroundTruthLabel
+
+from .metrics import compute_fold_metrics, compute_overall_metrics
+from .reports import write_backtest_jsonl, write_metrics_csv, write_metrics_json
+from .walk_forward import WalkForwardSplitter
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestRunner:
+    splitter: WalkForwardSplitter
+    scenario_path: Path
+    output_dir: Path
+    scenario_invoker: Callable[
+        [Path | str, date, Path | None, Path | None],
+        DecisionResult,
+    ] = run_kospi_scenario
+
+    def run(self, *, dataset_path: Path) -> OverallMetrics:
+        dataset_rows = self._load_dataset_rows(dataset_path)
+        runtime_rows = self._build_runtime_rows(dataset_rows)
+        sorted_trade_dates = tuple(
+            _require_trade_date(row, context="trade_date") for row in runtime_rows
+        )
+        fold_rows: list[BacktestRow] = []
+
+        with TemporaryDirectory() as temporary_dir:
+            runtime_features_path = Path(temporary_dir) / "runtime_features.parquet"
+            scenario_output_dir = Path(temporary_dir) / "scenario-output"
+            self._write_runtime_features(runtime_features_path, runtime_rows)
+            for fold in self.splitter.split(sorted_trade_dates):
+                for test_index in fold.test_indices:
+                    runtime_row = runtime_rows[test_index]
+                    decision_date = _require_decision_date(runtime_row)
+                    target_label = _require_target_label(runtime_row)
+                    result = self.scenario_invoker(
+                        self.scenario_path,
+                        decision_date,
+                        runtime_features_path,
+                        scenario_output_dir,
+                    )
+                    fold_rows.append(
+                        BacktestRow(
+                            fold_id=fold.fold_id,
+                            decision_date=result.decision_date,
+                            label=result.label,
+                            aggregate_score=result.aggregate_score,
+                            target_label=target_label,
+                            correct=result.label == target_label,
+                            snapshot_id=result.snapshot_id,
+                            config_signature=result.config_signature,
+                        )
+                    )
+
+        sorted_rows = self._sorted_rows(fold_rows)
+        if len(sorted_rows) == 0:
+            raise ValueError("backtest runner produced no rows")
+        folds = tuple(
+            compute_fold_metrics(tuple(row for row in sorted_rows if row.fold_id == fold_id))
+            for fold_id in sorted({row.fold_id for row in sorted_rows})
+        )
+        overall_metrics = replace(compute_overall_metrics(sorted_rows), folds=folds)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        _ = write_backtest_jsonl(self.output_dir / "rows.jsonl", sorted_rows)
+        _ = write_metrics_json(self.output_dir / "metrics.json", overall_metrics)
+        _ = write_metrics_csv(self.output_dir / "metrics.csv", overall_metrics)
+        return overall_metrics
+
+    @staticmethod
+    def _sorted_rows(rows: Sequence[BacktestRow]) -> tuple[BacktestRow, ...]:
+        return tuple(sorted(rows, key=lambda row: (row.fold_id, row.decision_date)))
+
+    @staticmethod
+    def _next_decision_date_for_test(rows: Sequence[Mapping[str, object]], index: int) -> date:
+        return _next_decision_date(rows, index)
+
+    @staticmethod
+    def _require_decision_date_for_test(row: Mapping[str, object]) -> date:
+        return _require_decision_date(row)
+
+    @staticmethod
+    def _require_target_label_for_test(row: Mapping[str, object]) -> GroundTruthLabel:
+        return _require_target_label(row)
+
+    def _load_dataset_rows(self, dataset_path: Path) -> tuple[dict[str, object], ...]:
+        raw_rows = READ_TABLE(dataset_path).to_pylist()
+        if len(raw_rows) == 0:
+            raise ValueError("backtest dataset must not be empty")
+        sorted_rows = tuple(sorted((dict(row) for row in raw_rows), key=_trade_date_sort_key))
+        for index, row in enumerate(sorted_rows):
+            _ = _require_trade_date(row, context="trade_date")
+            _ = _require_target_label(row)
+            if index > 0 and sorted_rows[index - 1]["trade_date"] == row["trade_date"]:
+                raise ValueError("duplicate trade_date in backtest dataset")
+        return sorted_rows
+
+    def _build_runtime_rows(
+        self,
+        dataset_rows: Sequence[Mapping[str, object]],
+    ) -> tuple[dict[str, object], ...]:
+        runtime_rows: list[dict[str, object]] = []
+        for index, row in enumerate(dataset_rows):
+            trade_date = _require_trade_date(row, context="trade_date")
+            decision_date = _next_decision_date(dataset_rows, index)
+            runtime_row = {
+                key: value
+                for key, value in row.items()
+                if not key.startswith("target_") and not key.startswith("future_")
+            }
+            runtime_row["decision_date"] = decision_date
+            runtime_row["target_direction_label"] = _require_target_label(row)
+            runtime_row["trade_date"] = trade_date
+            runtime_rows.append(runtime_row)
+        return tuple(runtime_rows)
+
+    def _write_runtime_features(
+        self,
+        path: Path,
+        runtime_rows: Sequence[Mapping[str, object]],
+    ) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        factory = cast(_ArrowTableFactory, pa.Table)
+        table = factory.from_pylist(
+            [
+                {key: value for key, value in row.items() if key != "target_direction_label"}
+                for row in runtime_rows
+            ]
+        )
+        WRITE_TABLE(table, path, compression="snappy")
+
+
+def _trade_date_sort_key(row: Mapping[str, object]) -> date:
+    return _require_trade_date(row, context="trade_date")
+
+
+def _next_decision_date(rows: Sequence[Mapping[str, object]], index: int) -> date:
+    current_trade_date = _require_trade_date(rows[index], context="trade_date")
+    if index + 1 < len(rows):
+        next_trade_date = _require_trade_date(rows[index + 1], context="trade_date")
+        if next_trade_date <= current_trade_date:
+            raise ValueError("backtest dataset trade_date must be strictly increasing")
+        return next_trade_date
+    return _next_weekday(current_trade_date)
+
+
+def _next_weekday(current_trade_date: date) -> date:
+    candidate = current_trade_date + timedelta(days=1)
+    while candidate.weekday() >= 5:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+def _require_trade_date(row: Mapping[str, object], *, context: str) -> date:
+    value = row.get(context)
+    if not isinstance(value, date):
+        raise ValueError(f"{context} must be a date")
+    return value
+
+
+def _require_decision_date(row: Mapping[str, object]) -> date:
+    value = row.get("decision_date")
+    if not isinstance(value, date):
+        raise ValueError("decision_date must be a date")
+    return value
+
+
+def _require_target_label(row: Mapping[str, object]) -> GroundTruthLabel:
+    value = row.get("target_direction_label")
+    if value not in {"up", "down", "flat"}:
+        raise ValueError("target_direction_label must be one of: down, flat, up")
+    return cast(GroundTruthLabel, value)
+
+
+__all__ = ["BacktestRunner"]

--- a/core/src/kospi_decision_pipeline_core/schemas/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/__init__.py
@@ -6,9 +6,9 @@ from .config import (
     ScenarioConfig,
     ThresholdsConfig,
 )
+from .backtest import BacktestRow, FoldMetrics, OverallMetrics
 from .decisions import (
     AgentVote,
-    BacktestRow,
     DecisionRecord,
     DecisionResult,
     EvidenceItem,
@@ -29,9 +29,11 @@ __all__ = [
     "DecisionResult",
     "EvidenceItem",
     "FeatureRecord",
+    "FoldMetrics",
     "GroundTruthLabel",
     "from_jsonl_line",
     "ModelLabel",
+    "OverallMetrics",
     "ScenarioRuntimeConfig",
     "ScenarioConfig",
     "ThresholdsConfig",

--- a/core/src/kospi_decision_pipeline_core/schemas/backtest.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/backtest.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from typing import cast
+
+from .decisions import GroundTruthLabel, ModelLabel
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestRow:
+    fold_id: int
+    decision_date: date
+    label: ModelLabel
+    aggregate_score: float
+    target_label: GroundTruthLabel
+    correct: bool
+    snapshot_id: str
+    config_signature: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fold_id", _ensure_positive_int(self.fold_id, context="fold_id"))
+        object.__setattr__(
+            self,
+            "decision_date",
+            _ensure_date(self.decision_date, context="decision_date"),
+        )
+        object.__setattr__(self, "label", _ensure_model_label(self.label, context="label"))
+        object.__setattr__(
+            self,
+            "aggregate_score",
+            _ensure_float(self.aggregate_score, context="aggregate_score"),
+        )
+        object.__setattr__(
+            self,
+            "target_label",
+            _ensure_ground_truth_label(self.target_label, context="target_label"),
+        )
+        object.__setattr__(self, "correct", _ensure_bool(self.correct, context="correct"))
+        object.__setattr__(
+            self,
+            "snapshot_id",
+            _ensure_string(self.snapshot_id, context="snapshot_id"),
+        )
+        object.__setattr__(
+            self,
+            "config_signature",
+            _ensure_string(self.config_signature, context="config_signature"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FoldMetrics:
+    fold_id: int
+    fold_start: date
+    fold_end: date
+    decision_count: int
+    hit_rate: float | None
+    precision_up: float | None
+    precision_down: float | None
+    recall_up: float | None
+    recall_down: float | None
+    skip_rate: float | None
+    flat_rate: float | None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "fold_id", _ensure_positive_int(self.fold_id, context="fold_id"))
+        object.__setattr__(self, "fold_start", _ensure_date(self.fold_start, context="fold_start"))
+        object.__setattr__(self, "fold_end", _ensure_date(self.fold_end, context="fold_end"))
+        object.__setattr__(
+            self,
+            "decision_count",
+            _ensure_non_negative_int(self.decision_count, context="decision_count"),
+        )
+        if self.fold_end < self.fold_start:
+            raise ValueError("fold_end must be on or after fold_start")
+        _validate_optional_rate(self.hit_rate, context="hit_rate")
+        _validate_optional_rate(self.precision_up, context="precision_up")
+        _validate_optional_rate(self.precision_down, context="precision_down")
+        _validate_optional_rate(self.recall_up, context="recall_up")
+        _validate_optional_rate(self.recall_down, context="recall_down")
+        _validate_optional_rate(self.skip_rate, context="skip_rate")
+        _validate_optional_rate(self.flat_rate, context="flat_rate")
+
+
+@dataclass(frozen=True, slots=True)
+class OverallMetrics:
+    fold_count: int
+    period_start: date
+    period_end: date
+    decision_count: int
+    hit_rate: float | None
+    precision_up: float | None
+    precision_down: float | None
+    recall_up: float | None
+    recall_down: float | None
+    skip_rate: float | None
+    flat_rate: float | None
+    folds: tuple[FoldMetrics, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "fold_count",
+            _ensure_non_negative_int(self.fold_count, context="fold_count"),
+        )
+        object.__setattr__(
+            self,
+            "period_start",
+            _ensure_date(self.period_start, context="period_start"),
+        )
+        object.__setattr__(self, "period_end", _ensure_date(self.period_end, context="period_end"))
+        object.__setattr__(
+            self,
+            "decision_count",
+            _ensure_non_negative_int(self.decision_count, context="decision_count"),
+        )
+        if self.period_end < self.period_start:
+            raise ValueError("period_end must be on or after period_start")
+        if self.fold_count != len(self.folds) and len(self.folds) != 0:
+            raise ValueError("fold_count must match len(folds)")
+        _validate_optional_rate(self.hit_rate, context="hit_rate")
+        _validate_optional_rate(self.precision_up, context="precision_up")
+        _validate_optional_rate(self.precision_down, context="precision_down")
+        _validate_optional_rate(self.recall_up, context="recall_up")
+        _validate_optional_rate(self.recall_down, context="recall_down")
+        _validate_optional_rate(self.skip_rate, context="skip_rate")
+        _validate_optional_rate(self.flat_rate, context="flat_rate")
+        for fold in self.folds:
+            if type(fold) is not FoldMetrics:
+                raise ValueError("folds items must be FoldMetrics")
+
+
+def backtest_row_to_mapping(row: BacktestRow) -> dict[str, object]:
+    return {
+        "fold_id": row.fold_id,
+        "decision_date": row.decision_date.isoformat(),
+        "label": row.label,
+        "aggregate_score": row.aggregate_score,
+        "target_label": row.target_label,
+        "correct": row.correct,
+        "snapshot_id": row.snapshot_id,
+        "config_signature": row.config_signature,
+    }
+
+
+def backtest_row_from_mapping(mapping: Mapping[str, object]) -> BacktestRow:
+    return BacktestRow(
+        fold_id=_require_int(mapping, "fold_id"),
+        decision_date=_require_date_string(mapping, "decision_date"),
+        label=_require_model_label(mapping, "label"),
+        aggregate_score=_require_float(mapping, "aggregate_score"),
+        target_label=_require_ground_truth_label(mapping, "target_label"),
+        correct=_require_bool(mapping, "correct"),
+        snapshot_id=_require_string(mapping, "snapshot_id"),
+        config_signature=_require_string(mapping, "config_signature"),
+    )
+
+
+def fold_metrics_to_mapping(metrics: FoldMetrics) -> dict[str, object]:
+    return {
+        "fold_id": metrics.fold_id,
+        "fold_start": metrics.fold_start.isoformat(),
+        "fold_end": metrics.fold_end.isoformat(),
+        "decision_count": metrics.decision_count,
+        "hit_rate": metrics.hit_rate,
+        "precision_up": metrics.precision_up,
+        "precision_down": metrics.precision_down,
+        "recall_up": metrics.recall_up,
+        "recall_down": metrics.recall_down,
+        "skip_rate": metrics.skip_rate,
+        "flat_rate": metrics.flat_rate,
+    }
+
+
+def overall_metrics_to_mapping(metrics: OverallMetrics) -> dict[str, object]:
+    return {
+        "fold_count": metrics.fold_count,
+        "period_start": metrics.period_start.isoformat(),
+        "period_end": metrics.period_end.isoformat(),
+        "decision_count": metrics.decision_count,
+        "hit_rate": metrics.hit_rate,
+        "precision_up": metrics.precision_up,
+        "precision_down": metrics.precision_down,
+        "recall_up": metrics.recall_up,
+        "recall_down": metrics.recall_down,
+        "skip_rate": metrics.skip_rate,
+        "flat_rate": metrics.flat_rate,
+        "folds": [fold_metrics_to_mapping(fold) for fold in metrics.folds],
+    }
+
+
+def _ensure_string(value: object, *, context: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{context} must be a string")
+    return value
+
+
+def _ensure_float(value: object, *, context: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"{context} must be a float")
+    return float(value)
+
+
+def _ensure_date(value: object, *, context: str) -> date:
+    if not isinstance(value, date):
+        raise ValueError(f"{context} must be a date")
+    return value
+
+
+def _ensure_bool(value: object, *, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{context} must be a bool")
+    return value
+
+
+def _ensure_positive_int(value: object, *, context: str) -> int:
+    normalized = _ensure_non_negative_int(value, context=context)
+    if normalized <= 0:
+        raise ValueError(f"{context} must be positive")
+    return normalized
+
+
+def _ensure_non_negative_int(value: object, *, context: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{context} must be an int")
+    if value < 0:
+        raise ValueError(f"{context} must be non-negative")
+    return value
+
+
+def _ensure_model_label(value: object, *, context: str) -> ModelLabel:
+    if not isinstance(value, str) or value not in {"up", "down", "skip"}:
+        raise ValueError(f"{context} must be one of: down, skip, up")
+    return cast(ModelLabel, value)
+
+
+def _ensure_ground_truth_label(value: object, *, context: str) -> GroundTruthLabel:
+    if not isinstance(value, str) or value not in {"up", "down", "flat"}:
+        raise ValueError(f"{context} must be one of: down, flat, up")
+    return cast(GroundTruthLabel, value)
+
+
+def _validate_optional_rate(value: float | None, *, context: str) -> None:
+    if value is None:
+        return
+    normalized = _ensure_float(value, context=context)
+    if normalized < 0.0 or normalized > 1.0:
+        raise ValueError(f"{context} must be between 0.0 and 1.0")
+
+
+def _require_value(mapping: Mapping[str, object], key: str) -> object:
+    if key not in mapping:
+        raise ValueError(f"missing required key: {key}")
+    return mapping[key]
+
+
+def _require_int(mapping: Mapping[str, object], key: str) -> int:
+    return _ensure_non_negative_int(_require_value(mapping, key), context=key)
+
+
+def _require_string(mapping: Mapping[str, object], key: str) -> str:
+    return _ensure_string(_require_value(mapping, key), context=key)
+
+
+def _require_bool(mapping: Mapping[str, object], key: str) -> bool:
+    return _ensure_bool(_require_value(mapping, key), context=key)
+
+
+def _require_float(mapping: Mapping[str, object], key: str) -> float:
+    return _ensure_float(_require_value(mapping, key), context=key)
+
+
+def _require_date_string(mapping: Mapping[str, object], key: str) -> date:
+    value = _require_string(mapping, key)
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{key} must be an ISO date") from exc
+
+
+def _require_model_label(mapping: Mapping[str, object], key: str) -> ModelLabel:
+    return _ensure_model_label(_require_value(mapping, key), context=key)
+
+
+def _require_ground_truth_label(mapping: Mapping[str, object], key: str) -> GroundTruthLabel:
+    return _ensure_ground_truth_label(_require_value(mapping, key), context=key)
+
+
+__all__ = [
+    "BacktestRow",
+    "FoldMetrics",
+    "OverallMetrics",
+    "backtest_row_from_mapping",
+    "backtest_row_to_mapping",
+    "fold_metrics_to_mapping",
+    "overall_metrics_to_mapping",
+]

--- a/core/src/kospi_decision_pipeline_core/schemas/decisions.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/decisions.py
@@ -99,40 +99,6 @@ class DecisionResult:
 
 
 @dataclass(frozen=True, slots=True)
-class BacktestRow:
-    decision_date: date
-    label: ModelLabel
-    aggregate_score: float
-    ground_truth: GroundTruthLabel
-    next_day_return: float
-    hit: bool
-
-    def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "decision_date",
-            _ensure_date(self.decision_date, context="decision_date"),
-        )
-        object.__setattr__(self, "label", _ensure_model_label(self.label, context="label"))
-        object.__setattr__(
-            self,
-            "aggregate_score",
-            _ensure_float(self.aggregate_score, context="aggregate_score"),
-        )
-        object.__setattr__(
-            self,
-            "ground_truth",
-            _ensure_ground_truth_label(self.ground_truth, context="ground_truth"),
-        )
-        object.__setattr__(
-            self,
-            "next_day_return",
-            _ensure_float(self.next_day_return, context="next_day_return"),
-        )
-        object.__setattr__(self, "hit", _ensure_bool(self.hit, context="hit"))
-
-
-@dataclass(frozen=True, slots=True)
 class DecisionRecord:
     pass
 
@@ -155,22 +121,10 @@ def _ensure_date(value: object, *, context: str) -> date:
     return value
 
 
-def _ensure_bool(value: object, *, context: str) -> bool:
-    if not isinstance(value, bool):
-        raise ValueError(f"{context} must be a bool")
-    return value
-
-
 def _ensure_model_label(value: object, *, context: str) -> ModelLabel:
     if not isinstance(value, str) or value not in _MODEL_LABELS:
         raise ValueError(f"{context} must be one of: down, skip, up")
     return cast(ModelLabel, value)
-
-
-def _ensure_ground_truth_label(value: object, *, context: str) -> GroundTruthLabel:
-    if not isinstance(value, str) or value not in _GROUND_TRUTH_LABELS:
-        raise ValueError(f"{context} must be one of: down, flat, up")
-    return cast(GroundTruthLabel, value)
 
 
 def _ensure_tuple_of(

--- a/core/src/kospi_decision_pipeline_core/schemas/serialization.py
+++ b/core/src/kospi_decision_pipeline_core/schemas/serialization.py
@@ -5,9 +5,9 @@ from collections.abc import Mapping
 from datetime import date
 from typing import cast, overload
 
+from .backtest import BacktestRow
 from .decisions import (
     AgentVote,
-    BacktestRow,
     DecisionResult,
     EvidenceItem,
     GroundTruthLabel,
@@ -15,12 +15,14 @@ from .decisions import (
 )
 
 BACKTEST_CSV_FIELDS: tuple[str, ...] = (
+    "fold_id",
     "decision_date",
     "label",
     "aggregate_score",
-    "ground_truth",
-    "next_day_return",
-    "hit",
+    "target_label",
+    "correct",
+    "snapshot_id",
+    "config_signature",
 )
 
 
@@ -59,7 +61,7 @@ def to_jsonl_line(obj: EvidenceItem | AgentVote | DecisionResult | BacktestRow) 
     return json.dumps(_to_json_value(obj), separators=(",", ":"), ensure_ascii=False)
 
 
-def to_csv_row(obj: BacktestRow, fields: tuple[str, ...]) -> dict[str, str]:
+def to_csv_row(obj: object, fields: tuple[str, ...]) -> dict[str, str]:
     if not isinstance(obj, BacktestRow):
         raise ValueError("to_csv_row supports only flat BacktestRow values")
     if fields != BACKTEST_CSV_FIELDS:
@@ -109,12 +111,14 @@ def parse_decision_result(line: str) -> DecisionResult:
 def parse_backtest_row(line: str) -> BacktestRow:
     payload = _parse_json_object(line)
     return BacktestRow(
+        fold_id=_require_int(payload, "fold_id"),
         decision_date=_require_date(payload, "decision_date"),
         label=_require_model_label(payload, "label"),
         aggregate_score=_require_float(payload, "aggregate_score"),
-        ground_truth=_require_ground_truth_label(payload, "ground_truth"),
-        next_day_return=_require_float(payload, "next_day_return"),
-        hit=_require_bool(payload, "hit"),
+        target_label=_require_ground_truth_label(payload, "target_label"),
+        correct=_require_bool(payload, "correct"),
+        snapshot_id=_require_string(payload, "snapshot_id"),
+        config_signature=_require_string(payload, "config_signature"),
     )
 
 
@@ -150,12 +154,14 @@ def _to_json_value(
             "snapshot_id": obj.snapshot_id,
         }
     return {
+        "fold_id": obj.fold_id,
         "decision_date": obj.decision_date.isoformat(),
         "label": obj.label,
         "aggregate_score": obj.aggregate_score,
-        "ground_truth": obj.ground_truth,
-        "next_day_return": obj.next_day_return,
-        "hit": obj.hit,
+        "target_label": obj.target_label,
+        "correct": obj.correct,
+        "snapshot_id": obj.snapshot_id,
+        "config_signature": obj.config_signature,
     }
 
 
@@ -195,6 +201,13 @@ def _require_bool(payload: Mapping[str, object], key: str) -> bool:
     return value
 
 
+def _require_int(payload: Mapping[str, object], key: str) -> int:
+    value = _require_value(payload, key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{key} must be an int")
+    return value
+
+
 def _require_date(payload: Mapping[str, object], key: str) -> date:
     value = _require_string(payload, key)
     try:
@@ -229,14 +242,18 @@ def _dump_json(value: object) -> str:
 
 
 def _backtest_field_string(row: BacktestRow, field: str) -> str:
+    if field == "fold_id":
+        return str(row.fold_id)
     if field == "decision_date":
         return row.decision_date.isoformat()
     if field == "label":
         return row.label
     if field == "aggregate_score":
         return str(row.aggregate_score)
-    if field == "ground_truth":
-        return row.ground_truth
-    if field == "next_day_return":
-        return str(row.next_day_return)
-    return "true" if row.hit else "false"
+    if field == "target_label":
+        return row.target_label
+    if field == "correct":
+        return "true" if row.correct else "false"
+    if field == "snapshot_id":
+        return row.snapshot_id
+    return row.config_signature

--- a/core/tests/backtest/test_metrics.py
+++ b/core/tests/backtest/test_metrics.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import date
+
+from kospi_decision_pipeline_core.backtest.metrics import (
+    compute_fold_metrics,
+    compute_overall_metrics,
+)
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow
+import pytest
+
+
+def _row(
+    *,
+    fold_id: int,
+    decision_date: date,
+    label: str,
+    target_label: str,
+) -> BacktestRow:
+    return BacktestRow(
+        fold_id=fold_id,
+        decision_date=decision_date,
+        label=label,
+        aggregate_score=0.0,
+        target_label=target_label,
+        correct=label == target_label and label != "skip",
+        snapshot_id=f"snapshot:{decision_date.isoformat()}",
+        config_signature="cfg:test",
+    )
+
+
+def test_compute_fold_metrics_covers_all_label_target_pairs() -> None:
+    rows = (
+        _row(fold_id=1, decision_date=date(2025, 1, 2), label="up", target_label="up"),
+        _row(fold_id=1, decision_date=date(2025, 1, 3), label="up", target_label="down"),
+        _row(fold_id=1, decision_date=date(2025, 1, 6), label="up", target_label="flat"),
+        _row(fold_id=1, decision_date=date(2025, 1, 7), label="down", target_label="up"),
+        _row(fold_id=1, decision_date=date(2025, 1, 8), label="down", target_label="down"),
+        _row(fold_id=1, decision_date=date(2025, 1, 9), label="down", target_label="flat"),
+        _row(fold_id=1, decision_date=date(2025, 1, 10), label="skip", target_label="up"),
+        _row(fold_id=1, decision_date=date(2025, 1, 13), label="skip", target_label="down"),
+        _row(fold_id=1, decision_date=date(2025, 1, 14), label="skip", target_label="flat"),
+    )
+
+    metrics = compute_fold_metrics(rows)
+
+    assert metrics.fold_id == 1
+    assert metrics.fold_start == date(2025, 1, 2)
+    assert metrics.fold_end == date(2025, 1, 14)
+    assert metrics.decision_count == 9
+    assert metrics.hit_rate == 2 / 6
+    assert metrics.precision_up == 1 / 3
+    assert metrics.precision_down == 1 / 3
+    assert metrics.recall_up == 1 / 3
+    assert metrics.recall_down == 1 / 3
+    assert metrics.skip_rate == 3 / 9
+    assert metrics.flat_rate == 3 / 9
+
+
+def test_compute_fold_metrics_returns_none_for_zero_denominator_cases() -> None:
+    rows = (
+        _row(fold_id=2, decision_date=date(2025, 2, 3), label="skip", target_label="flat"),
+        _row(fold_id=2, decision_date=date(2025, 2, 4), label="skip", target_label="flat"),
+    )
+
+    metrics = compute_fold_metrics(rows)
+
+    assert metrics.hit_rate is None
+    assert metrics.precision_up is None
+    assert metrics.precision_down is None
+    assert metrics.recall_up is None
+    assert metrics.recall_down is None
+    assert metrics.skip_rate == 1.0
+    assert metrics.flat_rate == 1.0
+
+
+def test_compute_overall_metrics_aggregates_across_folds() -> None:
+    rows = (
+        _row(fold_id=1, decision_date=date(2025, 1, 2), label="up", target_label="up"),
+        _row(fold_id=1, decision_date=date(2025, 1, 3), label="skip", target_label="down"),
+        _row(fold_id=2, decision_date=date(2025, 1, 6), label="down", target_label="down"),
+        _row(fold_id=2, decision_date=date(2025, 1, 7), label="down", target_label="flat"),
+    )
+
+    metrics = compute_overall_metrics(rows)
+
+    assert metrics.fold_count == 2
+    assert metrics.decision_count == 4
+    assert metrics.period_start == date(2025, 1, 2)
+    assert metrics.period_end == date(2025, 1, 7)
+    assert metrics.hit_rate == 2 / 3
+    assert metrics.precision_up == 1.0
+    assert metrics.precision_down == 1 / 2
+    assert metrics.recall_up == 1.0
+    assert metrics.recall_down == 1 / 2
+    assert metrics.skip_rate == 1 / 4
+    assert metrics.flat_rate == 1 / 4
+
+
+def test_metrics_reject_empty_rows_and_mixed_fold_rows() -> None:
+    with pytest.raises(ValueError, match="rows must not be empty"):
+        _ = compute_overall_metrics(())
+
+    with pytest.raises(ValueError, match="exactly one fold"):
+        _ = compute_fold_metrics(
+            (
+                _row(fold_id=1, decision_date=date(2025, 1, 2), label="up", target_label="up"),
+                _row(
+                    fold_id=2,
+                    decision_date=date(2025, 1, 3),
+                    label="down",
+                    target_label="down",
+                ),
+            )
+        )

--- a/core/tests/backtest/test_reports.py
+++ b/core/tests/backtest/test_reports.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+from kospi_decision_pipeline_core.backtest.reports import (
+    write_backtest_jsonl,
+    write_metrics_csv,
+    write_metrics_json,
+)
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow, FoldMetrics, OverallMetrics
+import pytest
+
+
+def _row(*, fold_id: int, decision_date: date, label: str, target_label: str) -> BacktestRow:
+    return BacktestRow(
+        fold_id=fold_id,
+        decision_date=decision_date,
+        label=label,
+        aggregate_score=0.0,
+        target_label=target_label,
+        correct=label == target_label and label != "skip",
+        snapshot_id=f"snapshot:{decision_date.isoformat()}",
+        config_signature="cfg:test",
+    )
+
+
+def test_write_backtest_jsonl_sorts_rows_deterministically(tmp_path: Path) -> None:
+    output_path = tmp_path / "rows.jsonl"
+
+    rows = (
+        _row(fold_id=2, decision_date=date(2025, 1, 8), label="down", target_label="down"),
+        _row(fold_id=1, decision_date=date(2025, 1, 7), label="up", target_label="up"),
+        _row(fold_id=1, decision_date=date(2025, 1, 6), label="skip", target_label="flat"),
+    )
+
+    write_backtest_jsonl(output_path, rows)
+    first_bytes = output_path.read_bytes()
+    write_backtest_jsonl(output_path, rows)
+
+    assert output_path.read_bytes() == first_bytes
+    assert output_path.read_text(encoding="utf-8") == (
+        '{"fold_id":1,"decision_date":"2025-01-06","label":"skip","aggregate_score":0.0,'
+        '"target_label":"flat","correct":false,"snapshot_id":"snapshot:2025-01-06",'
+        '"config_signature":"cfg:test"}\n'
+        '{"fold_id":1,"decision_date":"2025-01-07","label":"up","aggregate_score":0.0,'
+        '"target_label":"up","correct":true,"snapshot_id":"snapshot:2025-01-07",'
+        '"config_signature":"cfg:test"}\n'
+        '{"fold_id":2,"decision_date":"2025-01-08","label":"down","aggregate_score":0.0,'
+        '"target_label":"down","correct":true,"snapshot_id":"snapshot:2025-01-08",'
+        '"config_signature":"cfg:test"}\n'
+    )
+
+
+def test_write_metrics_json_emits_stable_summary_shape(tmp_path: Path) -> None:
+    output_path = tmp_path / "metrics.json"
+    metrics = OverallMetrics(
+        fold_count=1,
+        period_start=date(2025, 1, 6),
+        period_end=date(2025, 1, 8),
+        decision_count=3,
+        hit_rate=1.0,
+        precision_up=1.0,
+        precision_down=None,
+        recall_up=1.0,
+        recall_down=None,
+        skip_rate=1 / 3,
+        flat_rate=1 / 3,
+        folds=(
+            FoldMetrics(
+                fold_id=1,
+                fold_start=date(2025, 1, 6),
+                fold_end=date(2025, 1, 8),
+                decision_count=3,
+                hit_rate=1.0,
+                precision_up=1.0,
+                precision_down=None,
+                recall_up=1.0,
+                recall_down=None,
+                skip_rate=1 / 3,
+                flat_rate=1 / 3,
+            ),
+        ),
+    )
+
+    write_metrics_json(output_path, metrics)
+    first_bytes = output_path.read_bytes()
+    write_metrics_json(output_path, metrics)
+
+    assert output_path.read_bytes() == first_bytes
+    assert json.loads(output_path.read_text(encoding="utf-8")) == {
+        "folds": [
+            {
+                "fold_id": 1,
+                "fold_start": "2025-01-06",
+                "fold_end": "2025-01-08",
+                "decision_count": 3,
+                "hit_rate": 1.0,
+                "precision_up": 1.0,
+                "precision_down": None,
+                "recall_up": 1.0,
+                "recall_down": None,
+                "skip_rate": 1 / 3,
+                "flat_rate": 1 / 3,
+            }
+        ],
+        "overall": {
+            "fold_count": 1,
+            "period_start": "2025-01-06",
+            "period_end": "2025-01-08",
+            "decision_count": 3,
+            "hit_rate": 1.0,
+            "precision_up": 1.0,
+            "precision_down": None,
+            "recall_up": 1.0,
+            "recall_down": None,
+            "skip_rate": 1 / 3,
+            "flat_rate": 1 / 3,
+        },
+    }
+
+
+def test_write_metrics_csv_emits_human_readable_rows(tmp_path: Path) -> None:
+    output_path = tmp_path / "metrics.csv"
+    metrics = OverallMetrics(
+        fold_count=2,
+        period_start=date(2025, 1, 6),
+        period_end=date(2025, 1, 10),
+        decision_count=5,
+        hit_rate=0.5,
+        precision_up=1.0,
+        precision_down=0.0,
+        recall_up=0.5,
+        recall_down=0.0,
+        skip_rate=0.2,
+        flat_rate=0.2,
+        folds=(
+            FoldMetrics(
+                fold_id=1,
+                fold_start=date(2025, 1, 6),
+                fold_end=date(2025, 1, 7),
+                decision_count=2,
+                hit_rate=1.0,
+                precision_up=1.0,
+                precision_down=None,
+                recall_up=1.0,
+                recall_down=1.0,
+                skip_rate=0.0,
+                flat_rate=0.0,
+            ),
+            FoldMetrics(
+                fold_id=2,
+                fold_start=date(2025, 1, 8),
+                fold_end=date(2025, 1, 10),
+                decision_count=3,
+                hit_rate=0.0,
+                precision_up=None,
+                precision_down=0.0,
+                recall_up=0.0,
+                recall_down=0.0,
+                skip_rate=1 / 3,
+                flat_rate=1 / 3,
+            ),
+        ),
+    )
+
+    write_metrics_csv(output_path, metrics)
+
+    assert output_path.read_text(encoding="utf-8") == (
+        "scope,fold_id,fold_start,fold_end,decision_count,hit_rate,precision_up,precision_down,recall_up,recall_down,skip_rate,flat_rate\n"
+        "fold,1,2025-01-06,2025-01-07,2,1.0,1.0,,1.0,1.0,0.0,0.0\n"
+        "fold,2,2025-01-08,2025-01-10,3,0.0,,0.0,0.0,0.0,0.3333333333333333,0.3333333333333333\n"
+        "overall,,2025-01-06,2025-01-10,5,0.5,1.0,0.0,0.5,0.0,0.2,0.2\n"
+    )
+
+
+def test_report_writers_validate_input_types(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="BacktestRow"):
+        _ = write_backtest_jsonl(tmp_path / "rows.jsonl", (object(),))
+
+    with pytest.raises(ValueError, match="OverallMetrics"):
+        _ = write_metrics_json(tmp_path / "metrics.json", object())
+
+    with pytest.raises(ValueError, match="OverallMetrics"):
+        _ = write_metrics_csv(tmp_path / "metrics.csv", object())

--- a/core/tests/backtest/test_runner.py
+++ b/core/tests/backtest/test_runner.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from kospi_decision_pipeline_core.backtest.runner import BacktestRunner
+from kospi_decision_pipeline_core.backtest.walk_forward import WalkForwardSplitter
+from kospi_decision_pipeline_core.schemas import DecisionResult
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+    def slice(self, offset: int, length: int | None = None) -> _ArrowTable: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    if len(rows) == 0:
+        return factory.from_pylist([{"trade_date": date(1970, 1, 1)}]).slice(0, 0)
+    return factory.from_pylist(rows)
+
+
+def _write_dataset(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _dataset_rows() -> list[dict[str, object]]:
+    trade_dates = [date(2025, 1, 6) + timedelta(days=offset) for offset in range(5)]
+    labels = ["up", "flat", "down", "up", "down"]
+    rows: list[dict[str, object]] = []
+    for index, trade_date in enumerate(trade_dates):
+        rows.append(
+            {
+                "trade_date": trade_date,
+                "kospi_return_1d": float(index),
+                "kospi_return_5d": float(index + 1),
+                "target_next_day_simple_return": 0.01,
+                "target_next_day_log_return": 0.01,
+                "target_direction_label": labels[index],
+            }
+        )
+    return rows
+
+
+def test_backtest_runner_orchestrates_split_invoke_join_and_reports(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "data" / "gold" / "backtest_dataset.parquet"
+    _write_dataset(dataset_path, _dataset_rows())
+    scenario_path = tmp_path / "config" / "scenario.yaml"
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = scenario_path.write_text("scenario_id: test\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    calls: list[tuple[date, Path, Path | None]] = []
+
+    def stub_invoker(
+        scenario_path: Path | str,
+        decision_date: date,
+        features_path: Path | None = None,
+        output_dir: Path | None = None,
+    ) -> DecisionResult:
+        del scenario_path
+        assert features_path is not None
+        runtime_rows = pq.read_table(features_path).to_pylist()
+        assert all("target_direction_label" not in row for row in runtime_rows)
+        assert all("decision_date" in row for row in runtime_rows)
+        calls.append((decision_date, features_path, output_dir))
+        label_by_date = {
+            date(2025, 1, 9): "down",
+            date(2025, 1, 10): "skip",
+            date(2025, 1, 13): "up",
+        }
+        score_by_date = {
+            date(2025, 1, 9): -0.4,
+            date(2025, 1, 10): 0.0,
+            date(2025, 1, 13): 0.3,
+        }
+        return DecisionResult(
+            decision_date=decision_date,
+            label=label_by_date[decision_date],
+            aggregate_score=score_by_date[decision_date],
+            threshold_up=0.25,
+            threshold_down=-0.25,
+            votes=(),
+            config_signature="cfg:test",
+            snapshot_id=f"snapshot:{decision_date.isoformat()}",
+        )
+
+    runner = BacktestRunner(
+        splitter=WalkForwardSplitter(min_train_rows=2, test_fold_size=2, gap_days=0),
+        scenario_path=scenario_path,
+        output_dir=output_dir,
+        scenario_invoker=stub_invoker,
+    )
+
+    metrics = runner.run(dataset_path=dataset_path)
+
+    assert [decision_date for decision_date, _, _ in calls] == [
+        date(2025, 1, 9),
+        date(2025, 1, 10),
+        date(2025, 1, 13),
+    ]
+    assert all(path == calls[0][1] for _, path, _ in calls)
+    assert metrics.fold_count == 2
+    assert metrics.decision_count == 3
+    assert metrics.hit_rate == 1 / 2
+    assert metrics.precision_up == 0.0
+    assert metrics.precision_down == 1.0
+    assert metrics.recall_up == 0.0
+    assert metrics.recall_down == 1 / 2
+    assert metrics.skip_rate == 1 / 3
+    assert metrics.flat_rate == 0.0
+    assert [fold.fold_id for fold in metrics.folds] == [1, 2]
+
+    rows_path = output_dir / "rows.jsonl"
+    metrics_path = output_dir / "metrics.json"
+    csv_path = output_dir / "metrics.csv"
+    assert rows_path.is_file()
+    assert metrics_path.is_file()
+    assert csv_path.is_file()
+    assert rows_path.read_text(encoding="utf-8").splitlines() == [
+        '{"fold_id":1,"decision_date":"2025-01-09","label":"down","aggregate_score":-0.4,'
+        '"target_label":"down","correct":true,"snapshot_id":"snapshot:2025-01-09",'
+        '"config_signature":"cfg:test"}',
+        '{"fold_id":1,"decision_date":"2025-01-10","label":"skip","aggregate_score":0.0,'
+        '"target_label":"up","correct":false,"snapshot_id":"snapshot:2025-01-10",'
+        '"config_signature":"cfg:test"}',
+        '{"fold_id":2,"decision_date":"2025-01-13","label":"up","aggregate_score":0.3,'
+        '"target_label":"down","correct":false,"snapshot_id":"snapshot:2025-01-13",'
+        '"config_signature":"cfg:test"}',
+    ]
+
+
+def test_backtest_runner_is_byte_deterministic_across_repeated_runs(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "data" / "gold" / "backtest_dataset.parquet"
+    _write_dataset(dataset_path, _dataset_rows())
+    scenario_path = tmp_path / "config" / "scenario.yaml"
+    scenario_path.parent.mkdir(parents=True, exist_ok=True)
+    _ = scenario_path.write_text("scenario_id: test\n", encoding="utf-8")
+
+    def stub_invoker(
+        scenario_path: Path | str,
+        decision_date: date,
+        features_path: Path | None = None,
+        output_dir: Path | None = None,
+    ) -> DecisionResult:
+        del scenario_path, features_path, output_dir
+        return DecisionResult(
+            decision_date=decision_date,
+            label="skip",
+            aggregate_score=0.0,
+            threshold_up=0.25,
+            threshold_down=-0.25,
+            votes=(),
+            config_signature="cfg:test",
+            snapshot_id=f"snapshot:{decision_date.isoformat()}",
+        )
+
+    first_output_dir = tmp_path / "first"
+    second_output_dir = tmp_path / "second"
+    for output_dir in (first_output_dir, second_output_dir):
+        BacktestRunner(
+            splitter=WalkForwardSplitter(min_train_rows=2, test_fold_size=2, gap_days=0),
+            scenario_path=scenario_path,
+            output_dir=output_dir,
+            scenario_invoker=stub_invoker,
+        ).run(dataset_path=dataset_path)
+
+    assert (first_output_dir / "rows.jsonl").read_bytes() == (
+        second_output_dir / "rows.jsonl"
+    ).read_bytes()
+    assert (first_output_dir / "metrics.json").read_bytes() == (
+        second_output_dir / "metrics.json"
+    ).read_bytes()
+
+
+def test_backtest_runner_rows_are_sorted_by_fold_then_decision_date() -> None:
+    rows = (
+        BacktestRow(
+            fold_id=2,
+            decision_date=date(2025, 1, 13),
+            label="skip",
+            aggregate_score=0.0,
+            target_label="down",
+            correct=False,
+            snapshot_id="snapshot:2",
+            config_signature="cfg:test",
+        ),
+        BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 1, 10),
+            label="skip",
+            aggregate_score=0.0,
+            target_label="up",
+            correct=False,
+            snapshot_id="snapshot:1b",
+            config_signature="cfg:test",
+        ),
+        BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 1, 9),
+            label="down",
+            aggregate_score=-0.4,
+            target_label="down",
+            correct=True,
+            snapshot_id="snapshot:1a",
+            config_signature="cfg:test",
+        ),
+    )
+
+    assert BacktestRunner._sorted_rows(rows) == (
+        rows[2],
+        rows[1],
+        rows[0],
+    )
+
+
+def test_backtest_runner_validates_dataset_and_helper_inputs(tmp_path: Path) -> None:
+    dataset_path = tmp_path / "data" / "gold" / "backtest_dataset.parquet"
+    _write_dataset(
+        dataset_path,
+        [
+            {
+                "trade_date": date(2025, 1, 6),
+                "kospi_return_1d": 0.0,
+                "kospi_return_5d": 0.0,
+                "target_next_day_simple_return": 0.0,
+                "target_next_day_log_return": 0.0,
+                "target_direction_label": "up",
+            },
+            {
+                "trade_date": date(2025, 1, 6),
+                "kospi_return_1d": 0.0,
+                "kospi_return_5d": 0.0,
+                "target_next_day_simple_return": 0.0,
+                "target_next_day_log_return": 0.0,
+                "target_direction_label": "down",
+            },
+        ],
+    )
+    runner = BacktestRunner(
+        splitter=WalkForwardSplitter(min_train_rows=1, test_fold_size=1, gap_days=0),
+        scenario_path=tmp_path / "scenario.yaml",
+        output_dir=tmp_path / "out",
+    )
+
+    with pytest.raises(ValueError, match="duplicate trade_date"):
+        _ = runner._load_dataset_rows(dataset_path)
+
+    invalid_dataset_path = tmp_path / "invalid.parquet"
+    _write_dataset(
+        invalid_dataset_path,
+        [
+            {
+                "trade_date": "2025-01-06",
+                "kospi_return_1d": 0.0,
+                "kospi_return_5d": 0.0,
+                "target_next_day_simple_return": 0.0,
+                "target_next_day_log_return": 0.0,
+                "target_direction_label": "up",
+            }
+        ],
+    )
+    with pytest.raises(ValueError, match="trade_date must be a date"):
+        _ = runner._load_dataset_rows(invalid_dataset_path)
+
+
+def test_backtest_runner_exercises_error_branches(tmp_path: Path) -> None:
+    empty_dataset_path = tmp_path / "empty.parquet"
+    _write_dataset(empty_dataset_path, [])
+    scenario_path = tmp_path / "scenario.yaml"
+    _ = scenario_path.write_text("scenario_id: test\n", encoding="utf-8")
+    runner = BacktestRunner(
+        splitter=WalkForwardSplitter(min_train_rows=10, test_fold_size=1, gap_days=0),
+        scenario_path=scenario_path,
+        output_dir=tmp_path / "out",
+        scenario_invoker=lambda *_args, **_kwargs: cast(DecisionResult, object()),
+    )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        _ = runner.run(dataset_path=empty_dataset_path)
+
+    dataset_path = tmp_path / "dataset.parquet"
+    _write_dataset(dataset_path, _dataset_rows())
+    with pytest.raises(ValueError, match="produced no rows"):
+        _ = runner.run(dataset_path=dataset_path)
+
+    with pytest.raises(ValueError, match="strictly increasing"):
+        _ = BacktestRunner._next_decision_date_for_test(
+            (
+                {"trade_date": date(2025, 1, 7)},
+                {"trade_date": date(2025, 1, 7)},
+            ),
+            0,
+        )
+
+    with pytest.raises(ValueError, match="decision_date must be a date"):
+        _ = BacktestRunner._require_decision_date_for_test({})
+
+    with pytest.raises(ValueError, match="target_direction_label must be one of"):
+        _ = BacktestRunner._require_target_label_for_test({"target_direction_label": "skip"})

--- a/core/tests/schemas/test_backtest.py
+++ b/core/tests/schemas/test_backtest.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import cast
+
+import pytest
+
+from kospi_decision_pipeline_core.schemas.backtest import (
+    BacktestRow,
+    FoldMetrics,
+    OverallMetrics,
+    backtest_row_from_mapping,
+    backtest_row_to_mapping,
+    fold_metrics_to_mapping,
+    overall_metrics_to_mapping,
+)
+
+
+def test_backtest_row_serialization_round_trip() -> None:
+    row = BacktestRow(
+        fold_id=3,
+        decision_date=date(2025, 2, 14),
+        label="down",
+        aggregate_score=-0.41,
+        target_label="down",
+        correct=True,
+        snapshot_id="snapshot:2025-02-14",
+        config_signature="cfg:123",
+    )
+
+    assert backtest_row_from_mapping(backtest_row_to_mapping(row)) == row
+
+
+def test_metrics_mapping_helpers_emit_stable_shapes() -> None:
+    fold = FoldMetrics(
+        fold_id=2,
+        fold_start=date(2025, 2, 3),
+        fold_end=date(2025, 2, 7),
+        decision_count=5,
+        hit_rate=0.5,
+        precision_up=None,
+        precision_down=1.0,
+        recall_up=0.25,
+        recall_down=None,
+        skip_rate=0.2,
+        flat_rate=0.4,
+    )
+    overall = OverallMetrics(
+        fold_count=1,
+        period_start=date(2025, 2, 3),
+        period_end=date(2025, 2, 14),
+        decision_count=10,
+        hit_rate=0.625,
+        precision_up=0.75,
+        precision_down=0.5,
+        recall_up=0.6,
+        recall_down=0.4,
+        skip_rate=0.1,
+        flat_rate=0.3,
+        folds=(fold,),
+    )
+
+    assert fold_metrics_to_mapping(fold) == {
+        "fold_id": 2,
+        "fold_start": "2025-02-03",
+        "fold_end": "2025-02-07",
+        "decision_count": 5,
+        "hit_rate": 0.5,
+        "precision_up": None,
+        "precision_down": 1.0,
+        "recall_up": 0.25,
+        "recall_down": None,
+        "skip_rate": 0.2,
+        "flat_rate": 0.4,
+    }
+    assert overall_metrics_to_mapping(overall) == {
+        "fold_count": 1,
+        "period_start": "2025-02-03",
+        "period_end": "2025-02-14",
+        "decision_count": 10,
+        "hit_rate": 0.625,
+        "precision_up": 0.75,
+        "precision_down": 0.5,
+        "recall_up": 0.6,
+        "recall_down": 0.4,
+        "skip_rate": 0.1,
+        "flat_rate": 0.3,
+        "folds": [
+            {
+                "fold_id": 2,
+                "fold_start": "2025-02-03",
+                "fold_end": "2025-02-07",
+                "decision_count": 5,
+                "hit_rate": 0.5,
+                "precision_up": None,
+                "precision_down": 1.0,
+                "recall_up": 0.25,
+                "recall_down": None,
+                "skip_rate": 0.2,
+                "flat_rate": 0.4,
+            }
+        ],
+    }
+
+
+def test_backtest_row_validates_runtime_values() -> None:
+    with pytest.raises(ValueError, match="fold_id must be positive"):
+        _ = BacktestRow(
+            fold_id=0,
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=0.4,
+            target_label="up",
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="snapshot_id must be a string"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=0.4,
+            target_label="up",
+            correct=True,
+            snapshot_id=cast(str, cast(object, 1)),
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="aggregate_score must be a float"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=cast(float, cast(object, True)),
+            target_label="up",
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="decision_date must be a date"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=cast(date, cast(object, "2025-02-14")),
+            label="up",
+            aggregate_score=0.4,
+            target_label="up",
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="correct must be a bool"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=0.4,
+            target_label="up",
+            correct=cast(bool, cast(object, 1)),
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="fold_id must be an int"):
+        _ = BacktestRow(
+            fold_id=cast(int, cast(object, True)),
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=0.4,
+            target_label="up",
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="label must be one of"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 2, 14),
+            label=cast(str, cast(object, "flat")),
+            aggregate_score=0.4,
+            target_label="up",
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+    with pytest.raises(ValueError, match="target_label must be one of"):
+        _ = BacktestRow(
+            fold_id=1,
+            decision_date=date(2025, 2, 14),
+            label="up",
+            aggregate_score=0.4,
+            target_label=cast(str, cast(object, "skip")),
+            correct=True,
+            snapshot_id="snapshot:2025-02-14",
+            config_signature="cfg:123",
+        )
+
+
+def test_metrics_and_mapping_helpers_validate_error_branches() -> None:
+    with pytest.raises(ValueError, match="fold_end must be on or after fold_start"):
+        _ = FoldMetrics(
+            fold_id=1,
+            fold_start=date(2025, 2, 7),
+            fold_end=date(2025, 2, 3),
+            decision_count=1,
+            hit_rate=0.0,
+            precision_up=0.0,
+            precision_down=0.0,
+            recall_up=0.0,
+            recall_down=0.0,
+            skip_rate=0.0,
+            flat_rate=0.0,
+        )
+
+    with pytest.raises(ValueError, match="period_end must be on or after period_start"):
+        _ = OverallMetrics(
+            fold_count=0,
+            period_start=date(2025, 2, 7),
+            period_end=date(2025, 2, 3),
+            decision_count=0,
+            hit_rate=None,
+            precision_up=None,
+            precision_down=None,
+            recall_up=None,
+            recall_down=None,
+            skip_rate=None,
+            flat_rate=None,
+        )
+
+    with pytest.raises(ValueError, match=r"fold_count must match len\(folds\)"):
+        _ = OverallMetrics(
+            fold_count=2,
+            period_start=date(2025, 2, 3),
+            period_end=date(2025, 2, 7),
+            decision_count=1,
+            hit_rate=0.0,
+            precision_up=0.0,
+            precision_down=0.0,
+            recall_up=0.0,
+            recall_down=0.0,
+            skip_rate=0.0,
+            flat_rate=0.0,
+            folds=(
+                FoldMetrics(
+                    fold_id=1,
+                    fold_start=date(2025, 2, 3),
+                    fold_end=date(2025, 2, 3),
+                    decision_count=1,
+                    hit_rate=0.0,
+                    precision_up=0.0,
+                    precision_down=0.0,
+                    recall_up=0.0,
+                    recall_down=0.0,
+                    skip_rate=0.0,
+                    flat_rate=0.0,
+                ),
+            ),
+        )
+
+    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        _ = FoldMetrics(
+            fold_id=1,
+            fold_start=date(2025, 2, 3),
+            fold_end=date(2025, 2, 3),
+            decision_count=1,
+            hit_rate=2.0,
+            precision_up=0.0,
+            precision_down=0.0,
+            recall_up=0.0,
+            recall_down=0.0,
+            skip_rate=0.0,
+            flat_rate=0.0,
+        )
+
+    with pytest.raises(ValueError, match="folds items must be FoldMetrics"):
+        _ = OverallMetrics(
+            fold_count=1,
+            period_start=date(2025, 2, 3),
+            period_end=date(2025, 2, 7),
+            decision_count=1,
+            hit_rate=0.0,
+            precision_up=0.0,
+            precision_down=0.0,
+            recall_up=0.0,
+            recall_down=0.0,
+            skip_rate=0.0,
+            flat_rate=0.0,
+            folds=cast(tuple[FoldMetrics, ...], cast(object, (object(),))),
+        )
+
+    with pytest.raises(ValueError, match="decision_count must be non-negative"):
+        _ = OverallMetrics(
+            fold_count=0,
+            period_start=date(2025, 2, 3),
+            period_end=date(2025, 2, 7),
+            decision_count=-1,
+            hit_rate=None,
+            precision_up=None,
+            precision_down=None,
+            recall_up=None,
+            recall_down=None,
+            skip_rate=None,
+            flat_rate=None,
+        )
+
+    with pytest.raises(ValueError, match="decision_date must be an ISO date"):
+        _ = backtest_row_from_mapping(
+            {
+                "fold_id": 1,
+                "decision_date": "bad-date",
+                "label": "up",
+                "aggregate_score": 0.1,
+                "target_label": "up",
+                "correct": True,
+                "snapshot_id": "snapshot:1",
+                "config_signature": "cfg:1",
+            }
+        )
+
+    with pytest.raises(ValueError, match="missing required key: snapshot_id"):
+        _ = backtest_row_from_mapping(
+            {
+                "fold_id": 1,
+                "decision_date": "2025-02-14",
+                "label": "up",
+                "aggregate_score": 0.1,
+                "target_label": "up",
+                "correct": True,
+                "config_signature": "cfg:1",
+            }
+        )

--- a/core/tests/schemas/test_decisions.py
+++ b/core/tests/schemas/test_decisions.py
@@ -8,10 +8,8 @@ import pytest
 
 from kospi_decision_pipeline_core.schemas.decisions import (
     AgentVote,
-    BacktestRow,
     DecisionResult,
     EvidenceItem,
-    GroundTruthLabel,
     ModelLabel,
 )
 
@@ -84,24 +82,6 @@ def test_decision_result_construction_and_immutability() -> None:
         setattr(decision, "votes", ())
 
 
-def test_backtest_row_construction_and_immutability() -> None:
-    row = BacktestRow(
-        decision_date=date(2026, 4, 25),
-        label="down",
-        aggregate_score=-0.41,
-        ground_truth="down",
-        next_day_return=-0.018,
-        hit=True,
-    )
-
-    assert row.ground_truth == "down"
-    assert row.next_day_return == -0.018
-    assert row.hit is True
-
-    with pytest.raises(AttributeError):
-        setattr(row, "hit", False)
-
-
 @pytest.mark.parametrize(
     ("factory", "match"),
     [
@@ -116,17 +96,6 @@ def test_backtest_row_construction_and_immutability() -> None:
                 evidence=(make_evidence_item(),),
             ),
             "label must be one of",
-        ),
-        (
-            lambda: BacktestRow(
-                decision_date=date(2026, 4, 25),
-                label="skip",
-                aggregate_score=0.0,
-                ground_truth=cast(GroundTruthLabel, cast(object, "skip")),
-                next_day_return=0.0,
-                hit=False,
-            ),
-            "ground_truth must be one of",
         ),
         (
             lambda: DecisionResult(
@@ -226,17 +195,6 @@ def test_decision_result_rejects_non_tuple_votes() -> None:
                 snapshot_id="snapshot:2026-04-25",
             ),
             "threshold_up must be greater than threshold_down",
-        ),
-        (
-            lambda: BacktestRow(
-                decision_date=date(2026, 4, 25),
-                label="down",
-                aggregate_score=-0.41,
-                ground_truth="down",
-                next_day_return=-0.018,
-                hit=cast(bool, cast(object, 1)),
-            ),
-            "hit must be a bool",
         ),
         (
             lambda: AgentVote(

--- a/core/tests/schemas/test_serialization.py
+++ b/core/tests/schemas/test_serialization.py
@@ -6,9 +6,9 @@ from typing import cast
 
 import pytest
 
+from kospi_decision_pipeline_core.schemas.backtest import BacktestRow
 from kospi_decision_pipeline_core.schemas.decisions import (
     AgentVote,
-    BacktestRow,
     DecisionResult,
     EvidenceItem,
 )
@@ -56,12 +56,14 @@ def make_decision_result() -> DecisionResult:
 
 def make_backtest_row() -> BacktestRow:
     return BacktestRow(
+        fold_id=2,
         decision_date=date(2026, 4, 25),
         label="down",
         aggregate_score=-0.41,
-        ground_truth="down",
-        next_day_return=-0.018,
-        hit=True,
+        target_label="down",
+        correct=True,
+        snapshot_id="snapshot:2026-04-25",
+        config_signature="cfg:abc123",
     )
 
 
@@ -119,20 +121,24 @@ def test_backtest_csv_fields_and_row_are_stable() -> None:
     row = make_backtest_row()
 
     assert BACKTEST_CSV_FIELDS == (
+        "fold_id",
         "decision_date",
         "label",
         "aggregate_score",
-        "ground_truth",
-        "next_day_return",
-        "hit",
+        "target_label",
+        "correct",
+        "snapshot_id",
+        "config_signature",
     )
     assert to_csv_row(row, BACKTEST_CSV_FIELDS) == {
+        "fold_id": "2",
         "decision_date": "2026-04-25",
         "label": "down",
         "aggregate_score": "-0.41",
-        "ground_truth": "down",
-        "next_day_return": "-0.018",
-        "hit": "true",
+        "target_label": "down",
+        "correct": "true",
+        "snapshot_id": "snapshot:2026-04-25",
+        "config_signature": "cfg:abc123",
     }
 
 
@@ -167,11 +173,11 @@ def test_parse_helpers_reject_invalid_payloads() -> None:
 
 
 def test_parse_backtest_row_rejects_missing_field() -> None:
-    with pytest.raises(ValueError, match="missing required key: hit"):
+    with pytest.raises(ValueError, match="missing required key: config_signature"):
         _ = parse_backtest_row(
             "{"
-            + '"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,'
-            + '"ground_truth":"down","next_day_return":-0.018'
+            + '"fold_id":2,"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,'
+            + '"target_label":"down","correct":true,"snapshot_id":"snapshot:2026-04-25"'
             + "}"
         )
 
@@ -201,13 +207,18 @@ def test_parse_backtest_row_rejects_missing_field() -> None:
         ),
         (
             parse_backtest_row,
-            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"ground_truth":"skip","next_day_return":-0.018,"hit":true}',
-            "ground_truth must be one of",
+            '{"fold_id":2,"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"target_label":"skip","correct":true,"snapshot_id":"snapshot:2026-04-25","config_signature":"cfg:abc123"}',
+            "target_label must be one of",
         ),
         (
             parse_backtest_row,
-            '{"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"ground_truth":"down","next_day_return":-0.018,"hit":1}',
-            "hit must be a bool",
+            '{"fold_id":2,"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"target_label":"down","correct":1,"snapshot_id":"snapshot:2026-04-25","config_signature":"cfg:abc123"}',
+            "correct must be a bool",
+        ),
+        (
+            parse_backtest_row,
+            '{"fold_id":true,"decision_date":"2026-04-25","label":"down","aggregate_score":-0.41,"target_label":"down","correct":true,"snapshot_id":"snapshot:2026-04-25","config_signature":"cfg:abc123"}',
+            "fold_id must be an int",
         ),
     ],
 )


### PR DESCRIPTION
## Summary
- add typed backtest schemas, metrics, report writers, and a walk-forward `BacktestRunner` that strips targets before reusing `run_kospi_scenario`
- add `run-backtest` CLI support with optional fold-config loading plus deterministic JSONL/JSON/CSV outputs
- cover the new flow with unit, integration, determinism, and 100% line+branch coverage tests for the new backtest code