### PR TITLE
Finalize v0.1 documentation: README, spec, CONTRIBUTING (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+> 본 프로젝트는 연구 및 교육 목적의 실험 도구이며, 투자 권유 또는 금융 자문이 아닙니다.
+>
+> This project is an experimental tool for research and education only. It is not investment advice or financial advisory.
+
+## v0.1
+
+### Foundation
+
+- Issue #1 / PR #21: ADR-001 project foundation and v0.1 scope
+- Issue #2 / PR #22: repository scaffold and Python packaging
+- Issue #3 / PR #23: CI workflows and policy gates
+- Issue #4 / PR #25: typed config loaders for scenario and agent configs
+- Issue #5 / PR #24: public-data connector protocols and fixture clients
+
+### Data plane
+
+- Issue #6 / PR #26: Bronze ingest pipeline and ingest CLI
+- Issue #7 / PR #27: Silver typed normalization
+- Issue #8 / PR #29: Gold decision-feature dataset
+- Issue #9 / PR #30: leakage guardrails and sanitized agent inputs
+- Issue #18 / PR #36: target labels and walk-forward backtest dataset
+
+### Decision and runtime
+
+- Issue #10 / PR #28: frozen decision schemas and deterministic serializers
+- Issue #11 / PR #33: TechnicalAgent rule logic
+- Issue #12 / PR #37: DomesticMacroAgent rule logic
+- Issue #13 / PR #35: FlowAgent rule logic
+- Issue #14 / PR #34: ValuationAgent rule logic
+- Issue #15 / PR #32: VolatilityAgent rule logic
+- Issue #16 / PR #38: DecisionAgent weighted aggregation
+- Issue #17 / PR #39: ABDP ScenarioRunner integration and runtime service
+
+### Backtest
+
+- Issue #19 / PR #40: walk-forward backtest runner and report writers
+
+### Documentation
+
+- Issue #20: release-ready README, spec, contributing guide, and changelog finalization

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing
+
+> 본 프로젝트는 연구 및 교육 목적의 실험 도구이며, 투자 권유 또는 금융 자문이 아닙니다.
+>
+> This project is an experimental tool for research and education only. It is not investment advice or financial advisory.
+
+## Toolchain
+
+- Python 3.12+
+- `uv`
+- GitHub CLI (`gh`) for issue and PR workflows
+
+Install development dependencies:
+
+```bash
+uv sync --extra dev
+```
+
+## Branch and PR conventions
+
+- Branch name: `feat/issue-<N>-<slug>`
+- PR title: `<verb-phrase> (#<N>)`
+- Merge policy: **squash merge only**
+
+Example:
+
+- Branch: `feat/issue-20-docs-finalization`
+- PR title: `Finalize v0.1 documentation: README, spec, CONTRIBUTING (#20)`
+
+## Required delivery workflow
+
+1. Start from an open GitHub issue.
+2. Consult Oracle before or during implementation when the change is non-trivial.
+3. Follow TDD: **RED → GREEN → REFACTOR (optional)**.
+4. Keep the work atomic. Default expectation is **3 commits per issue**, each referencing the issue number. Doc-only changes may use fewer when the review stays atomic.
+5. Run local verification before opening or updating the PR.
+6. Request Oracle review again before merge.
+7. Merge with **squash** after all blockers are cleared.
+
+## Oracle review policy
+
+- Consult Oracle before implementation for ambiguous or high-risk work.
+- Merge target: **100/100**.
+- Acceptable non-blocking pass threshold: **PASS with no blockers and at least 95/100**.
+- Documentation-only work may accept a lower pass only when explicitly approved in the issue or release workflow.
+
+Record any drift between spec, docs, and shipped code in the PR description.
+
+These Oracle requirements are team workflow conventions for this repository; they are not enforced by the Python package itself.
+
+## TDD expectations
+
+- RED: write or update a failing test first whenever code behavior changes.
+- GREEN: implement the smallest change that makes the test pass.
+- REFACTOR: optional cleanup without behavior drift.
+- Never merge code that reduces clarity around determinism, leakage prevention, or schema guarantees.
+
+## Tests, lint, and typing
+
+Run the baseline suite:
+
+```bash
+uv run --python 3.12 --extra dev python -m pytest
+```
+
+Run the CI-equivalent coverage command:
+
+```bash
+uv run --python 3.12 --extra dev pytest \
+  --cov=core/src \
+  --cov=apps/kr-kospi/src \
+  --cov-branch \
+  --cov-report=xml \
+  --cov-fail-under=100
+```
+
+Run lint and typing:
+
+```bash
+uv run --python 3.12 --extra dev ruff check .
+uv run --python 3.12 --extra dev ruff format --check .
+uv run --python 3.12 --extra dev python scripts/check_typing_policy.py
+uv run --python 3.12 --extra dev mypy --strict core/src apps/kr-kospi/src
+```
+
+## Coverage policy
+
+- New code must maintain **100% line and branch coverage**.
+- Doc-only changes do not require coverage expansion.
+- Do not weaken coverage thresholds without an explicit issue and reviewer approval.
+
+## Typing policy
+
+- No `Any` without a written justification in code review.
+- No `# type: ignore` without explicit reviewer approval and a comment explaining the boundary.
+- Preserve `mypy --strict` compatibility.
+
+## Commit guidance
+
+- Reference the issue number in every commit message.
+- Keep commits revertible and scoped to one concern.
+- Prefer separate commits for docs, code, and fixtures when they can be reviewed independently.
+
+## Filing issues
+
+- Use the repository issue tracker: <https://github.com/kpubdata-lab/kospi-decision-pipeline/issues>
+- If templates are later added under `.github/ISSUE_TEMPLATE/`, use the closest matching template.
+- Include scope, expected behavior, non-goals, and verification notes.
+
+## Project boundaries
+
+Contributions for v0.1 must respect the documented exclusions:
+
+- no S&P 500
+- no real-time FX
+- no broker reports
+- no individual-stock prediction
+- no production-readiness claims

--- a/README.md
+++ b/README.md
@@ -1,40 +1,292 @@
-# kospi-decision-pipeline
+# KOSPI Decision Pipeline
 
-Deterministic next-day KOSPI direction pipeline built from Korean public data.
-
-> **Disclaimer**
+> **Disclaimer / 면책 고지**
 >
 > 본 프로젝트는 연구 및 교육 목적의 실험 도구이며, 투자 권유 또는 금융 자문이 아닙니다.
 >
-> This project is an experimental research and educational tool. It is not investment advice or financial advisory.
+> This project is an experimental tool for research and education only. It is not investment advice or financial advisory.
 
-## Project status
+Public-data-first ABDP-based KOSPI next-day direction prediction pipeline for research and education. The repository turns Korean public market and macro data into deterministic Bronze, Silver, and Gold datasets, scores five rule agents plus one decision aggregator through ABDP, and emits reproducible scenario and backtest artifacts with explicit scope boundaries.
 
-Project status: v0.1 in development.
+## Status
 
-## Scope
+[![Tests](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/test.yml/badge.svg)](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/test.yml)
+[![Lint](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/lint.yml/badge.svg)](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/lint.yml)
+[![Mypy](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/mypy.yml/badge.svg)](https://github.com/kpubdata-lab/kospi-decision-pipeline/actions/workflows/mypy.yml)
+![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)
+![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green)
 
-- Public-data-first KOSPI direction decisions
-- Deterministic Bronze → Silver → Gold pipeline
-- ABDP-native scenario execution for rule-based agents
+- Release target: **v0.1**
+- Project posture: **research-grade, deterministic, public-data-first**
+- Out of scope for v0.1: S&P 500, real-time FX, broker reports, individual stocks, production trading automation
 
-## Documentation
+## Architecture overview
 
-- Spec placeholder: [docs/spec.md](docs/spec.md)
-- ADRs: [docs/adr/](docs/adr/)
-
-## Repository layout
-
-- `core/` for shared schemas, IDs, and I/O helpers
-- `apps/kr-kospi/` for the Korea KOSPI application package
-- `.github/workflows/` reserved for CI workflows finalized in issue #3
+```text
+KRX / ECOS (+ optional KOSIS / Public Data Portal connector surfaces)
+                |
+                v
+      Bronze raw parquet snapshots
+                |
+                v
+       Silver typed normalized datasets
+                |
+                v
+      Gold decision features parquet
+                |
+                v
+TechnicalAgent   DomesticMacroAgent   FlowAgent   ValuationAgent   VolatilityAgent
+        \              |                 |             |                /
+         \             |                 |             |               /
+          +------------+-----------------+-------------+--------------+
+                                       |
+                                       v
+                       DecisionAgent weighted aggregation
+                                       |
+                                       v
+                     ABDP ScenarioRunner / runtime service
+                                       |
+                    +------------------+------------------+
+                    |                                     |
+                    v                                     v
+      decision JSONL artifacts                walk-forward backtest reports
+```
 
 ## Quickstart
 
+### Prerequisites
+
+- Python 3.12+
+- `uv`
+- Fixture-backed local runs for documentation and CI-style dry runs
+- API credentials for KRX, ECOS, and KOSIS only if live connectors are introduced later; the shipped v0.1 `LiveConnectorRegistry` is not yet implemented
+
+Environment variables typically used for live runs depend on the upstream data client configuration. For safe automation, export the non-interactive shell settings used in CI:
+
 ```bash
-pip install -e ".[dev]"
-kospi-pipeline --help
-python -m kospi_decision_pipeline_app_kr_kospi --help
+export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 \
+  GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 \
+  PIP_DISABLE_PIP_VERSION_CHECK=1
 ```
 
-See #20 for finalized docs.
+### Install
+
+```bash
+uv sync --extra dev
+```
+
+### Smoke-check the shipped command surface
+
+These commands are safe to run on a fresh checkout and match the current CLI/runtime surface:
+
+```bash
+uv run --python 3.12 kospi-pipeline --help
+uv run --python 3.12 kospi-pipeline ingest --help
+uv run --python 3.12 kospi-pipeline build-features --help
+uv run --python 3.12 python -c "from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; print(build_backtest_dataset.__name__)"
+uv run --python 3.12 kospi-pipeline run-scenario --help
+uv run --python 3.12 kospi-pipeline run-backtest --help
+```
+
+### End-to-end example
+
+The shipped CLI implements `ingest`, `build-features`, `run-scenario`, and `run-backtest`. The backtest dataset builder is already implemented in Python (`transforms.target_labels.build_backtest_dataset`) but is not yet wired as a dedicated CLI subcommand in `cli.py`, so the release workflow below uses the shipped library entry point for that step.
+
+Important constraints before running the full pipeline:
+
+- you need at least **272 trading days of upstream history** for the first non-empty Gold output
+- the repository's checked-in fixtures are **smoke-size only** and do not contain enough history for a full non-empty Gold/backtest run
+- therefore, the sequence below is a **command template** for a full run once you have sufficient Bronze coverage from expanded fixtures or a future live-ingest implementation
+
+```bash
+# 1) Bronze ingest the six datasets required by `build-features --layer all`
+uv run --python 3.12 kospi-pipeline ingest \
+  --source krx \
+  --dataset kospi_index \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+uv run --python 3.12 kospi-pipeline ingest \
+  --source krx \
+  --dataset investor_flow \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+uv run --python 3.12 kospi-pipeline ingest \
+  --source krx \
+  --dataset market_valuation \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+uv run --python 3.12 kospi-pipeline ingest \
+  --source ecos \
+  --dataset base_rate \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+uv run --python 3.12 kospi-pipeline ingest \
+  --source ecos \
+  --dataset usd_krw \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+uv run --python 3.12 kospi-pipeline ingest \
+  --source ecos \
+  --dataset bond_yield \
+  --from 2023-01-01 \
+  --to 2025-03-31 \
+  --out data/bronze
+
+# 2) Silver + Gold features
+uv run --python 3.12 kospi-pipeline build-features \
+  --layer all \
+  --from 2024-01-02 \
+  --to 2025-03-31 \
+  --bronze-dir data/bronze \
+  --silver-dir data/silver \
+  --out data/gold
+
+# 3) Backtest dataset materialization (shipped transform API)
+uv run --python 3.12 python -c "from pathlib import Path; from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; build_backtest_dataset(Path('data/gold/decision_features.parquet'), Path('data/gold/backtest_dataset.parquet'))"
+
+# 4) Scenario execution
+uv run --python 3.12 kospi-pipeline run-scenario \
+  --date 2025-04-01 \
+  --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
+  --features data/gold/decision_features.parquet \
+  --out data/decisions
+
+# 5) Walk-forward backtest
+uv run --python 3.12 kospi-pipeline run-backtest \
+  --dataset data/gold/backtest_dataset.parquet \
+  --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
+  --out data/backtests/v0_1
+```
+
+### Expected outputs
+
+| Step | Output |
+| --- | --- |
+| Bronze ingest | `data/bronze/<source>/<dataset>/<date>.parquet` |
+| Silver build | `data/silver/.../*.parquet` |
+| Gold build | `data/gold/decision_features.parquet` |
+| Backtest dataset build | `data/gold/backtest_dataset.parquet` |
+| Scenario run | `data/decisions/kospi.next_day/<decision-date>.jsonl` |
+| Backtest run | `data/backtests/v0_1/rows.jsonl`, `metrics.json`, `metrics.csv` |
+
+## CLI reference
+
+| Command | Status | Notes |
+| --- | --- | --- |
+| `ingest` | implemented | Bronze parquet ingestion |
+| `build-features` | implemented | `silver`, `gold`, or `all` |
+| `run-scenario` | implemented | ABDP scenario execution |
+| `run-backtest` | implemented | Walk-forward reports |
+| `build-backtest-dataset` | not yet exposed as CLI | Use `build_backtest_dataset(...)` from Python for v0.1 |
+
+## Configuration reference
+
+### `apps/kr-kospi/config/agents.yaml`
+
+`agents.yaml` pins aggregate voting weights, final decision thresholds, and per-agent rule-version threshold maps.
+
+| Block | Purpose |
+| --- | --- |
+| `weights` | DecisionAgent aggregation weights for `technical`, `domestic_macro`, `flow`, `valuation`, `volatility` |
+| `thresholds.up` / `thresholds.down` | Final aggregate cutoffs for `up` and `down` |
+| `agents.<name>.rule_version` | Exact binding rule contract version |
+| `agents.<name>.thresholds` | Rule-specific thresholds validated against the rule version |
+
+### `apps/kr-kospi/config/scenario.kospi.next_day.yaml`
+
+The scenario file defines the runtime envelope used by `run-scenario` and `run-backtest`.
+
+| Key | Current committed value | Meaning |
+| --- | --- | --- |
+| `scenario_id` | `kospi.next_day` | Scenario namespace for decision artifacts |
+| `horizon` | `next_day` | Fixed v0.1 horizon |
+| `agents` | `technical`, `domestic_macro`, `flow`, `valuation`, `volatility`, `decision` | ABDP participant order |
+| `runtime.agents_config_path` | `apps/kr-kospi/config/agents.yaml` | Agent config source |
+| `runtime.features_path` | `data/gold/features.parquet` | Default runtime features path in committed YAML |
+| `runtime.output_dir` | `data/decisions` | Decision artifact root |
+
+For generated Gold features in the current codebase, pass `--features data/gold/decision_features.parquet` explicitly or update the runtime block locally before running.
+
+## Project layout
+
+```text
+core/
+  src/kospi_decision_pipeline_core/
+apps/kr-kospi/
+  config/
+  src/kospi_decision_pipeline_app_kr_kospi/
+  tests/
+docs/
+  adr/
+  spec.md
+data/
+  bronze/        # generated
+  silver/        # generated
+  gold/          # generated
+  decisions/     # generated
+  backtests/     # generated
+```
+
+## Testing
+
+Run the default test suite:
+
+```bash
+uv run --python 3.12 --extra dev python -m pytest
+```
+
+Run with coverage gates matching CI:
+
+```bash
+uv run --python 3.12 --extra dev pytest \
+  --cov=core/src \
+  --cov=apps/kr-kospi/src \
+  --cov-branch \
+  --cov-report=xml \
+  --cov-fail-under=100
+```
+
+Lint and typing checks:
+
+```bash
+uv run --python 3.12 --extra dev ruff check .
+uv run --python 3.12 --extra dev ruff format --check .
+uv run --python 3.12 --extra dev python scripts/check_typing_policy.py
+uv run --python 3.12 --extra dev mypy --strict core/src apps/kr-kospi/src
+```
+
+## Public data attribution
+
+- **KRX**: Korea Exchange market data and valuation inputs
+- **ECOS**: Bank of Korea Economic Statistics System macro series
+- **KOSIS**: supported public statistical connector surface in the data layer; not part of the current Gold/runtime path
+- **Public Data Portal**: optional connector surface declared in the CLI and connector layer
+
+## License
+
+Licensed under the [Apache License 2.0](LICENSE).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for Oracle review workflow, branch naming, TDD expectations, coverage policy, and squash-merge rules.
+
+## Design contract
+
+The normative release contract lives in [docs/spec.md](docs/spec.md). ADR context begins with [docs/adr/001-project-foundation.md](docs/adr/001-project-foundation.md).
+
+## ABDP attribution
+
+This project depends on the Agent-Based Decision Pipeline reference implementation:
+
+- Repository: <https://github.com/yeongseon/agent-based-decision-pipeline>
+- Pinned SHA: `9520cfed7e150f644fb5d01bb1a9b32eb0082f8d`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,5 +1,114 @@
 # KOSPI Decision Pipeline Specification
 
+## §1. Purpose
+
+This specification defines the binding v0.1 contract for a public-data-first, deterministic KOSPI next-day direction pipeline built on ABDP. It is the normative reference for repository scope, schemas, rule logic, runtime orchestration, and release documentation.
+
+## §2. Intended use
+
+The project is for research, education, auditability, and reproducible experimentation. It is not a production trading system.
+
+## §3. Output domain
+
+- Model outputs: `up | down | skip`
+- Backtest-only ground truth: `up | down | flat`
+
+## §4. Data principle
+
+v0.1 is public-data-first and Korea-focused. All shipped pipelines are built around public Korean data sources and deterministic transformations.
+
+## §5. System summary
+
+The system has two planes:
+
+1. Data plane: Bronze → Silver → Gold parquet datasets
+2. Decision plane: five rule agents + one DecisionAgent executed through ABDP `ScenarioRunner`
+
+## §6. Supported public data sources
+
+- KRX
+- ECOS (Bank of Korea)
+- KOSIS (Statistics Korea) connector surface for future or upstream expansion
+- Public Data Portal connectors declared in code, where applicable
+
+## §7. Repository topology
+
+- `core/`: shared schemas, config loaders, runtime, backtest, serialization
+- `apps/kr-kospi/`: KOSPI application package, CLI, transforms, fixtures, app tests
+- `docs/`: ADRs and normative spec
+
+## §8. Runtime baseline
+
+- Python `>=3.12`
+- `uv` is the preferred local dependency manager
+- Repository package version at v0.1 release cut remains `0.0.1`
+
+## §9. Determinism and reproducibility
+
+- Parquet artifacts are the system-of-record interfaces between stages.
+- Rule outputs are fixed-label, fixed-score branches.
+- Decision outputs persist config signatures and snapshot identifiers.
+- Runtime and backtest flows must be repeatable from the same inputs.
+
+## §10. Explicit v0.1 exclusions
+
+The following are out of scope for v0.1:
+
+- S&P 500
+- Nasdaq
+- Dow
+- VIX
+- US futures
+- real-time FX
+- news sentiment
+- broker reports
+- individual stocks
+- production trading automation
+
+## §11. Bronze ingest contract
+
+Bronze ingestion writes raw source snapshots to parquet under a source and dataset keyed directory structure. The shipped CLI surface for Bronze is `kospi-pipeline ingest`.
+
+## §12. Silver normalization contract
+
+Silver datasets are typed, normalized, source-aware parquet outputs derived from Bronze. Silver is the canonical typed staging layer used by Gold builders.
+
+## §13. Gold feature contract
+
+The shipped Gold feature builder writes `data/gold/decision_features.parquet`. Gold features must not contain `target_*` or `future_*` columns and must remain safe for direct agent scoring.
+
+## §14. Leakage guardrails
+
+- No agent may read `target_*` or `future_*` columns.
+- No future-incorporating joins are allowed.
+- Runtime feature rows must be strictly earlier than the decision date.
+- Full-period normalization and hidden future leakage are forbidden.
+
+## §15. Config contract
+
+Scenario runtime config and agent config are YAML-driven and validated by strict loaders. Unknown agent IDs, mismatched rule versions, and missing threshold keys must raise validation errors.
+
+## §16. Decision schema contract
+
+Decision runtime outputs must preserve typed votes, final decision labels, aggregate score, snapshot identity, and config signature. Frozen decision schemas and deterministic serializers are part of the v0.1 contract.
+
+## §17. Serialization and artifact contract
+
+- Scenario decisions persist as JSONL under `data/decisions/<scenario_id>/<decision_date>.jsonl`
+- Backtests persist `rows.jsonl`, `metrics.json`, and `metrics.csv`
+- JSON serialization is deterministic and explicit
+
+## §18. CLI surface contract
+
+The shipped CLI currently implements:
+
+- `ingest`
+- `build-features`
+- `run-scenario`
+- `run-backtest`
+
+`build_backtest_dataset(...)` is shipped as a Python API in `transforms.target_labels`, but a dedicated `build-backtest-dataset` CLI subcommand is not yet exposed in `cli.py` as of v0.1 release documentation finalization.
+
 ## §19-§23 Common execution contract
 
 The following rules are binding for `technical@1.0.0`, `domestic_macro@1.0.0`, `flow@1.0.0`, `valuation@1.0.0`, and `volatility@1.0.0`.
@@ -91,7 +200,7 @@ The following rules are binding for `technical@1.0.0`, `domestic_macro@1.0.0`, `
 | T3 | 0.007 | -0.008 | 0.001 | 0.55 | Mixed momentum abstain | skip | 0.0 |
 | T4 | 0.002 | 0.006 | 0.002 | 0.54 | Fallback | skip | 0.0 |
 
----
+
 
 ## §20. DomesticMacroAgent
 
@@ -422,7 +531,7 @@ This label is for backtest/evaluation only. Agents MUST NOT read it.
 
 ### §24.2 Target column names
 
-The following are the only target columns for v1.0.0, and all MUST use the `target_` prefix:
+The following are the only target columns for v0.1, and all MUST use the `target_` prefix:
 
 - `target_next_day_simple_return`
 - `target_next_day_log_return`
@@ -437,7 +546,7 @@ Rules:
 
 ### §24.3 Walk-forward split
 
-Walk-forward mode is fixed to **expanding-window** for v1.0.0. Rolling-window mode is out of scope.
+Walk-forward mode is fixed to **expanding-window** for v0.1. Rolling-window mode is out of scope.
 
 Binding defaults:
 
@@ -595,3 +704,190 @@ agents:
 ```
 
 ---
+
+## §25. DecisionAgent aggregation contract
+
+DecisionAgent consumes exactly five rule-agent votes and aggregates them with configured weights from `agents.yaml`.
+
+Binding rules:
+
+- input agent set must be `technical`, `domestic_macro`, `flow`, `valuation`, `volatility`
+- aggregate thresholds come from `thresholds.up` and `thresholds.down`
+- output labels remain `up | down | skip`
+- config signature must be persisted on the final decision result
+
+## §26. Scenario configuration contract
+
+The shipped scenario config declares:
+
+- `scenario_id: kospi.next_day`
+- `horizon: next_day`
+- six agents in order: five rule agents plus `decision`
+- runtime block with `agents_config_path`, `features_path`, and `output_dir`
+
+## §27. Scenario execution lifecycle
+
+ABDP runtime proceeds in two phases:
+
+1. `vote`: exactly five unique `VoteProposal` values from rule agents
+2. `decide`: exactly one `DecisionResultProposal` from DecisionAgent
+
+Any other proposal shape or count is invalid and must raise.
+
+## §28. Runtime service outputs
+
+`run_kospi_scenario(...)` must:
+
+1. load scenario config
+2. resolve agent config and feature paths
+3. load exactly one lag-safe feature row for the requested decision date
+4. run ABDP `ScenarioRunner`
+5. persist one JSONL decision artifact under `data/decisions/<scenario_id>/<decision_date>.jsonl` or the supplied output override
+
+Documented v0.1 drift:
+
+- committed `scenario.kospi.next_day.yaml` points `runtime.features_path` to `data/gold/features.parquet`
+- shipped Gold builder writes `data/gold/decision_features.parquet`
+- release docs must therefore instruct users to pass `--features data/gold/decision_features.parquet` explicitly unless they customize the YAML locally
+
+## §29. Backtest reporting contract
+
+Backtest output files are:
+
+- `rows.jsonl`
+- `metrics.json`
+- `metrics.csv`
+
+Metrics include fold-level and overall statistics such as hit rate, precision, recall, skip rate, and flat rate.
+
+## §30. Quality gate contract
+
+- CI runs tests, Ruff lint/format checks, typing policy, and mypy
+- new code is expected to maintain 100% line and branch coverage
+- doc-only changes do not need coverage expansion
+
+## §31. ADR linkage
+
+ADR-001 is the architectural foundation for this specification. If an implementation choice conflicts with ADR-001, ADR-001 and this spec govern until superseded by a later accepted ADR and spec revision.
+
+## §32. Versioning policy
+
+- repository package version is currently `0.0.1`
+- release documentation is prepared for the v0.1 milestone
+- rule versions are explicitly pinned, e.g. `technical@1.0.0`
+
+## §33. Public data attribution contract
+
+Release documentation must attribute KRX and ECOS as the primary shipped v0.1 decision inputs, while also acknowledging KOSIS as a supported public-data connector surface in the broader repository.
+
+## §34. Secrets and live access boundary
+
+Live ingestion may require API credentials, but secrets must never be committed to the repository. Documentation may reference the need for credentials without embedding them.
+
+## §35. Scale boundary
+
+v0.1 is optimized for deterministic research workflows, not for high-throughput low-latency production deployment.
+
+## §36. Artifact traceability
+
+Generated outputs should remain traceable by path, date, scenario ID, snapshot ID, and config signature wherever those concepts apply.
+
+## §37. Compatibility statement
+
+The release contract is defined against the current mainline implementation that merged issues #1 through #19.
+
+## §38. Packaging statement
+
+The project is packaged from a single top-level `pyproject.toml` that includes both the shared core package and the `apps/kr-kospi` app package. There are no separate workspace `pyproject.toml` files under `core/` or `apps/kr-kospi/` in the shipped repository.
+
+## §39. Testing strategy
+
+The repository uses unit, contract, and integration tests to protect schemas, transforms, runtime behavior, and backtest determinism.
+
+## §40. Terminology
+
+- Bronze: raw source snapshot layer
+- Silver: typed normalized dataset layer
+- Gold: final lag-safe decision feature layer
+- Scenario run: one next-day ABDP decision execution
+- Backtest row: one scored decision paired with ground truth
+
+## §41. Documentation obligations
+
+Release documentation must be explicit about scope, exclusions, disclaimers, CLI surface, and any known drift between configuration defaults and generated artifacts.
+
+## §42. Research-use statement
+
+All release-facing docs must describe the repository as research-grade and educational, not production-ready.
+
+## §43. Public-data limitations
+
+v0.1 intentionally favors auditability and narrow scope over predictive breadth. Missing non-public, real-time, and cross-market features are a deliberate design constraint, not an omission.
+
+## §44. Extension boundary
+
+Future releases may add new markets, signals, or deployment surfaces, but such changes are non-binding for v0.1 unless explicitly versioned in this specification.
+
+## §45. ABDP dependency attribution
+
+ABDP integration is a first-class architectural dependency. Release documentation must reference <https://github.com/yeongseon/agent-based-decision-pipeline> at pinned SHA `9520cfed7e150f644fb5d01bb1a9b32eb0082f8d`.
+
+## §46. License
+
+The repository is licensed under Apache-2.0 and release documentation must link to `LICENSE`.
+
+## §47. Disclaimer
+
+> 본 프로젝트는 연구 및 교육 목적의 실험 도구이며, 투자 권유 또는 금융 자문이 아닙니다.
+>
+> This project is an experimental tool for research and education only. It is not investment advice or financial advisory.
+
+This disclaimer must appear prominently in release-facing documentation.
+
+## §48. v0.1 implementation status
+
+The table below maps major spec areas to the shipped issue and PR set merged before documentation finalization.
+
+| Spec area | Summary | Issue / PR |
+| --- | --- | --- |
+| §1-§10 | foundation, scope, exclusions | #1 / PR #21, #2 / PR #22 |
+| §11 | Bronze ingest | #6 / PR #26 |
+| §12 | Silver normalization | #7 / PR #27 |
+| §13-§14 | Gold features and leakage guardrails | #8 / PR #29, #9 / PR #30 |
+| §15 | typed config loading | #4 / PR #25 |
+| §16-§17 | frozen schemas and deterministic serialization | #10 / PR #28 |
+| §18 | CLI surface | #6 / PR #26, #19 / PR #40, issue #20 release audit |
+| §19-§23 | rule-agent contracts | #11 / PR #33, #12 / PR #37, #13 / PR #35, #14 / PR #34, #15 / PR #32 |
+| §24 | targets and walk-forward dataset | #18 / PR #36 |
+| §25 | DecisionAgent aggregation | #16 / PR #38 |
+| §26-§28 | ABDP runtime integration and scenario service | #17 / PR #39 |
+| §29 | backtest reports | #19 / PR #40 |
+| §30 | CI and policy gates | #3 / PR #23 |
+| §31 | ADR linkage | #1 / PR #21 |
+| §33 | public data connectors | #5 / PR #24 |
+| §47-§50 | release documentation finalization | #20 |
+
+## §49. Known limitations and documented drift
+
+- No dedicated `build-backtest-dataset` CLI subcommand is exposed yet, even though the transform implementation exists.
+- The committed scenario YAML defaults `runtime.features_path` to `data/gold/features.parquet`, while the shipped Gold feature builder writes `data/gold/decision_features.parquet`.
+- v0.1 remains Korea-only, next-day-only, and rule-based.
+- v0.1 is not production-ready and should not be presented as such.
+
+## §50. Release notes, version log, and v0.2 roadmap
+
+### v0.1 release notes
+
+v0.1 completes the initial milestone: foundation, public-data ingest, typed normalization, Gold features, leakage guardrails, five rule agents, weighted decision aggregation, ABDP runtime execution, walk-forward backtesting, and release-grade documentation.
+
+### Version log
+
+- `0.0.1`: initial packaged repository line used throughout the v0.1 buildout
+- `v0.1` milestone: documentation-complete release state after issues #1-#20
+
+### v0.2 roadmap
+
+- expose backtest-dataset generation as a first-class CLI subcommand
+- reconcile default scenario feature paths with generated Gold artifact names
+- add richer release automation and artifact publishing
+- evaluate carefully scoped extensions without violating the public-data-first and anti-leakage principles


### PR DESCRIPTION
## Summary
- rewrite README for a release-ready v0.1 overview, command surface, configuration reference, testing guidance, and explicit research-only disclaimers
- add CONTRIBUTING.md and CHANGELOG.md, then finalize docs/spec.md through §50 with implementation-status mapping, release caveats, and documented runtime/config drift
- document the two shipped doc/runtime drifts honestly: the backtest dataset builder is Python-only in v0.1 and the committed scenario features path differs from the generated Gold artifact name

## Verification
- `uv run --python 3.12 kospi-pipeline --help`
- `uv run --python 3.12 kospi-pipeline ingest --help`
- `uv run --python 3.12 kospi-pipeline build-features --help`
- `uv run --python 3.12 python -c "from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; print(build_backtest_dataset.__name__)"`
- `uv run --python 3.12 kospi-pipeline run-scenario --help`
- `uv run --python 3.12 kospi-pipeline run-backtest --help`
- `uv run --python 3.12 --extra dev python -m pytest`

## Oracle
- PASS, 94/100
- no blockers remaining