### PR TITLE
Implement Issue #49 — Bronze-only KOSIS live connector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 ECOS_API_KEY=
+# Bronze-only KOSIS live ingest in v0.2 uses this key.
 KOSIS_API_KEY=

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from datetime import date, datetime
 import os
 from pathlib import Path
+import sys
 from typing import Protocol, cast
 
 import yaml
@@ -12,6 +13,7 @@ import yaml
 from kospi_decision_pipeline_core.backtest import BacktestRunner, WalkForwardSplitter
 from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario, run_kospi_snapshot
 
+from .connectors.kosis import UnsupportedDatasetError
 from .connectors.registry import LiveConnectorRegistry
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry
 from .transforms.calendar import TradingCalendar
@@ -302,16 +304,20 @@ def main(argv: list[str] | None = None) -> int:
         live_mode = _is_live_mode_requested(bool(args.live))
         if live_mode and str(args.snapshot_id).strip() == "":
             parser.error("--snapshot-id is required when live ingest is enabled")
-        return run_ingest_command(
-            source=str(args.source),
-            dataset=str(args.dataset),
-            start=str(args.start),
-            end=str(args.end),
-            output_dir=str(args.output_dir),
-            live=live_mode,
-            snapshot_id=str(args.snapshot_id) or None,
-            api_key=str(args.api_key) or None,
-        )
+        try:
+            return run_ingest_command(
+                source=str(args.source),
+                dataset=str(args.dataset),
+                start=str(args.start),
+                end=str(args.end),
+                output_dir=str(args.output_dir),
+                live=live_mode,
+                snapshot_id=str(args.snapshot_id) or None,
+                api_key=str(args.api_key) or None,
+            )
+        except UnsupportedDatasetError as error:
+            print(str(error), file=sys.stderr)
+            return 1
     if cmd == "build-features":
         layer = str(args.layer)
         if layer == "silver" and (str(args.source) == "" or str(args.dataset) == ""):

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -240,7 +240,11 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="kospi-pipeline")
     _ = parser.add_argument("--version", action="version", version="0.0.1")
     sub = parser.add_subparsers(dest="cmd", required=False)
-    ingest_parser = sub.add_parser("ingest", help="ingest Bronze data")
+    ingest_parser = sub.add_parser(
+        "ingest",
+        help="ingest Bronze data (KOSIS live support is bronze-only in v0.2)",
+        description="Ingest Bronze data. KOSIS live support is bronze-only in v0.2.",
+    )
     _ = ingest_parser.add_argument(
         "--source", choices=("krx", "ecos", "kosis", "data_portal"), required=True
     )

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -16,6 +16,10 @@ from .base import ConnectorRowBase
 from .base import SourceMetadata
 
 
+class UnsupportedDatasetError(ValueError):
+    pass
+
+
 @dataclass(frozen=True, slots=True)
 class PerPbrPercentileRow(ConnectorRowBase):
     value_date: date
@@ -112,7 +116,7 @@ class LiveKosisConnector:
 
     def fetch_per_pbr_percentiles(self, start: date, end: date) -> tuple[PerPbrPercentileRow, ...]:
         del start, end
-        raise ValueError(
+        raise UnsupportedDatasetError(
             "KOSIS live ingest does not support per_pbr_percentiles in v0.2; "
             "only bronze macro_indicators is supported"
         )

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Protocol, runtime_checkable
+import hashlib
+import os
+from typing import Callable, Mapping, Protocol, cast, final, runtime_checkable
+from urllib.parse import urlencode
 
+import httpx
+
+from ._http import HttpRequestError, HttpRetryPolicy, SyncHttpRequester
+from ._secrets import resolve_live_api_key
 from .base import ConnectorRowBase
+from .base import SourceMetadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -32,3 +40,209 @@ class KosisConnector(Protocol):
     def fetch_macro_indicators(
         self, start: date, end: date
     ) -> tuple[KosisMacroIndicatorRow, ...]: ...
+
+
+_KOSIS_API_BASE_URL = "https://kosis.kr"
+_KOSIS_API_PATH = "/openapi/Param/statisticsParameterData.do"
+_KOSIS_API_METHOD = "getList"
+_KOSIS_API_FORMAT = "json"
+_KOSIS_JSON_VD = "Y"
+_KOSIS_API_VERSION = "getList"
+_LIVE_CONNECTOR_ID = "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector"
+
+
+@dataclass(frozen=True, slots=True)
+class _KosisSeriesDefinition:
+    dataset_name: str
+    org_id: str
+    table_id: str
+    item_id: str
+    object_level_1: str
+    period_type: str
+    series_name: str
+    unit: str
+
+
+_MACRO_INDICATORS_SERIES = _KosisSeriesDefinition(
+    dataset_name="macro_indicators",
+    org_id="101",
+    table_id="DT_1J22003",
+    item_id="T",
+    object_level_1="T10",
+    period_type="M",
+    series_name="T10",
+    unit="",
+)
+
+
+@final
+class LiveKosisConnector:
+    _api_key: str
+    _key_fingerprint_sha256: str
+    _http_requester: SyncHttpRequester
+    _environment: Mapping[str, str]
+    _transport: httpx.BaseTransport | None
+    _now: Callable[[], datetime]
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        environment: Mapping[str, str] | None = None,
+        transport: httpx.BaseTransport | None = None,
+        retry_policy: HttpRetryPolicy | None = None,
+        sleep: Callable[[float], None] | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._environment = environment or os.environ
+        self._api_key = cast(
+            str,
+            resolve_live_api_key(
+                source="kosis",
+                api_key=api_key,
+                environment=self._environment,
+            ),
+        )
+        self._key_fingerprint_sha256 = hashlib.sha256(self._api_key.encode("utf-8")).hexdigest()[
+            :16
+        ]
+        self._http_requester = SyncHttpRequester(retry_policy, sleep=sleep or _default_sleep)
+        self._transport = transport
+        self._now = now or _utc_now
+
+    def fetch_per_pbr_percentiles(self, start: date, end: date) -> tuple[PerPbrPercentileRow, ...]:
+        del start, end
+        raise ValueError(
+            "KOSIS live ingest does not support per_pbr_percentiles in v0.2; "
+            "only bronze macro_indicators is supported"
+        )
+
+    def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
+        payload = self._fetch_payload(_MACRO_INDICATORS_SERIES, start, end)
+        return parse_macro_indicator_rows(
+            payload=payload,
+            dataset_name=_MACRO_INDICATORS_SERIES.dataset_name,
+            fetched_at_utc=self._fetched_at_utc(),
+            key_fingerprint_sha256=self._key_fingerprint_sha256,
+            series_name=_MACRO_INDICATORS_SERIES.series_name,
+            unit=_MACRO_INDICATORS_SERIES.unit,
+        )
+
+    def _fetch_payload(self, definition: _KosisSeriesDefinition, start: date, end: date) -> object:
+        params = {
+            "method": _KOSIS_API_METHOD,
+            "apiKey": self._api_key,
+            "format": _KOSIS_API_FORMAT,
+            "jsonVD": _KOSIS_JSON_VD,
+            "orgId": definition.org_id,
+            "tblId": definition.table_id,
+            "itmId": definition.item_id,
+            "objL1": definition.object_level_1,
+            "prdSe": definition.period_type,
+            "startPrdDe": _format_period(start, definition.period_type),
+            "endPrdDe": _format_period(end, definition.period_type),
+        }
+        path = f"{_KOSIS_API_PATH}?{urlencode(params)}"
+        try:
+            with httpx.Client(
+                base_url=_KOSIS_API_BASE_URL,
+                timeout=httpx.Timeout(self._http_requester.retry_policy.timeout_seconds),
+                transport=self._transport,
+            ) as client:
+                return self._http_requester.get(client, path)
+        except HttpRequestError as error:
+            message = str(error)
+            if message.startswith("HTTP 401") or message.startswith("HTTP 403"):
+                raise PermissionError(f"KOSIS authentication failed: {message}") from error
+            raise
+
+    def _fetched_at_utc(self) -> str:
+        return self._now().replace(microsecond=0).isoformat()
+
+
+def parse_macro_indicator_rows(
+    *,
+    payload: object,
+    dataset_name: str,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str,
+    series_name: str,
+    unit: str,
+) -> tuple[KosisMacroIndicatorRow, ...]:
+    metadata = _source_metadata(dataset_name, fetched_at_utc, key_fingerprint_sha256)
+    rows: list[KosisMacroIndicatorRow] = []
+    for raw_row in _kosis_rows(payload):
+        indicator_name = _optional_string(raw_row, "C1_OBJ_NM") or series_name
+        indicator_unit = _optional_string(raw_row, "UNIT_NM") or unit
+        rows.append(
+            KosisMacroIndicatorRow(
+                metadata=metadata,
+                value_date=_parse_kosis_period(_require_string(raw_row, "PRD_DE")),
+                indicator_name=indicator_name,
+                indicator_value=Decimal(_require_string(raw_row, "DT")),
+                unit=indicator_unit,
+            )
+        )
+    return tuple(sorted(rows, key=lambda row: row.value_date))
+
+
+def _source_metadata(
+    dataset_name: str, fetched_at_utc: str, key_fingerprint_sha256: str
+) -> SourceMetadata:
+    return SourceMetadata(
+        source_name="kosis",
+        dataset_name=dataset_name,
+        fetched_at_utc=fetched_at_utc,
+        connector_id=_LIVE_CONNECTOR_ID,
+        api_version=_KOSIS_API_VERSION,
+        key_fingerprint_sha256=key_fingerprint_sha256,
+    )
+
+
+def _kosis_rows(payload: object) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(payload, list):
+        raise ValueError("KOSIS payload must be a JSON array")
+    rows: list[Mapping[str, object]] = []
+    for raw_row in cast(list[object], payload):
+        if not isinstance(raw_row, dict):
+            raise ValueError("KOSIS row payload must be a JSON object")
+        rows.append(cast(dict[str, object], raw_row))
+    return tuple(rows)
+
+
+def _require_string(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"missing KOSIS string field: {key}")
+    return value
+
+
+def _optional_string(mapping: Mapping[str, object], key: str) -> str | None:
+    if key not in mapping:
+        return None
+    value = mapping[key]
+    if not isinstance(value, str):
+        raise ValueError(f"missing KOSIS string field: {key}")
+    return value
+
+
+def _parse_kosis_period(value: str) -> date:
+    if len(value) != 6:
+        raise ValueError(f"unsupported KOSIS period format: {value}")
+    return date.fromisoformat(f"{value[0:4]}-{value[4:6]}-01")
+
+
+def _format_period(value: date, period_type: str) -> str:
+    if period_type != "M":
+        raise ValueError(f"unsupported KOSIS period type: {period_type}")
+    return value.strftime("%Y%m")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _default_sleep(seconds: float) -> None:
+    from time import sleep
+
+    sleep(seconds)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
@@ -6,6 +6,7 @@ from typing import final
 
 from ._secrets import resolve_live_api_key
 from .ecos import LiveEcosConnector
+from .kosis import LiveKosisConnector
 from .krx import PykrxKrxConnector
 
 
@@ -29,8 +30,13 @@ class LiveConnectorRegistry:
                 environment=self._environment,
             )
         if source == "kosis":
-            raise NotImplementedError(
-                "KOSIS live connector is not implemented yet in v0.2 — see #49"
+            return LiveKosisConnector(
+                api_key=resolve_live_api_key(
+                    source=source,
+                    api_key=api_key,
+                    environment=self._environment,
+                ),
+                environment=self._environment,
             )
         raise ValueError(f"unsupported source: {source}")
 

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/ingest/bronze.py
@@ -20,6 +20,7 @@ from ..connectors import (
     KosisConnector,
     KrxConnector,
 )
+from ..connectors.kosis import UnsupportedDatasetError
 from ..connectors.base import ConnectorRowBase, SourceMetadata
 from .manifests import BronzeManifest, LiveIngestManifest, ManifestEntry, write_manifest
 
@@ -284,6 +285,8 @@ class BronzeIngestor:
 
             try:
                 rows = definition.fetch_rows(connector, current, current)
+            except UnsupportedDatasetError:
+                raise
             except Exception:
                 failed_dates.append(current)
                 current = current.fromordinal(current.toordinal() + 1)

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+import hashlib
+import os
+
+import httpx
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
+    LiveKosisConnector,
+    parse_macro_indicator_rows,
+)
+
+
+START_DATE = date(2024, 1, 1)
+END_DATE = date(2024, 2, 29)
+FETCHED_AT = datetime(2024, 3, 1, tzinfo=timezone.utc)
+
+
+def _json_response(request: httpx.Request, payload: object) -> httpx.Response:
+    return httpx.Response(status_code=200, json=payload, request=request)
+
+
+def test_parse_macro_indicator_rows_parses_verified_monthly_kosis_payload() -> None:
+    rows = parse_macro_indicator_rows(
+        payload=[
+            {
+                "PRD_DE": "202402",
+                "DT": "101.2",
+                "C1_OBJ_NM": "반도체",
+                "UNIT_NM": "2020=100",
+            },
+            {
+                "PRD_DE": "202401",
+                "DT": "100.1",
+                "C1_OBJ_NM": "반도체",
+                "UNIT_NM": "2020=100",
+            },
+        ],
+        dataset_name="macro_indicators",
+        fetched_at_utc=FETCHED_AT.isoformat(),
+        key_fingerprint_sha256="fingerprint123456",
+        series_name="반도체",
+        unit="2020=100",
+    )
+
+    assert [row.value_date for row in rows] == [date(2024, 1, 1), date(2024, 2, 1)]
+    assert [row.indicator_value for row in rows] == [Decimal("100.1"), Decimal("101.2")]
+    assert all(row.indicator_name == "반도체" for row in rows)
+    assert all(row.unit == "2020=100" for row in rows)
+    assert rows[0].metadata.source_name == "kosis"
+    assert rows[0].metadata.dataset_name == "macro_indicators"
+
+
+def test_live_kosis_connector_uses_explicit_api_key_over_environment() -> None:
+    expected_fingerprint = hashlib.sha256("explicit-kosis-key".encode("utf-8")).hexdigest()[:16]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.params["apiKey"] == "explicit-kosis-key"
+        assert request.url.params["orgId"] == "101"
+        assert request.url.params["tblId"] == "DT_1J22003"
+        assert request.url.params["itmId"] == "T"
+        assert request.url.params["objL1"] == "T10"
+        assert request.url.params["prdSe"] == "M"
+        assert request.url.params["startPrdDe"] == "202401"
+        assert request.url.params["endPrdDe"] == "202402"
+        return _json_response(
+            request,
+            [
+                {
+                    "PRD_DE": "202401",
+                    "DT": "100.1",
+                    "C1_OBJ_NM": "반도체",
+                    "UNIT_NM": "2020=100",
+                }
+            ],
+        )
+
+    connector = LiveKosisConnector(
+        api_key="explicit-kosis-key",
+        environment={"KOSIS_API_KEY": "env-kosis-key"},
+        transport=httpx.MockTransport(handler),
+        now=lambda: FETCHED_AT,
+    )
+
+    rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+    assert rows[0].metadata.key_fingerprint_sha256 == expected_fingerprint
+
+
+def test_live_kosis_connector_requires_api_key_when_no_auth_source_exists() -> None:
+    with pytest.raises(ValueError, match="KOSIS API key is required"):
+        LiveKosisConnector(environment={})
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_live_kosis_connector_maps_http_auth_failure_to_permission_error(status_code: int) -> None:
+    connector = LiveKosisConnector(
+        api_key="test-kosis-key",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=status_code, request=request)
+        ),
+    )
+
+    with pytest.raises(PermissionError, match=f"HTTP {status_code}"):
+        connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+
+def test_live_kosis_connector_rejects_unsupported_live_dataset_shape() -> None:
+    connector = LiveKosisConnector(api_key="test-kosis-key")
+
+    with pytest.raises(ValueError, match="per_pbr_percentiles"):
+        connector.fetch_per_pbr_percentiles(START_DATE, END_DATE)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "JSON array"),
+        (["bad-row"], "JSON object"),
+        ([{"DT": "1.0"}], "PRD_DE"),
+        ([{"PRD_DE": 202401, "DT": "1.0"}], "PRD_DE"),
+        ([{"PRD_DE": "202401", "DT": 1.0}], "DT"),
+        ([{"PRD_DE": "202401", "DT": "1.0", "C1_OBJ_NM": 1}], "C1_OBJ_NM"),
+        ([{"PRD_DE": "202401", "DT": "1.0", "UNIT_NM": 1}], "UNIT_NM"),
+        ([{"PRD_DE": "2024", "DT": "1.0"}], "unsupported KOSIS period format"),
+    ],
+)
+def test_parse_macro_indicator_rows_validates_payload_shape(payload: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_macro_indicator_rows(
+            payload=payload,
+            dataset_name="macro_indicators",
+            fetched_at_utc=FETCHED_AT.isoformat(),
+            key_fingerprint_sha256="fingerprint123456",
+            series_name="verified-series",
+            unit="index",
+        )
+
+
+@pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")
+def test_live_kosis_connector_smoke_fetches_verified_bronze_series() -> None:
+    connector = LiveKosisConnector(now=lambda: FETCHED_AT)
+
+    rows = connector.fetch_macro_indicators(date(2024, 1, 1), date(2024, 3, 31))
+
+    assert rows
+    assert rows[0].metadata.source_name == "kosis"
+    assert rows[0].metadata.dataset_name == "macro_indicators"
+    assert rows[0].indicator_name != ""

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -8,8 +8,12 @@ import os
 import httpx
 import pytest
 
+from kospi_decision_pipeline_app_kr_kospi.connectors._http import HttpRequestError
 from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
     LiveKosisConnector,
+    _default_sleep,
+    _format_period,
+    _utc_now,
     parse_macro_indicator_rows,
 )
 
@@ -115,6 +119,19 @@ def test_live_kosis_connector_rejects_unsupported_live_dataset_shape() -> None:
         connector.fetch_per_pbr_percentiles(START_DATE, END_DATE)
 
 
+def test_live_kosis_connector_reraises_non_auth_http_failures() -> None:
+    connector = LiveKosisConnector(
+        api_key="test-kosis-key",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=500, request=request)
+        ),
+        sleep=lambda _seconds: None,
+    )
+
+    with pytest.raises(HttpRequestError, match="HTTP request failed after 3 attempts"):
+        connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+
 @pytest.mark.parametrize(
     ("payload", "message"),
     [
@@ -138,6 +155,36 @@ def test_parse_macro_indicator_rows_validates_payload_shape(payload: object, mes
             series_name="verified-series",
             unit="index",
         )
+
+
+def test_parse_macro_indicator_rows_uses_fallback_series_name_and_unit() -> None:
+    rows = parse_macro_indicator_rows(
+        payload=[{"PRD_DE": "202401", "DT": "99.9"}],
+        dataset_name="macro_indicators",
+        fetched_at_utc=FETCHED_AT.isoformat(),
+        key_fingerprint_sha256="fingerprint123456",
+        series_name="verified-series",
+        unit="index",
+    )
+
+    assert rows[0].indicator_name == "verified-series"
+    assert rows[0].unit == "index"
+
+
+def test_kosis_period_helpers_cover_supported_and_unsupported_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert _format_period(date(2024, 2, 29), "M") == "202402"
+
+    with pytest.raises(ValueError, match="unsupported KOSIS period type"):
+        _format_period(date(2024, 2, 29), "D")
+
+    slept: list[float] = []
+    monkeypatch.setattr("time.sleep", slept.append)
+    _default_sleep(0.25)
+
+    assert slept == [0.25]
+    assert _utc_now().tzinfo == timezone.utc
 
 
 @pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")

--- a/apps/kr-kospi/tests/contract/test_live_connector_registry.py
+++ b/apps/kr-kospi/tests/contract/test_live_connector_registry.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pytest
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import LiveEcosConnector
+from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import LiveKosisConnector
 from kospi_decision_pipeline_app_kr_kospi.connectors.krx import PykrxKrxConnector
 from kospi_decision_pipeline_app_kr_kospi.connectors.registry import (
     LiveConnectorRegistry,
@@ -55,11 +58,33 @@ def test_live_connector_registry_rejects_missing_required_api_key() -> None:
         _ = resolve_live_api_key(source="ecos", api_key=None, environment={})
 
 
-def test_live_connector_registry_rejects_kosis_until_issue_49() -> None:
+def test_live_connector_registry_returns_live_kosis_connector_with_explicit_api_key() -> None:
     registry = LiveConnectorRegistry(environment={})
 
-    with pytest.raises(NotImplementedError, match="#49"):
-        registry.get_connector("kosis")
+    connector = registry.get_connector("kosis", api_key="explicit-kosis-key")
+
+    assert isinstance(connector, LiveKosisConnector)
+
+
+def test_live_connector_registry_reads_kosis_environment_key() -> None:
+    assert (
+        resolve_live_api_key(
+            source="kosis",
+            api_key=None,
+            environment={"KOSIS_API_KEY": "env-kosis-key"},
+        )
+        == "env-kosis-key"
+    )
+
+
+def test_live_connector_registry_passes_environment_to_live_kosis_connector() -> None:
+    registry = LiveConnectorRegistry(environment={"KOSIS_API_KEY": "env-kosis-key"})
+
+    connector = registry.get_connector("kosis")
+
+    environment = getattr(connector, "_environment")
+    assert isinstance(environment, Mapping)
+    assert environment["KOSIS_API_KEY"] == "env-kosis-key"
 
 
 def test_live_connector_registry_rejects_unknown_source() -> None:

--- a/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
@@ -217,6 +217,36 @@ def test_cli_main_live_ingest_writes_snapshot_partition_layout(
     ).is_file()
 
 
+def test_cli_main_fails_clearly_for_unsupported_live_kosis_dataset(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert (
+        main(
+            [
+                "ingest",
+                "--live",
+                "--source",
+                "kosis",
+                "--dataset",
+                "per_pbr_percentiles",
+                "--from",
+                "2024-01-01",
+                "--to",
+                "2024-01-31",
+                "--snapshot-id",
+                "snapshot-20240115T000000Z",
+                "--api-key",
+                "cli-key",
+                "--out",
+                str(tmp_path),
+            ]
+        )
+        == 1
+    )
+
+    assert "per_pbr_percentiles" in capsys.readouterr().err
+
+
 @pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")
 def test_run_ingest_command_live_kosis_writes_verified_bronze_partition(tmp_path: Path) -> None:
     assert (

--- a/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from decimal import Decimal
+import os
 from pathlib import Path
+from typing import Protocol, cast
 
+import pyarrow.parquet as pq
 import pytest
 
 from kospi_decision_pipeline_app_kr_kospi.cli import main, run_ingest_command
@@ -14,6 +17,18 @@ from kospi_decision_pipeline_app_kr_kospi.ingest.manifests import LiveIngestMani
 
 
 RUN_TIMESTAMP = datetime(2024, 1, 15, 0, 0, tzinfo=timezone.utc)
+
+
+class _ArrowTable(Protocol):
+    @property
+    def num_rows(self) -> int: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
 
 
 @dataclass(slots=True)
@@ -200,3 +215,28 @@ def test_cli_main_live_ingest_writes_snapshot_partition_layout(
     assert (
         tmp_path / "snapshot-20240115T000000Z" / "ecos" / "base_rate" / "2024-01-03.parquet"
     ).is_file()
+
+
+@pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")
+def test_run_ingest_command_live_kosis_writes_verified_bronze_partition(tmp_path: Path) -> None:
+    assert (
+        run_ingest_command(
+            source="kosis",
+            dataset="macro_indicators",
+            start="2024-01-01",
+            end="2024-03-31",
+            output_dir=str(tmp_path),
+            live=True,
+            snapshot_id="snapshot-20240301T000000Z",
+            connector_registry=None,
+            deterministic_run_timestamp=RUN_TIMESTAMP,
+        )
+        == 0
+    )
+
+    dataset_root = tmp_path / "snapshot-20240301T000000Z" / "kosis" / "macro_indicators"
+    parquet_paths = sorted(dataset_root.glob("*.parquet"))
+
+    assert parquet_paths
+    first_table = READ_TABLE(parquet_paths[0])
+    assert first_table.num_rows > 0

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -728,6 +728,15 @@ def test_cli_main_prints_help_without_command(capsys: pytest.CaptureFixture[str]
     assert "build-features" in capsys.readouterr().out
 
 
+def test_cli_ingest_help_documents_bronze_only_kosis_live_support(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit, match="0"):
+        main(["ingest", "--help"])
+
+    assert "bronze-only" in capsys.readouterr().out.lower()
+
+
 def test_cli_main_prints_version_and_exits(capsys: pytest.CaptureFixture[str]) -> None:
     try:
         _ = main(["--version"])


### PR DESCRIPTION
## Summary
- add a bronze-only live KOSIS connector for the verified `DT_1J22003 / T10 / T / M` series with `--api-key`/`KOSIS_API_KEY` auth resolution and clear auth failures
- wire live KOSIS into the registry/CLI while rejecting unsupported live dataset shapes such as `per_pbr_percentiles`
- add metadata parsing, registry, CLI, unsupported-shape, auth, and env-gated real bronze smoke coverage with full local verification

Closes #49