### PR TITLE
Implement Issue #43 — Live ECOS connector for base rate, USD/KRW, and 3Y yield

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
@@ -1,6 +1,12 @@
 from .base import ConnectorRow, SourceMetadata
 from .data_portal import DataPortalConnector, DataPortalSampleRow
-from .ecos import EcosBaseRateRow, EcosBondYieldRow, EcosConnector, EcosUsdKrwRow
+from .ecos import (
+    EcosBaseRateRow,
+    EcosBondYieldRow,
+    EcosConnector,
+    EcosUsdKrwRow,
+    LiveEcosConnector,
+)
 from .fixture import (
     FixtureDataPortalConnector,
     FixtureEcosConnector,
@@ -18,6 +24,7 @@ __all__ = [
     "EcosBondYieldRow",
     "EcosConnector",
     "EcosUsdKrwRow",
+    "LiveEcosConnector",
     "FixtureDataPortalConnector",
     "FixtureEcosConnector",
     "FixtureKosisConnector",

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/_http.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/_http.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Callable, final
+
+import httpx
+
+
+@dataclass(frozen=True, slots=True)
+class HttpRetryPolicy:
+    timeout_seconds: float = 10.0
+    max_attempts: int = 3
+    backoff_base_seconds: float = 0.5
+    retryable_status_codes: frozenset[int] = field(
+        default_factory=lambda: frozenset({500, 502, 503, 504})
+    )
+
+
+class HttpRequestError(RuntimeError):
+    pass
+
+
+@final
+class SyncHttpRequester:
+    _retry_policy: HttpRetryPolicy
+    _sleep: Callable[[float], None]
+
+    def __init__(
+        self,
+        retry_policy: HttpRetryPolicy | None = None,
+        *,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._retry_policy = retry_policy or HttpRetryPolicy()
+        self._sleep = sleep
+
+    @property
+    def retry_policy(self) -> HttpRetryPolicy:
+        return self._retry_policy
+
+    def get(self, client: httpx.Client, path: str) -> object:
+        last_error: Exception | None = None
+        for attempt in range(1, self._retry_policy.max_attempts + 1):
+            try:
+                response = client.get(path)
+            except httpx.TransportError as error:
+                last_error = error
+                if attempt == self._retry_policy.max_attempts:
+                    break
+                self._sleep(self._backoff_seconds(attempt))
+                continue
+
+            if response.status_code in self._retry_policy.retryable_status_codes:
+                last_error = HttpRequestError(
+                    f"HTTP {response.status_code} from upstream after attempt {attempt}"
+                )
+                if attempt == self._retry_policy.max_attempts:
+                    break
+                self._sleep(self._backoff_seconds(attempt))
+                continue
+
+            if response.status_code >= 400:
+                raise HttpRequestError(f"HTTP {response.status_code} from upstream")
+
+            return response.json()
+
+        if last_error is None:
+            raise HttpRequestError("HTTP request failed without response")
+        raise HttpRequestError(
+            f"HTTP request failed after {self._retry_policy.max_attempts} attempts"
+        ) from last_error
+
+    def _backoff_seconds(self, attempt: int) -> float:
+        multiplier = 2 ** (attempt - 1)
+        return float(self._retry_policy.backoff_base_seconds * multiplier)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Protocol, runtime_checkable
+import hashlib
+import os
+from typing import Callable, Mapping, Protocol, TypedDict, cast, final, runtime_checkable
 
-from .base import ConnectorRowBase
+import httpx
+
+from ._http import HttpRetryPolicy, SyncHttpRequester
+from .base import ConnectorRowBase, SourceMetadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,3 +39,256 @@ class EcosConnector(Protocol):
     def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]: ...
 
     def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]: ...
+
+
+_ECOS_API_BASE_URL = "https://ecos.bok.or.kr"
+_ECOS_API_KEY_ENV_VAR = "ECOS_API_KEY"
+_ECOS_RESULT_OK = "INFO-000"
+_ECOS_FORMAT = "json"
+_ECOS_LANGUAGE = "kr"
+_ECOS_START_ROW = 1
+_ECOS_END_ROW = 100000
+_ECOS_DAILY_CYCLE = "D"
+_ECOS_API_VERSION = "StatisticSearch"
+_LIVE_CONNECTOR_ID = "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector"
+
+
+@dataclass(frozen=True, slots=True)
+class _EcosSeriesDefinition:
+    stat_code: str
+    item_code1: str
+
+
+class _EcosResponseRow(TypedDict):
+    TIME: str
+    DATA_VALUE: str
+
+
+_BASE_RATE_SERIES = _EcosSeriesDefinition(
+    stat_code="722Y001",
+    item_code1="0101000",
+)
+_USD_KRW_SERIES = _EcosSeriesDefinition(
+    stat_code="731Y003",
+    item_code1="0000003",
+)
+_BOND_YIELD_SERIES = _EcosSeriesDefinition(
+    stat_code="817Y002",
+    item_code1="010200000",
+)
+
+
+@final
+class LiveEcosConnector:
+    _api_key: str
+    _key_fingerprint_sha256: str
+    _http_requester: SyncHttpRequester
+    _transport: httpx.BaseTransport | None
+    _now: Callable[[], datetime]
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        environment: Mapping[str, str] | None = None,
+        transport: httpx.BaseTransport | None = None,
+        retry_policy: HttpRetryPolicy | None = None,
+        sleep: Callable[[float], None] | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._api_key = _resolve_api_key(api_key, environment or os.environ)
+        self._key_fingerprint_sha256 = hashlib.sha256(self._api_key.encode("utf-8")).hexdigest()[
+            :16
+        ]
+        self._http_requester = SyncHttpRequester(retry_policy, sleep=sleep or _default_sleep)
+        self._transport = transport
+        self._now = now or _utc_now
+
+    def fetch_base_rate_series(self, start: date, end: date) -> tuple[EcosBaseRateRow, ...]:
+        payload = self._fetch_payload(_BASE_RATE_SERIES, start, end)
+        return parse_base_rate_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+
+    def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]:
+        payload = self._fetch_payload(_USD_KRW_SERIES, start, end)
+        return parse_usd_krw_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+
+    def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]:
+        payload = self._fetch_payload(_BOND_YIELD_SERIES, start, end)
+        return parse_bond_yield_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+
+    def _fetch_payload(self, definition: _EcosSeriesDefinition, start: date, end: date) -> object:
+        path = _statistic_search_path(
+            api_key=self._api_key,
+            stat_code=definition.stat_code,
+            start=start,
+            end=end,
+            item_code1=definition.item_code1,
+        )
+        with httpx.Client(
+            base_url=_ECOS_API_BASE_URL,
+            timeout=httpx.Timeout(self._http_requester.retry_policy.timeout_seconds),
+            transport=self._transport,
+        ) as client:
+            return self._http_requester.get(client, path)
+
+    def _fetched_at_utc(self) -> str:
+        return self._now().replace(microsecond=0).isoformat()
+
+
+def parse_base_rate_rows(
+    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+) -> tuple[EcosBaseRateRow, ...]:
+    metadata = _source_metadata("base_rate", fetched_at_utc, key_fingerprint_sha256)
+    return tuple(
+        sorted(
+            (
+                EcosBaseRateRow(
+                    metadata=metadata,
+                    value_date=_parse_ecos_date(raw_row["TIME"]),
+                    base_rate=_parse_decimal(raw_row["DATA_VALUE"]),
+                )
+                for raw_row in _ecos_rows(payload)
+            ),
+            key=lambda row: row.value_date,
+        )
+    )
+
+
+def parse_usd_krw_rows(
+    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+) -> tuple[EcosUsdKrwRow, ...]:
+    metadata = _source_metadata("usd_krw", fetched_at_utc, key_fingerprint_sha256)
+    return tuple(
+        sorted(
+            (
+                EcosUsdKrwRow(
+                    metadata=metadata,
+                    value_date=_parse_ecos_date(raw_row["TIME"]),
+                    exchange_rate=_parse_decimal(raw_row["DATA_VALUE"]),
+                )
+                for raw_row in _ecos_rows(payload)
+            ),
+            key=lambda row: row.value_date,
+        )
+    )
+
+
+def parse_bond_yield_rows(
+    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+) -> tuple[EcosBondYieldRow, ...]:
+    metadata = _source_metadata("bond_yield", fetched_at_utc, key_fingerprint_sha256)
+    return tuple(
+        sorted(
+            (
+                EcosBondYieldRow(
+                    metadata=metadata,
+                    value_date=_parse_ecos_date(raw_row["TIME"]),
+                    maturity_code="3Y",
+                    yield_rate=_parse_decimal(raw_row["DATA_VALUE"]),
+                )
+                for raw_row in _ecos_rows(payload)
+            ),
+            key=lambda row: row.value_date,
+        )
+    )
+
+
+def _source_metadata(
+    dataset_name: str, fetched_at_utc: str, key_fingerprint_sha256: str
+) -> SourceMetadata:
+    return SourceMetadata(
+        source_name="ecos",
+        dataset_name=dataset_name,
+        fetched_at_utc=fetched_at_utc,
+        connector_id=_LIVE_CONNECTOR_ID,
+        api_version=_ECOS_API_VERSION,
+        key_fingerprint_sha256=key_fingerprint_sha256,
+    )
+
+
+def _ecos_rows(payload: object) -> tuple[_EcosResponseRow, ...]:
+    statistic_search = _require_nested_mapping(_require_payload_mapping(payload), "StatisticSearch")
+    result = _require_nested_mapping(statistic_search, "RESULT")
+    result_code = _require_string(result, "CODE")
+    if result_code != _ECOS_RESULT_OK:
+        message = _require_string(result, "MESSAGE")
+        if "인증" in message or result_code.startswith("ERROR-3"):
+            raise PermissionError(f"ECOS authentication failed: {result_code}: {message}")
+        raise RuntimeError(f"ECOS request failed: {result_code}: {message}")
+    raw_rows = statistic_search.get("row")
+    if raw_rows is None:
+        return ()
+    rows: list[_EcosResponseRow] = []
+    for raw_row in _require_object_list(raw_rows, "row"):
+        mapping = _require_payload_mapping(raw_row)
+        rows.append(
+            {
+                "TIME": _require_string(mapping, "TIME"),
+                "DATA_VALUE": _require_string(mapping, "DATA_VALUE"),
+            }
+        )
+    return tuple(rows)
+
+
+def _require_payload_mapping(payload: object) -> Mapping[str, object]:
+    if isinstance(payload, dict):
+        return cast(dict[str, object], payload)
+    raise ValueError("ECOS payload must be a JSON object")
+
+
+def _require_nested_mapping(mapping: Mapping[str, object], key: str) -> Mapping[str, object]:
+    nested = mapping.get(key)
+    if isinstance(nested, dict):
+        return cast(dict[str, object], nested)
+    raise ValueError(f"missing ECOS mapping field: {key}")
+
+
+def _require_string(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"missing ECOS string field: {key}")
+    return value
+
+
+def _require_object_list(payload: object, key: str) -> tuple[object, ...]:
+    if isinstance(payload, list):
+        return tuple(cast(list[object], payload))
+    raise ValueError(f"ECOS {key} payload must be a list")
+
+
+def _parse_ecos_date(value: str) -> date:
+    return date.fromisoformat(f"{value[0:4]}-{value[4:6]}-{value[6:8]}")
+
+
+def _parse_decimal(value: str) -> Decimal:
+    return Decimal(value)
+
+
+def _resolve_api_key(api_key: str | None, environment: Mapping[str, str]) -> str:
+    explicit = (api_key or "").strip()
+    if explicit:
+        return explicit
+    from_environment = environment.get(_ECOS_API_KEY_ENV_VAR, "").strip()
+    if from_environment:
+        return from_environment
+    raise ValueError("ECOS API key is required via explicit argument or ECOS_API_KEY")
+
+
+def _statistic_search_path(
+    *, api_key: str, stat_code: str, start: date, end: date, item_code1: str
+) -> str:
+    return (
+        f"/api/StatisticSearch/{api_key}/{_ECOS_FORMAT}/{_ECOS_LANGUAGE}/"
+        f"{_ECOS_START_ROW}/{_ECOS_END_ROW}/{stat_code}/{_ECOS_DAILY_CYCLE}/"
+        f"{start.strftime('%Y%m%d')}/{end.strftime('%Y%m%d')}/{item_code1}"
+    )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _default_sleep(seconds: float) -> None:
+    from time import sleep
+
+    sleep(seconds)

--- a/apps/kr-kospi/tests/contract/test_connector_fixtures.py
+++ b/apps/kr-kospi/tests/contract/test_connector_fixtures.py
@@ -20,6 +20,7 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
     EcosBondYieldRow,
     EcosConnector,
     EcosUsdKrwRow,
+    LiveEcosConnector,
 )
 from kospi_decision_pipeline_app_kr_kospi.connectors.fixture import (
     FixtureDataPortalConnector,
@@ -164,6 +165,7 @@ def test_connectors_package_exports_fixture_connectors() -> None:
     assert connectors.FixtureEcosConnector is FixtureEcosConnector
     assert connectors.FixtureKosisConnector is FixtureKosisConnector
     assert connectors.FixtureDataPortalConnector is FixtureDataPortalConnector
+    assert connectors.LiveEcosConnector is LiveEcosConnector
 
 
 def test_connector_modules_do_not_read_fixtures_at_import_time(

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Mapping
 from datetime import date
 from decimal import Decimal
 import json
@@ -9,6 +9,11 @@ from pathlib import Path
 import httpx
 import pytest
 
+from kospi_decision_pipeline_app_kr_kospi.connectors._http import (
+    HttpRequestError,
+    HttpRetryPolicy,
+    SyncHttpRequester,
+)
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
     LiveEcosConnector,
     parse_base_rate_rows,
@@ -28,11 +33,11 @@ USD_KRW_PATH = (
 )
 
 
-def _load_payload(name: str) -> dict[str, object]:
+def _load_payload(name: str) -> Mapping[str, object]:
     return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
 
 
-def _json_response(request: httpx.Request, payload: dict[str, object]) -> httpx.Response:
+def _json_response(request: httpx.Request, payload: Mapping[str, object]) -> httpx.Response:
     return httpx.Response(status_code=200, json=payload, request=request)
 
 
@@ -75,6 +80,47 @@ def test_live_ecos_connector_raises_on_ecos_auth_failure() -> None:
         connector.fetch_base_rate_series(START_DATE, END_DATE)
 
 
+def test_live_ecos_connector_prefers_explicit_api_key_over_environment() -> None:
+    payload = _load_payload("base_rate_statistic_search.json")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "explicit-api-key" in request.url.path
+        assert "env-api-key" not in request.url.path
+        return _json_response(request, payload)
+
+    connector = LiveEcosConnector(
+        api_key="explicit-api-key",
+        environment={"ECOS_API_KEY": "env-api-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
+
+    assert rows
+
+
+def test_live_ecos_connector_requires_api_key_when_no_auth_source_exists() -> None:
+    with pytest.raises(ValueError, match="ECOS API key"):
+        LiveEcosConnector(environment={})
+
+
+def test_live_ecos_connector_uses_environment_api_key() -> None:
+    payload = _load_payload("usd_krw_statistic_search.json")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "env-api-key" in request.url.path
+        return _json_response(request, payload)
+
+    connector = LiveEcosConnector(
+        environment={"ECOS_API_KEY": "env-api-key"},
+        transport=httpx.MockTransport(handler),
+    )
+
+    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
+
+    assert rows
+
+
 def test_live_ecos_connector_retries_transient_http_failures() -> None:
     payload = _load_payload("usd_krw_statistic_search.json")
     attempts = 0
@@ -104,45 +150,223 @@ def test_live_ecos_connector_retries_transient_http_failures() -> None:
     ]
 
 
+def test_live_ecos_connector_uses_default_sleep_for_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _load_payload("usd_krw_statistic_search.json")
+    attempts = 0
+    slept: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(status_code=503, request=request)
+        return _json_response(request, payload)
+
+    monkeypatch.setattr("time.sleep", slept.append)
+
+    connector = LiveEcosConnector(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
+
+    assert attempts == 2
+    assert slept == [0.5]
+    assert rows
+
+
+def test_live_ecos_connector_fetches_bond_yield_rows() -> None:
+    payload = _load_payload("bond_yield_statistic_search.json")
+
+    connector = LiveEcosConnector(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+    )
+
+    rows = connector.fetch_bond_yield_series(START_DATE, END_DATE)
+
+    assert tuple(row.yield_rate for row in rows) == (
+        Decimal("3.23"),
+        Decimal("3.20"),
+        Decimal("3.18"),
+    )
+    assert all(row.maturity_code == "3Y" for row in rows)
+
+
+def test_parse_base_rate_rows_returns_empty_tuple_when_row_block_missing() -> None:
+    rows = parse_base_rate_rows(
+        {"StatisticSearch": {"RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}}},
+        "2024-01-15T00:00:00+00:00",
+        "abc123def4567890",
+    )
+
+    assert rows == ()
+
+
+def test_parse_base_rate_rows_raises_runtime_error_for_non_auth_ecos_failure() -> None:
+    payload = {"StatisticSearch": {"RESULT": {"CODE": "ERROR-100", "MESSAGE": "잘못된 요청"}}}
+
+    with pytest.raises(RuntimeError, match="ERROR-100"):
+        parse_base_rate_rows(payload, "2024-01-15T00:00:00+00:00", "abc123def4567890")
+
+
 @pytest.mark.parametrize(
-    ("fixture_name", "parser", "expected_values"),
+    ("payload", "message"),
     [
+        ("not-a-dict", "JSON object"),
+        ({"StatisticSearch": []}, "StatisticSearch"),
+        ({"StatisticSearch": {"RESULT": []}}, "RESULT"),
         (
-            "base_rate_statistic_search.json",
-            parse_base_rate_rows,
-            (Decimal("3.50"), Decimal("3.50"), Decimal("3.50")),
+            {"StatisticSearch": {"RESULT": {"CODE": 123, "MESSAGE": "정상 처리되었습니다."}}},
+            "CODE",
         ),
         (
-            "usd_krw_statistic_search.json",
-            parse_usd_krw_rows,
-            (Decimal("1293.10"), Decimal("1288.40"), Decimal("1290.00")),
+            {
+                "StatisticSearch": {
+                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
+                    "row": {},
+                }
+            },
+            "row payload must be a list",
         ),
         (
-            "bond_yield_statistic_search.json",
-            parse_bond_yield_rows,
-            (Decimal("3.23"), Decimal("3.20"), Decimal("3.18")),
+            {
+                "StatisticSearch": {
+                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
+                    "row": ["not-a-dict"],
+                }
+            },
+            "JSON object",
+        ),
+        (
+            {
+                "StatisticSearch": {
+                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
+                    "row": [{"TIME": "20240102", "DATA_VALUE": 1.23}],
+                }
+            },
+            "DATA_VALUE",
         ),
     ],
 )
-def test_ecos_recorded_payload_parsers_match_expected_values(
-    fixture_name: str,
-    parser: Callable[[dict[str, object], str, str], tuple[object, ...]],
-    expected_values: tuple[Decimal, ...],
-) -> None:
-    payload = _load_payload(fixture_name)
+def test_parse_base_rate_rows_validates_ecos_payload_shape(payload: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_base_rate_rows(payload, "2024-01-15T00:00:00+00:00", "abc123def4567890")
 
-    rows = parser(
-        payload,
-        fetched_at_utc="2024-01-15T00:00:00+00:00",
-        key_fingerprint_sha256="abc123def4567890",
+
+def test_sync_http_requester_retries_transport_errors() -> None:
+    attempts = 0
+    sleeps: list[float] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ReadTimeout("timeout", request=request)
+        return _json_response(request, _load_payload("base_rate_statistic_search.json"))
+
+    requester = SyncHttpRequester(sleep=sleeps.append)
+    with httpx.Client(
+        base_url="https://example.com", transport=httpx.MockTransport(handler)
+    ) as client:
+        payload = requester.get(client, "/payload")
+
+    assert attempts == 2
+    assert sleeps == [0.5]
+    assert isinstance(payload, Mapping)
+
+
+def test_sync_http_requester_raises_for_non_retryable_http_status() -> None:
+    requester = SyncHttpRequester()
+    with httpx.Client(
+        base_url="https://example.com",
+        transport=httpx.MockTransport(lambda request: httpx.Response(404, request=request)),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="HTTP 404"):
+            requester.get(client, "/missing")
+
+
+def test_sync_http_requester_raises_after_retry_exhaustion() -> None:
+    requester = SyncHttpRequester(sleep=lambda _seconds: None)
+    with httpx.Client(
+        base_url="https://example.com",
+        transport=httpx.MockTransport(lambda request: httpx.Response(503, request=request)),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="3 attempts"):
+            requester.get(client, "/retry")
+
+
+def test_sync_http_requester_raises_after_last_transport_error() -> None:
+    requester = SyncHttpRequester(HttpRetryPolicy(max_attempts=1), sleep=lambda _seconds: None)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("timeout", request=request)
+
+    with httpx.Client(
+        base_url="https://example.com",
+        transport=httpx.MockTransport(handler),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="1 attempts"):
+            requester.get(client, "/timeout")
+
+
+def test_sync_http_requester_rejects_zero_attempt_policy() -> None:
+    requester = SyncHttpRequester(HttpRetryPolicy(max_attempts=0))
+    with httpx.Client(
+        base_url="https://example.com",
+        transport=httpx.MockTransport(lambda request: _json_response(request, {})),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="without response"):
+            requester.get(client, "/never-called")
+
+
+def test_parse_base_rate_rows_matches_recorded_payload() -> None:
+    rows = parse_base_rate_rows(
+        _load_payload("base_rate_statistic_search.json"),
+        "2024-01-15T00:00:00+00:00",
+        "abc123def4567890",
     )
 
     assert len(rows) == 3
+    assert tuple(row.base_rate for row in rows) == (
+        Decimal("3.50"),
+        Decimal("3.50"),
+        Decimal("3.50"),
+    )
     assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)
-    if fixture_name == "base_rate_statistic_search.json":
-        assert tuple(row.base_rate for row in rows) == expected_values
-    elif fixture_name == "usd_krw_statistic_search.json":
-        assert tuple(row.exchange_rate for row in rows) == expected_values
-    else:
-        assert tuple(row.yield_rate for row in rows) == expected_values
-        assert all(row.maturity_code == "3Y" for row in rows)
+
+
+def test_parse_usd_krw_rows_matches_recorded_payload() -> None:
+    rows = parse_usd_krw_rows(
+        _load_payload("usd_krw_statistic_search.json"),
+        "2024-01-15T00:00:00+00:00",
+        "abc123def4567890",
+    )
+
+    assert len(rows) == 3
+    assert tuple(row.exchange_rate for row in rows) == (
+        Decimal("1293.10"),
+        Decimal("1288.40"),
+        Decimal("1290.00"),
+    )
+    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)
+
+
+def test_parse_bond_yield_rows_matches_recorded_payload() -> None:
+    rows = parse_bond_yield_rows(
+        _load_payload("bond_yield_statistic_search.json"),
+        "2024-01-15T00:00:00+00:00",
+        "abc123def4567890",
+    )
+
+    assert len(rows) == 3
+    assert tuple(row.yield_rate for row in rows) == (
+        Decimal("3.23"),
+        Decimal("3.20"),
+        Decimal("3.18"),
+    )
+    assert all(row.maturity_code == "3Y" for row in rows)
+    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import date
+from decimal import Decimal
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
+    LiveEcosConnector,
+    parse_base_rate_rows,
+    parse_bond_yield_rows,
+    parse_usd_krw_rows,
+)
+
+
+FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "ecos"
+START_DATE = date(2024, 1, 2)
+END_DATE = date(2024, 1, 4)
+BASE_RATE_PATH = (
+    "/api/StatisticSearch/test-api-key/json/kr/1/100000/722Y001/D/20240102/20240104/0101000"
+)
+USD_KRW_PATH = (
+    "/api/StatisticSearch/test-api-key/json/kr/1/100000/731Y003/D/20240102/20240104/0000003"
+)
+
+
+def _load_payload(name: str) -> dict[str, object]:
+    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+
+
+def _json_response(request: httpx.Request, payload: dict[str, object]) -> httpx.Response:
+    return httpx.Response(status_code=200, json=payload, request=request)
+
+
+def test_live_ecos_connector_fetches_base_rate_rows_from_recorded_payload() -> None:
+    payload = _load_payload("base_rate_statistic_search.json")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == BASE_RATE_PATH
+        return _json_response(request, payload)
+
+    connector = LiveEcosConnector(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(handler),
+    )
+
+    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
+
+    assert [row.value_date for row in rows] == [START_DATE, date(2024, 1, 3), END_DATE]
+    assert [row.base_rate for row in rows] == [Decimal("3.50"), Decimal("3.50"), Decimal("3.50")]
+    assert rows[0].metadata.source_name == "ecos"
+    assert rows[0].metadata.dataset_name == "base_rate"
+    assert rows[0].metadata.api_version == "StatisticSearch"
+    assert rows[0].metadata.key_fingerprint_sha256 is not None
+    assert len(rows[0].metadata.key_fingerprint_sha256) == 16
+
+
+def test_live_ecos_connector_raises_on_ecos_auth_failure() -> None:
+    payload = {
+        "StatisticSearch": {
+            "RESULT": {"CODE": "ERROR-301", "MESSAGE": "인증키가 유효하지 않습니다."}
+        }
+    }
+
+    connector = LiveEcosConnector(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+    )
+
+    with pytest.raises(PermissionError, match="ERROR-301"):
+        connector.fetch_base_rate_series(START_DATE, END_DATE)
+
+
+def test_live_ecos_connector_retries_transient_http_failures() -> None:
+    payload = _load_payload("usd_krw_statistic_search.json")
+    attempts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            return httpx.Response(status_code=503, request=request)
+        return _json_response(request, payload)
+
+    slept: list[float] = []
+    connector = LiveEcosConnector(
+        api_key="test-api-key",
+        transport=httpx.MockTransport(handler),
+        sleep=slept.append,
+    )
+
+    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
+
+    assert attempts == 2
+    assert slept == [0.5]
+    assert [row.exchange_rate for row in rows] == [
+        Decimal("1293.10"),
+        Decimal("1288.40"),
+        Decimal("1290.00"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "parser", "expected_values"),
+    [
+        (
+            "base_rate_statistic_search.json",
+            parse_base_rate_rows,
+            (Decimal("3.50"), Decimal("3.50"), Decimal("3.50")),
+        ),
+        (
+            "usd_krw_statistic_search.json",
+            parse_usd_krw_rows,
+            (Decimal("1293.10"), Decimal("1288.40"), Decimal("1290.00")),
+        ),
+        (
+            "bond_yield_statistic_search.json",
+            parse_bond_yield_rows,
+            (Decimal("3.23"), Decimal("3.20"), Decimal("3.18")),
+        ),
+    ],
+)
+def test_ecos_recorded_payload_parsers_match_expected_values(
+    fixture_name: str,
+    parser: Callable[[dict[str, object], str, str], tuple[object, ...]],
+    expected_values: tuple[Decimal, ...],
+) -> None:
+    payload = _load_payload(fixture_name)
+
+    rows = parser(
+        payload,
+        fetched_at_utc="2024-01-15T00:00:00+00:00",
+        key_fingerprint_sha256="abc123def4567890",
+    )
+
+    assert len(rows) == 3
+    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)
+    if fixture_name == "base_rate_statistic_search.json":
+        assert tuple(row.base_rate for row in rows) == expected_values
+    elif fixture_name == "usd_krw_statistic_search.json":
+        assert tuple(row.exchange_rate for row in rows) == expected_values
+    else:
+        assert tuple(row.yield_rate for row in rows) == expected_values
+        assert all(row.maturity_code == "3Y" for row in rows)

--- a/apps/kr-kospi/tests/fixtures/ecos/base_rate_statistic_search.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/base_rate_statistic_search.json
@@ -1,0 +1,32 @@
+{
+  "StatisticSearch": {
+    "list_total_count": 3,
+    "RESULT": {
+      "CODE": "INFO-000",
+      "MESSAGE": "정상 처리되었습니다."
+    },
+    "row": [
+      {
+        "STAT_CODE": "722Y001",
+        "ITEM_CODE1": "0101000",
+        "ITEM_NAME1": "한국은행 기준금리",
+        "TIME": "20240102",
+        "DATA_VALUE": "3.50"
+      },
+      {
+        "STAT_CODE": "722Y001",
+        "ITEM_CODE1": "0101000",
+        "ITEM_NAME1": "한국은행 기준금리",
+        "TIME": "20240103",
+        "DATA_VALUE": "3.50"
+      },
+      {
+        "STAT_CODE": "722Y001",
+        "ITEM_CODE1": "0101000",
+        "ITEM_NAME1": "한국은행 기준금리",
+        "TIME": "20240104",
+        "DATA_VALUE": "3.50"
+      }
+    ]
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/ecos/bond_yield_statistic_search.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/bond_yield_statistic_search.json
@@ -1,0 +1,32 @@
+{
+  "StatisticSearch": {
+    "list_total_count": 3,
+    "RESULT": {
+      "CODE": "INFO-000",
+      "MESSAGE": "정상 처리되었습니다."
+    },
+    "row": [
+      {
+        "STAT_CODE": "817Y002",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "TIME": "20240102",
+        "DATA_VALUE": "3.23"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "TIME": "20240103",
+        "DATA_VALUE": "3.20"
+      },
+      {
+        "STAT_CODE": "817Y002",
+        "ITEM_CODE1": "010200000",
+        "ITEM_NAME1": "국고채(3년)",
+        "TIME": "20240104",
+        "DATA_VALUE": "3.18"
+      }
+    ]
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/ecos/usd_krw_statistic_search.json
+++ b/apps/kr-kospi/tests/fixtures/ecos/usd_krw_statistic_search.json
@@ -1,0 +1,32 @@
+{
+  "StatisticSearch": {
+    "list_total_count": 3,
+    "RESULT": {
+      "CODE": "INFO-000",
+      "MESSAGE": "정상 처리되었습니다."
+    },
+    "row": [
+      {
+        "STAT_CODE": "731Y003",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(종가)",
+        "TIME": "20240102",
+        "DATA_VALUE": "1293.10"
+      },
+      {
+        "STAT_CODE": "731Y003",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(종가)",
+        "TIME": "20240103",
+        "DATA_VALUE": "1288.40"
+      },
+      {
+        "STAT_CODE": "731Y003",
+        "ITEM_CODE1": "0000003",
+        "ITEM_NAME1": "원/달러(종가)",
+        "TIME": "20240104",
+        "DATA_VALUE": "1290.00"
+      }
+    ]
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "pyyaml",
   "pyarrow",
   "pandas",
+  "httpx>=0.27",
   "kpubdata>=0",
 ]
 


### PR DESCRIPTION
## Summary
- add a typed live ECOS connector and sync `httpx` retry/backoff helper for the required base rate, USD/KRW, and 3Y yield ECOS daily series
- add recorded ECOS `StatisticSearch` payload fixtures plus contract tests for success parsing, auth failure, retry handling, payload validation, and package exports
- add `httpx` to project dependencies and verify pytest, coverage, Ruff, typing-policy, and mypy gates all pass

Closes #43