### PR TITLE
Implement Issue #42 — Snapshot-aware connector contracts and bronze manifests

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/base.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/base.py
@@ -1,22 +1,8 @@
-from __future__ import annotations
+from kospi_decision_pipeline_core.connectors import (
+    Connector,
+    ConnectorRow,
+    ConnectorRowBase,
+    SourceMetadata,
+)
 
-from dataclasses import dataclass
-from datetime import datetime
-from typing import Protocol, runtime_checkable
-
-
-@dataclass(frozen=True, slots=True)
-class SourceMetadata:
-    source_name: str
-    source_series_id: str
-    fetched_at: datetime
-
-
-@dataclass(frozen=True, slots=True)
-class ConnectorRow:
-    metadata: SourceMetadata
-
-
-@runtime_checkable
-class Connector(Protocol):
-    pass
+__all__ = ["Connector", "ConnectorRow", "ConnectorRowBase", "SourceMetadata"]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/data_portal.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/data_portal.py
@@ -5,11 +5,11 @@ from datetime import date
 from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
-from .base import ConnectorRow
+from .base import ConnectorRowBase
 
 
 @dataclass(frozen=True, slots=True)
-class DataPortalSampleRow(ConnectorRow):
+class DataPortalSampleRow(ConnectorRowBase):
     value_date: date
     metric_name: str
     metric_value: Decimal

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -5,23 +5,23 @@ from datetime import date
 from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
-from .base import ConnectorRow
+from .base import ConnectorRowBase
 
 
 @dataclass(frozen=True, slots=True)
-class EcosBaseRateRow(ConnectorRow):
+class EcosBaseRateRow(ConnectorRowBase):
     value_date: date
     base_rate: Decimal
 
 
 @dataclass(frozen=True, slots=True)
-class EcosUsdKrwRow(ConnectorRow):
+class EcosUsdKrwRow(ConnectorRowBase):
     value_date: date
     exchange_rate: Decimal
 
 
 @dataclass(frozen=True, slots=True)
-class EcosBondYieldRow(ConnectorRow):
+class EcosBondYieldRow(ConnectorRowBase):
     value_date: date
     maturity_code: str
     yield_rate: Decimal

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/fixture.py
@@ -30,13 +30,14 @@ class _FixtureLoader:
     def __init__(self, fixtures_root: Path) -> None:
         self._fixtures_root = fixtures_root
 
-    def load(self, source_name: str, dataset_name: str) -> _FixturePayload:
+    def load(self, source_name: str, dataset_name: str, connector_id: str) -> _FixturePayload:
         fixture_path = self._fixtures_root / source_name / f"{dataset_name}.json"
         payload = cast(dict[str, object], json.loads(fixture_path.read_text(encoding="utf-8")))
         metadata = SourceMetadata(
             source_name=str(payload["source_name"]),
-            source_series_id=str(payload["source_series_id"]),
-            fetched_at=datetime.fromisoformat(str(payload["fetched_at"])),
+            dataset_name=str(payload["source_series_id"]),
+            fetched_at_utc=datetime.fromisoformat(str(payload["fetched_at"])).isoformat(),
+            connector_id=connector_id,
         )
         raw_rows = cast(list[dict[str, object]], payload["rows"])
         return _FixturePayload(metadata=metadata, rows=tuple(raw_rows))
@@ -71,7 +72,7 @@ class FixtureKrxConnector:
         self._loader = _FixtureLoader(fixtures_root)
 
     def fetch_kospi_index(self, start: date, end: date) -> tuple[KospiIndexRow, ...]:
-        payload = self._loader.load("krx", "kospi_index")
+        payload = self._loader.load("krx", "kospi_index", _connector_id(self))
         rows = tuple(
             KospiIndexRow(
                 metadata=payload.metadata,
@@ -88,7 +89,7 @@ class FixtureKrxConnector:
         return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
 
     def fetch_investor_flow(self, start: date, end: date) -> tuple[InvestorFlowRow, ...]:
-        payload = self._loader.load("krx", "investor_flow")
+        payload = self._loader.load("krx", "investor_flow", _connector_id(self))
         rows = tuple(
             InvestorFlowRow(
                 metadata=payload.metadata,
@@ -102,7 +103,7 @@ class FixtureKrxConnector:
         return _filter_by_date_range(rows, lambda row: row.trade_date, start, end)
 
     def fetch_market_valuation(self, start: date, end: date) -> tuple[MarketValuationRow, ...]:
-        payload = self._loader.load("krx", "market_valuation")
+        payload = self._loader.load("krx", "market_valuation", _connector_id(self))
         rows = tuple(
             MarketValuationRow(
                 metadata=payload.metadata,
@@ -124,7 +125,7 @@ class FixtureEcosConnector:
         self._loader = _FixtureLoader(fixtures_root)
 
     def fetch_base_rate_series(self, start: date, end: date) -> tuple[EcosBaseRateRow, ...]:
-        payload = self._loader.load("ecos", "base_rate")
+        payload = self._loader.load("ecos", "base_rate", _connector_id(self))
         rows = tuple(
             EcosBaseRateRow(
                 metadata=payload.metadata,
@@ -136,7 +137,7 @@ class FixtureEcosConnector:
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
 
     def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]:
-        payload = self._loader.load("ecos", "usd_krw")
+        payload = self._loader.load("ecos", "usd_krw", _connector_id(self))
         rows = tuple(
             EcosUsdKrwRow(
                 metadata=payload.metadata,
@@ -148,7 +149,7 @@ class FixtureEcosConnector:
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
 
     def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]:
-        payload = self._loader.load("ecos", "bond_yield")
+        payload = self._loader.load("ecos", "bond_yield", _connector_id(self))
         rows = tuple(
             EcosBondYieldRow(
                 metadata=payload.metadata,
@@ -169,7 +170,7 @@ class FixtureKosisConnector:
         self._loader = _FixtureLoader(fixtures_root)
 
     def fetch_per_pbr_percentiles(self, start: date, end: date) -> tuple[PerPbrPercentileRow, ...]:
-        payload = self._loader.load("kosis", "per_pbr_percentiles")
+        payload = self._loader.load("kosis", "per_pbr_percentiles", _connector_id(self))
         rows = tuple(
             PerPbrPercentileRow(
                 metadata=payload.metadata,
@@ -182,7 +183,7 @@ class FixtureKosisConnector:
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
 
     def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
-        payload = self._loader.load("kosis", "macro_indicators")
+        payload = self._loader.load("kosis", "macro_indicators", _connector_id(self))
         rows = tuple(
             KosisMacroIndicatorRow(
                 metadata=payload.metadata,
@@ -204,7 +205,7 @@ class FixtureDataPortalConnector:
         self._loader = _FixtureLoader(fixtures_root)
 
     def fetch_sample_dataset(self, start: date, end: date) -> tuple[DataPortalSampleRow, ...]:
-        payload = self._loader.load("data_portal", "sample_dataset")
+        payload = self._loader.load("data_portal", "sample_dataset", _connector_id(self))
         rows = tuple(
             DataPortalSampleRow(
                 metadata=payload.metadata,
@@ -215,3 +216,8 @@ class FixtureDataPortalConnector:
             for row in payload.rows
         )
         return _filter_by_date_range(rows, lambda row: row.value_date, start, end)
+
+
+def _connector_id(connector: object) -> str:
+    connector_type = type(connector)
+    return f"{connector_type.__module__}.{connector_type.__qualname__}"

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -5,18 +5,18 @@ from datetime import date
 from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
-from .base import ConnectorRow
+from .base import ConnectorRowBase
 
 
 @dataclass(frozen=True, slots=True)
-class PerPbrPercentileRow(ConnectorRow):
+class PerPbrPercentileRow(ConnectorRowBase):
     value_date: date
     per_percentile: Decimal
     pbr_percentile: Decimal
 
 
 @dataclass(frozen=True, slots=True)
-class KosisMacroIndicatorRow(ConnectorRow):
+class KosisMacroIndicatorRow(ConnectorRowBase):
     value_date: date
     indicator_name: str
     indicator_value: Decimal

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
@@ -5,11 +5,11 @@ from datetime import date
 from decimal import Decimal
 from typing import Protocol, runtime_checkable
 
-from .base import ConnectorRow
+from .base import ConnectorRowBase
 
 
 @dataclass(frozen=True, slots=True)
-class KospiIndexRow(ConnectorRow):
+class KospiIndexRow(ConnectorRowBase):
     trade_date: date
     open_price: Decimal
     high_price: Decimal
@@ -20,7 +20,7 @@ class KospiIndexRow(ConnectorRow):
 
 
 @dataclass(frozen=True, slots=True)
-class InvestorFlowRow(ConnectorRow):
+class InvestorFlowRow(ConnectorRowBase):
     trade_date: date
     individual_net_buy: Decimal
     foreign_net_buy: Decimal
@@ -28,7 +28,7 @@ class InvestorFlowRow(ConnectorRow):
 
 
 @dataclass(frozen=True, slots=True)
-class MarketValuationRow(ConnectorRow):
+class MarketValuationRow(ConnectorRowBase):
     trade_date: date
     market_capitalization: Decimal
     trailing_per: Decimal

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
@@ -20,8 +20,8 @@ from ..connectors import (
     KosisConnector,
     KrxConnector,
 )
-from ..connectors.base import ConnectorRow
-from .manifests import BronzeManifest, ManifestEntry, write_manifest
+from ..connectors.base import ConnectorRowBase, SourceMetadata
+from .manifests import BronzeManifest, LiveIngestManifest, ManifestEntry, write_manifest
 
 
 SourceName = str
@@ -54,54 +54,64 @@ class _DatasetDefinition:
 
 
 class _FetchRows(Protocol):
-    def __call__(self, connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]: ...
+    def __call__(
+        self, connector: object, start: date, end: date
+    ) -> tuple[ConnectorRowBase, ...]: ...
 
 
-def _fetch_krx_kospi_index(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_krx_kospi_index(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(KrxConnector, connector)
     return tuple(typed_connector.fetch_kospi_index(start, end))
 
 
-def _fetch_krx_investor_flow(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_krx_investor_flow(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(KrxConnector, connector)
     return tuple(typed_connector.fetch_investor_flow(start, end))
 
 
 def _fetch_krx_market_valuation(
     connector: object, start: date, end: date
-) -> tuple[ConnectorRow, ...]:
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(KrxConnector, connector)
     return tuple(typed_connector.fetch_market_valuation(start, end))
 
 
-def _fetch_ecos_base_rate(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_ecos_base_rate(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(EcosConnector, connector)
     return tuple(typed_connector.fetch_base_rate_series(start, end))
 
 
-def _fetch_ecos_usd_krw(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_ecos_usd_krw(connector: object, start: date, end: date) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(EcosConnector, connector)
     return tuple(typed_connector.fetch_usd_krw_series(start, end))
 
 
-def _fetch_ecos_bond_yield(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_ecos_bond_yield(
+    connector: object, start: date, end: date
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(EcosConnector, connector)
     return tuple(typed_connector.fetch_bond_yield_series(start, end))
 
 
-def _fetch_kosis_per_pbr(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_kosis_per_pbr(connector: object, start: date, end: date) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(KosisConnector, connector)
     return tuple(typed_connector.fetch_per_pbr_percentiles(start, end))
 
 
-def _fetch_kosis_macro(connector: object, start: date, end: date) -> tuple[ConnectorRow, ...]:
+def _fetch_kosis_macro(connector: object, start: date, end: date) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(KosisConnector, connector)
     return tuple(typed_connector.fetch_macro_indicators(start, end))
 
 
 def _fetch_data_portal_sample(
     connector: object, start: date, end: date
-) -> tuple[ConnectorRow, ...]:
+) -> tuple[ConnectorRowBase, ...]:
     typed_connector = cast(DataPortalConnector, connector)
     return tuple(typed_connector.fetch_sample_dataset(start, end))
 
@@ -172,6 +182,7 @@ class BronzeIngestor:
         dataset_id: str,
         start: date,
         end: date,
+        snapshot_id: str | None = None,
     ) -> BronzeIngestResult:
         definition = DATASET_DEFINITIONS.get(dataset_id)
         if definition is None:
@@ -185,17 +196,45 @@ class BronzeIngestor:
                 dataset_id=dataset_id,
                 as_of_date=as_of_date,
                 rows=partition_rows,
+                snapshot_id=snapshot_id,
             )
             for as_of_date, partition_rows in grouped_rows
         )
 
-        manifest = BronzeManifest(
-            dataset_id=dataset_id,
-            source_name=definition.source_name,
-            run_timestamp=self._resolve_run_timestamp(),
-            entries=entries,
+        run_timestamp = self._resolve_run_timestamp()
+        if snapshot_id is None:
+            manifest: BronzeManifest = BronzeManifest(
+                dataset_id=dataset_id,
+                source_name=definition.source_name,
+                run_timestamp=run_timestamp,
+                entries=entries,
+            )
+        else:
+            written_dates = tuple(as_of_date for as_of_date, _ in grouped_rows)
+            manifest = LiveIngestManifest(
+                dataset_id=dataset_id,
+                source_name=definition.source_name,
+                run_timestamp=run_timestamp,
+                entries=entries,
+                snapshot_id=snapshot_id,
+                requested_start=start,
+                requested_end=end,
+                written_dates=written_dates,
+                skipped_dates=_skipped_dates(start, end, written_dates),
+                failed_dates=(),
+                source_metadata=_source_metadata(
+                    connector=connector,
+                    source_name=definition.source_name,
+                    dataset_id=dataset_id,
+                    fetched_at=run_timestamp,
+                ),
+            )
+        manifest_path = (
+            self._output_root_for_snapshot(snapshot_id)
+            / definition.source_name
+            / dataset_id
+            / "manifest.json"
         )
-        manifest_path = self._output_root / definition.source_name / dataset_id / "manifest.json"
         write_manifest(manifest_path, manifest)
         return BronzeIngestResult(entries=entries, manifest_path=manifest_path)
 
@@ -209,10 +248,11 @@ class BronzeIngestor:
         source_name: str,
         dataset_id: str,
         as_of_date: date,
-        rows: tuple[ConnectorRow, ...],
+        rows: tuple[ConnectorRowBase, ...],
+        snapshot_id: str | None,
     ) -> ManifestEntry:
         relative_path = Path(source_name) / dataset_id / f"{as_of_date.isoformat()}.parquet"
-        output_path = self._output_root / relative_path
+        output_path = self._output_root_for_snapshot(snapshot_id) / relative_path
         output_path.parent.mkdir(parents=True, exist_ok=True)
 
         records = [_row_to_record(row) for row in rows]
@@ -227,18 +267,23 @@ class BronzeIngestor:
             fetched_at=str(sorted_records[0]["fetched_at"]),
         )
 
+    def _output_root_for_snapshot(self, snapshot_id: str | None) -> Path:
+        if snapshot_id is None:
+            return self._output_root
+        return self._output_root / snapshot_id
+
 
 def _group_rows_by_date(
-    rows: tuple[ConnectorRow, ...], date_field_name: str
-) -> tuple[tuple[date, tuple[ConnectorRow, ...]], ...]:
-    grouped: dict[date, list[ConnectorRow]] = {}
+    rows: tuple[ConnectorRowBase, ...], date_field_name: str
+) -> tuple[tuple[date, tuple[ConnectorRowBase, ...]], ...]:
+    grouped: dict[date, list[ConnectorRowBase]] = {}
     for row in rows:
         as_of_date = cast(date, getattr(row, date_field_name))
         grouped.setdefault(as_of_date, []).append(row)
     return tuple((as_of_date, tuple(grouped[as_of_date])) for as_of_date in sorted(grouped))
 
 
-def _row_to_record(row: ConnectorRow) -> dict[str, str | int]:
+def _row_to_record(row: ConnectorRowBase) -> dict[str, str | int]:
     payload = cast(dict[str, object], asdict(row))
     metadata = payload.pop("metadata")
     if not isinstance(metadata, dict):
@@ -246,8 +291,8 @@ def _row_to_record(row: ConnectorRow) -> dict[str, str | int]:
     metadata_payload = cast(dict[str, object], metadata)
     record: dict[str, str | int] = {
         "source_name": _normalize_scalar(metadata_payload["source_name"]),
-        "source_series_id": _normalize_scalar(metadata_payload["source_series_id"]),
-        "fetched_at": _normalize_scalar(metadata_payload["fetched_at"]),
+        "source_series_id": _normalize_scalar(metadata_payload["dataset_name"]),
+        "fetched_at": _normalize_scalar(metadata_payload["fetched_at_utc"]),
     }
     ordered_field_names = sorted(field.name for field in fields(row) if field.name != "metadata")
     for field_name in ordered_field_names:
@@ -270,6 +315,29 @@ def _normalize_scalar(value: object) -> str | int:
 
 def _record_sort_key(record: dict[str, str | int]) -> tuple[str, ...]:
     return tuple(f"{key}={record[key]}" for key in sorted(record))
+
+
+def _source_metadata(
+    *, connector: object, source_name: str, dataset_id: str, fetched_at: datetime
+) -> SourceMetadata:
+    connector_type = type(connector)
+    return SourceMetadata(
+        source_name=source_name,
+        dataset_name=dataset_id,
+        fetched_at_utc=fetched_at.isoformat(),
+        connector_id=f"{connector_type.__module__}.{connector_type.__qualname__}",
+    )
+
+
+def _skipped_dates(start: date, end: date, written_dates: tuple[date, ...]) -> tuple[date, ...]:
+    written_lookup = set(written_dates)
+    skipped: list[date] = []
+    current = start
+    while current <= end:
+        if current not in written_lookup:
+            skipped.append(current)
+        current = current.fromordinal(current.toordinal() + 1)
+    return tuple(skipped)
 
 
 class ConnectorRegistry(Protocol):

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/manifests.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/manifests.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import date, datetime
 import json
 from pathlib import Path
-from typing import TypedDict, cast
+from typing import TypedDict, cast, override
+
+from ..connectors.base import SourceMetadata
 
 
 class ManifestEntryDict(TypedDict):
@@ -19,6 +21,25 @@ class BronzeManifestDict(TypedDict):
     source_name: str
     run_timestamp: str
     entries: list[ManifestEntryDict]
+
+
+class SourceMetadataDict(TypedDict):
+    source_name: str
+    dataset_name: str
+    fetched_at_utc: str
+    connector_id: str
+    api_version: str | None
+    key_fingerprint_sha256: str | None
+
+
+class LiveIngestManifestDict(BronzeManifestDict):
+    snapshot_id: str
+    requested_start: str
+    requested_end: str
+    written_dates: list[str]
+    skipped_dates: list[str]
+    failed_dates: list[str]
+    source_metadata: SourceMetadataDict
 
 
 @dataclass(frozen=True, slots=True)
@@ -78,6 +99,85 @@ class BronzeManifest:
         )
 
 
+@dataclass(frozen=True, slots=True)
+class LiveIngestManifest(BronzeManifest):
+    snapshot_id: str
+    requested_start: date
+    requested_end: date
+    written_dates: tuple[date, ...]
+    skipped_dates: tuple[date, ...]
+    failed_dates: tuple[date, ...]
+    source_metadata: SourceMetadata
+
+    @override
+    def to_dict(self) -> LiveIngestManifestDict:
+        payload = super(LiveIngestManifest, self).to_dict()
+        return {
+            **payload,
+            "snapshot_id": self.snapshot_id,
+            "requested_start": self.requested_start.isoformat(),
+            "requested_end": self.requested_end.isoformat(),
+            "written_dates": [value.isoformat() for value in self.written_dates],
+            "skipped_dates": [value.isoformat() for value in self.skipped_dates],
+            "failed_dates": [value.isoformat() for value in self.failed_dates],
+            "source_metadata": _source_metadata_to_dict(self.source_metadata),
+        }
+
+    @override
+    def to_deterministic_dict(self) -> dict[str, object]:
+        payload = super(LiveIngestManifest, self).to_deterministic_dict()
+        payload.update(
+            {
+                "snapshot_id": self.snapshot_id,
+                "requested_start": self.requested_start.isoformat(),
+                "requested_end": self.requested_end.isoformat(),
+                "written_dates": [value.isoformat() for value in self.written_dates],
+                "skipped_dates": [value.isoformat() for value in self.skipped_dates],
+                "failed_dates": [value.isoformat() for value in self.failed_dates],
+                "source_metadata": _source_metadata_to_dict(self.source_metadata),
+            }
+        )
+        return payload
+
+
+def _source_metadata_to_dict(metadata: SourceMetadata) -> SourceMetadataDict:
+    return {
+        "source_name": metadata.source_name,
+        "dataset_name": metadata.dataset_name,
+        "fetched_at_utc": metadata.fetched_at_utc,
+        "connector_id": metadata.connector_id,
+        "api_version": metadata.api_version,
+        "key_fingerprint_sha256": metadata.key_fingerprint_sha256,
+    }
+
+
+def _source_metadata_from_dict(payload: SourceMetadataDict) -> SourceMetadata:
+    return SourceMetadata(
+        source_name=payload["source_name"],
+        dataset_name=payload["dataset_name"],
+        fetched_at_utc=payload["fetched_at_utc"],
+        connector_id=payload["connector_id"],
+        api_version=payload["api_version"],
+        key_fingerprint_sha256=payload["key_fingerprint_sha256"],
+    )
+
+
+def _live_manifest_from_dict(payload: LiveIngestManifestDict) -> LiveIngestManifest:
+    return LiveIngestManifest(
+        dataset_id=payload["dataset_id"],
+        source_name=payload["source_name"],
+        run_timestamp=datetime.fromisoformat(payload["run_timestamp"]),
+        entries=tuple(ManifestEntry.from_dict(raw_entry) for raw_entry in payload["entries"]),
+        snapshot_id=payload["snapshot_id"],
+        requested_start=date.fromisoformat(payload["requested_start"]),
+        requested_end=date.fromisoformat(payload["requested_end"]),
+        written_dates=tuple(date.fromisoformat(value) for value in payload["written_dates"]),
+        skipped_dates=tuple(date.fromisoformat(value) for value in payload["skipped_dates"]),
+        failed_dates=tuple(date.fromisoformat(value) for value in payload["failed_dates"]),
+        source_metadata=_source_metadata_from_dict(payload["source_metadata"]),
+    )
+
+
 def write_manifest(path: Path, manifest: BronzeManifest) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     _ = path.write_text(
@@ -90,4 +190,6 @@ def read_manifest(path: Path) -> BronzeManifest:
     loaded = cast(object, json.loads(path.read_text(encoding="utf-8")))
     if not isinstance(loaded, dict):
         raise ValueError("manifest payload must be an object")
+    if "snapshot_id" in loaded:
+        return _live_manifest_from_dict(cast(LiveIngestManifestDict, cast(object, loaded)))
     return BronzeManifest.from_dict(cast(BronzeManifestDict, cast(object, loaded)))

--- a/apps/kr-kospi/tests/contract/test_live_bronze_manifest.py
+++ b/apps/kr-kospi/tests/contract/test_live_bronze_manifest.py
@@ -52,3 +52,4 @@ def test_snapshot_aware_ingest_writes_snapshot_root_and_live_manifest(tmp_path: 
     assert manifest.source_metadata.dataset_name == "kospi_index"
     assert manifest.source_metadata.connector_id.endswith("FixtureKrxConnector")
     assert manifest.source_metadata.fetched_at_utc == RUN_TIMESTAMP.isoformat()
+    assert manifest.to_deterministic_dict()["snapshot_id"] == "snapshot-20240115T000000Z"

--- a/apps/kr-kospi/tests/contract/test_live_bronze_manifest.py
+++ b/apps/kr-kospi/tests/contract/test_live_bronze_manifest.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import FixtureKrxConnector
+from kospi_decision_pipeline_app_kr_kospi.ingest.bronze import BronzeIngestor
+from kospi_decision_pipeline_app_kr_kospi.ingest.manifests import LiveIngestManifest, read_manifest
+
+
+FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures"
+RUN_TIMESTAMP = datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc)
+
+
+def test_snapshot_aware_ingest_writes_snapshot_root_and_live_manifest(tmp_path: Path) -> None:
+    connector = FixtureKrxConnector(FIXTURES_ROOT)
+    ingestor = BronzeIngestor(output_root=tmp_path, deterministic_run_timestamp=RUN_TIMESTAMP)
+
+    result = ingestor.ingest(
+        connector=connector,
+        dataset_id="kospi_index",
+        start=date(2024, 1, 2),
+        end=date(2024, 1, 6),
+        snapshot_id="snapshot-20240115T000000Z",
+    )
+
+    assert [entry.path for entry in result.entries] == [
+        Path("krx/kospi_index/2024-01-02.parquet"),
+        Path("krx/kospi_index/2024-01-03.parquet"),
+        Path("krx/kospi_index/2024-01-04.parquet"),
+        Path("krx/kospi_index/2024-01-05.parquet"),
+    ]
+    assert all(
+        (tmp_path / "snapshot-20240115T000000Z" / entry.path).is_file() for entry in result.entries
+    )
+
+    manifest = read_manifest(result.manifest_path)
+
+    assert isinstance(manifest, LiveIngestManifest)
+    assert manifest.snapshot_id == "snapshot-20240115T000000Z"
+    assert manifest.requested_start == date(2024, 1, 2)
+    assert manifest.requested_end == date(2024, 1, 6)
+    assert manifest.written_dates == (
+        date(2024, 1, 2),
+        date(2024, 1, 3),
+        date(2024, 1, 4),
+        date(2024, 1, 5),
+    )
+    assert manifest.skipped_dates == (date(2024, 1, 6),)
+    assert manifest.failed_dates == ()
+    assert manifest.source_metadata.source_name == "krx"
+    assert manifest.source_metadata.dataset_name == "kospi_index"
+    assert manifest.source_metadata.connector_id.endswith("FixtureKrxConnector")
+    assert manifest.source_metadata.fetched_at_utc == RUN_TIMESTAMP.isoformat()

--- a/core/src/kospi_decision_pipeline_core/connectors/__init__.py
+++ b/core/src/kospi_decision_pipeline_core/connectors/__init__.py
@@ -1,0 +1,8 @@
+from .contracts import Connector, ConnectorRow, ConnectorRowBase, SourceMetadata
+
+__all__ = [
+    "Connector",
+    "ConnectorRow",
+    "ConnectorRowBase",
+    "SourceMetadata",
+]

--- a/core/src/kospi_decision_pipeline_core/connectors/__init__.pyi
+++ b/core/src/kospi_decision_pipeline_core/connectors/__init__.pyi
@@ -1,3 +1,0 @@
-from .contracts import Connector, ConnectorRow, ConnectorRowBase, SourceMetadata
-
-__all__: list[str]

--- a/core/src/kospi_decision_pipeline_core/connectors/__init__.pyi
+++ b/core/src/kospi_decision_pipeline_core/connectors/__init__.pyi
@@ -1,0 +1,3 @@
+from .contracts import Connector, ConnectorRow, ConnectorRowBase, SourceMetadata
+
+__all__: list[str]

--- a/core/src/kospi_decision_pipeline_core/connectors/contracts.py
+++ b/core/src/kospi_decision_pipeline_core/connectors/contracts.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Protocol, runtime_checkable
+
+
+def _parse_utc_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None or parsed.utcoffset() != timedelta(0):
+        raise ValueError("fetched_at_utc must be an ISO-8601 UTC timestamp")
+    return parsed
+
+
+@dataclass(frozen=True, slots=True)
+class SourceMetadata:
+    source_name: str
+    dataset_name: str
+    fetched_at_utc: str
+    connector_id: str
+    api_version: str | None = None
+    key_fingerprint_sha256: str | None = None
+
+    def __post_init__(self) -> None:
+        _ = _parse_utc_timestamp(self.fetched_at_utc)
+
+    @property
+    def source_series_id(self) -> str:
+        return self.dataset_name
+
+    @property
+    def fetched_at(self) -> datetime:
+        return _parse_utc_timestamp(self.fetched_at_utc)
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorRowBase:
+    metadata: SourceMetadata
+
+
+@runtime_checkable
+class ConnectorRow(Protocol):
+    @property
+    def metadata(self) -> SourceMetadata: ...
+
+
+@runtime_checkable
+class Connector(Protocol):
+    pass

--- a/core/tests/connectors/test_contracts.py
+++ b/core/tests/connectors/test_contracts.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, dataclass
+from datetime import UTC, datetime
+
+import pytest
+
+from kospi_decision_pipeline_core.connectors import ConnectorRow, SourceMetadata
+
+
+@dataclass(frozen=True, slots=True)
+class SampleConnectorRow:
+    metadata: SourceMetadata
+    value: str
+
+
+def test_source_metadata_captures_snapshot_connector_identity_fields() -> None:
+    metadata = SourceMetadata(
+        source_name="krx",
+        dataset_name="kospi_index",
+        fetched_at_utc="2024-01-10T09:00:00+00:00",
+        connector_id="fixture.krx.FixtureKrxConnector",
+        api_version="v1",
+        key_fingerprint_sha256="abc123",
+    )
+
+    assert metadata.source_name == "krx"
+    assert metadata.dataset_name == "kospi_index"
+    assert metadata.fetched_at_utc == "2024-01-10T09:00:00+00:00"
+    assert metadata.connector_id == "fixture.krx.FixtureKrxConnector"
+    assert metadata.api_version == "v1"
+    assert metadata.key_fingerprint_sha256 == "abc123"
+    assert metadata.source_series_id == "kospi_index"
+    assert metadata.fetched_at == datetime(2024, 1, 10, 9, 0, tzinfo=UTC)
+
+
+def test_source_metadata_is_frozen() -> None:
+    metadata = SourceMetadata(
+        source_name="krx",
+        dataset_name="kospi_index",
+        fetched_at_utc="2024-01-10T09:00:00+00:00",
+        connector_id="fixture.krx.FixtureKrxConnector",
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        metadata.source_name = "ecos"
+
+
+def test_connector_row_protocol_accepts_typed_dataclass_rows() -> None:
+    row = SampleConnectorRow(
+        metadata=SourceMetadata(
+            source_name="krx",
+            dataset_name="kospi_index",
+            fetched_at_utc="2024-01-10T09:00:00+00:00",
+            connector_id="fixture.krx.FixtureKrxConnector",
+        ),
+        value="ok",
+    )
+
+    assert isinstance(row, ConnectorRow)
+
+
+def test_source_metadata_rejects_non_utc_timestamp() -> None:
+    with pytest.raises(ValueError, match="UTC"):
+        SourceMetadata(
+            source_name="krx",
+            dataset_name="kospi_index",
+            fetched_at_utc="2024-01-10T18:00:00+09:00",
+            connector_id="fixture.krx.FixtureKrxConnector",
+        )

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": [
+    "core/src",
+    "core/tests",
+    "apps/kr-kospi/src",
+    "apps/kr-kospi/tests"
+  ],
+  "extraPaths": [
+    "core/src",
+    "apps/kr-kospi/src"
+  ],
+  "pythonVersion": "3.12",
+  "typeCheckingMode": "strict"
+}


### PR DESCRIPTION
## Summary
- add a core connector contract package with frozen `SourceMetadata`, a shared connector row protocol/base, and fixture metadata that preserves connector identity without exposing raw secrets
- extend bronze ingest with snapshot-aware output roots and live manifests that capture snapshot id, requested ranges, written/skipped/failed dates, and source metadata while keeping legacy fixture paths green
- add RED/GREEN/cleanup coverage for the new connector contracts and live bronze manifest behavior

Closes #42