### PR TITLE
Implement Issue #48 — Walk-forward backtest CLI with hit_rate reporting

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/backtest/__init__.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/backtest/__init__.py
@@ -1,0 +1,3 @@
+from .runner import BacktestRow, BacktestSummary, run_backtest
+
+__all__ = ["BacktestRow", "BacktestSummary", "run_backtest"]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/backtest/runner.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/backtest/runner.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from math import log
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from kospi_decision_pipeline_core.calendar import TradingCalendar
+from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario
+from kospi_decision_pipeline_core.schemas import DecisionResult, GroundTruthLabel, ModelLabel
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestRow:
+    decision_date: date
+    next_trading_date: date
+    decision: ModelLabel
+    truth_label: GroundTruthLabel
+    hit: bool | None
+    aggregate_score: float
+    snapshot_id: str
+    config_signature: str
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "decision_date": self.decision_date.isoformat(),
+            "next_trading_date": self.next_trading_date.isoformat(),
+            "decision": self.decision,
+            "truth_label": self.truth_label,
+            "hit": self.hit,
+            "aggregate_score": self.aggregate_score,
+            "snapshot_id": self.snapshot_id,
+            "config_signature": self.config_signature,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BacktestSummary:
+    evaluated_count: int
+    hit_count: int
+    skip_count: int
+    hit_rate: float | None
+    skip_rate: float | None
+    hit_rate_denominator: str = "evaluated_count - skip_count (skip excluded)"
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "evaluated_count": self.evaluated_count,
+            "hit_count": self.hit_count,
+            "skip_count": self.skip_count,
+            "hit_rate": self.hit_rate,
+            "skip_rate": self.skip_rate,
+            "hit_rate_denominator": self.hit_rate_denominator,
+        }
+
+
+def run_backtest(
+    *,
+    features_path: Path,
+    snapshot_root: Path,
+    output_dir: Path,
+    scenario_path: Path,
+    agents_path: Path | None,
+    scenario_invoker: Callable[[Path | str, date, Path | None, Path | None], DecisionResult]
+    | None = None,
+) -> BacktestSummary:
+    feature_rows = _load_feature_rows(features_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runtime_output_dir = output_dir / "decisions"
+    scenario_override_path = _write_runtime_scenario_override(
+        scenario_path=scenario_path,
+        features_path=features_path,
+        output_dir=runtime_output_dir,
+        agents_path=agents_path,
+    )
+    backtest_rows: list[BacktestRow] = []
+    calendar = TradingCalendar()
+    resolved_scenario_invoker = run_kospi_scenario if scenario_invoker is None else scenario_invoker
+    with TemporaryDirectory() as temporary_dir:
+        temporary_root = Path(temporary_dir)
+        for index, feature_row in enumerate(feature_rows):
+            decision_date = _require_date(feature_row, "as_of_date")
+            next_trading_date = calendar.next_trading_day(decision_date)
+            truth_label = _truth_label(snapshot_root=snapshot_root, decision_date=decision_date)
+            if truth_label is None:
+                continue
+            sliced_features_path = temporary_root / "runtime_features.parquet"
+            _write_feature_slice(sliced_features_path, feature_rows[: index + 1])
+            result = resolved_scenario_invoker(
+                scenario_override_path,
+                next_trading_date,
+                sliced_features_path,
+                runtime_output_dir,
+            )
+            backtest_rows.append(
+                BacktestRow(
+                    decision_date=decision_date,
+                    next_trading_date=next_trading_date,
+                    decision=result.label,
+                    truth_label=truth_label,
+                    hit=None if result.label == "skip" else result.label == truth_label,
+                    aggregate_score=result.aggregate_score,
+                    snapshot_id=result.snapshot_id,
+                    config_signature=result.config_signature,
+                )
+            )
+    if len(backtest_rows) == 0:
+        raise ValueError("backtest produced no evaluable rows")
+    summary = _summarize(backtest_rows)
+    _ = (output_dir / "rows.jsonl").write_text(
+        "".join(
+            json.dumps(row.to_mapping(), ensure_ascii=False, separators=(",", ":")) + "\n"
+            for row in backtest_rows
+        ),
+        encoding="utf-8",
+    )
+    _ = (output_dir / "summary.json").write_text(
+        json.dumps(summary.to_mapping(), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def _load_feature_rows(features_path: Path) -> tuple[dict[str, object], ...]:
+    raw_rows = READ_TABLE(features_path).to_pylist()
+    if len(raw_rows) == 0:
+        raise ValueError("features parquet must not be empty")
+    rows = tuple(
+        sorted((dict(row) for row in raw_rows), key=lambda row: _require_date(row, "as_of_date"))
+    )
+    for index, row in enumerate(rows[1:], start=1):
+        if _require_date(rows[index - 1], "as_of_date") == _require_date(row, "as_of_date"):
+            raise ValueError("expected unique as_of_date values in gold features")
+    return rows
+
+
+def _write_runtime_scenario_override(
+    *,
+    scenario_path: Path,
+    features_path: Path,
+    output_dir: Path,
+    agents_path: Path | None,
+) -> Path:
+    loaded = yaml.safe_load(scenario_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, Mapping):
+        raise ValueError("scenario payload must be a mapping")
+    scenario_payload = dict(cast(Mapping[str, object], loaded))
+    runtime = dict(_require_mapping(scenario_payload, "runtime"))
+    runtime["features_path"] = str(features_path)
+    runtime["output_dir"] = str(output_dir)
+    if agents_path is not None:
+        runtime["agents_config_path"] = str(agents_path)
+    scenario_payload["runtime"] = runtime
+    override_path = output_dir / "scenario.backtest.runtime.yaml"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    _ = override_path.write_text(
+        yaml.safe_dump(scenario_payload, sort_keys=False), encoding="utf-8"
+    )
+    return override_path
+
+
+def _write_feature_slice(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    factory = cast(_ArrowTableFactory, pa.Table)
+    table = factory.from_pylist([dict(row) for row in rows])
+    WRITE_TABLE(table, path, compression="snappy")
+
+
+def _truth_label(snapshot_root: Path, *, decision_date: date) -> GroundTruthLabel | None:
+    calendar = TradingCalendar()
+    next_trading_date = calendar.next_trading_day(decision_date)
+    current_close = _load_krx_close(snapshot_root, decision_date)
+    if current_close is None:
+        raise ValueError(f"missing KRX close for {decision_date.isoformat()}")
+    next_close = _load_krx_close(snapshot_root, next_trading_date)
+    if next_close is None:
+        return None
+    if current_close <= 0.0 or next_close <= 0.0:
+        raise ValueError("KRX closes must be positive")
+    target_next_day_log_return = log(next_close / current_close)
+    if target_next_day_log_return >= 0.001:
+        return "up"
+    if target_next_day_log_return <= -0.001:
+        return "down"
+    return "flat"
+
+
+def _load_krx_close(snapshot_root: Path, trading_date: date) -> float | None:
+    path = snapshot_root / "krx" / "kospi_index" / f"{trading_date.isoformat()}.parquet"
+    if not path.is_file():
+        return None
+    rows = READ_TABLE(path).to_pylist()
+    if len(rows) != 1:
+        raise ValueError(f"expected exactly one KRX row for {trading_date.isoformat()}")
+    return _require_float(rows[0], "close")
+
+
+def _summarize(rows: Sequence[BacktestRow]) -> BacktestSummary:
+    evaluated_count = len(rows)
+    skip_count = sum(1 for row in rows if row.decision == "skip")
+    hit_count = sum(1 for row in rows if row.hit is True)
+    hit_denominator = evaluated_count - skip_count
+    return BacktestSummary(
+        evaluated_count=evaluated_count,
+        hit_count=hit_count,
+        skip_count=skip_count,
+        hit_rate=None if hit_denominator == 0 else hit_count / hit_denominator,
+        skip_rate=None if evaluated_count == 0 else skip_count / evaluated_count,
+    )
+
+
+def _require_mapping(payload: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{key} must be a mapping")
+    return cast(Mapping[str, object], value)
+
+
+def _require_date(row: Mapping[str, object], key: str) -> date:
+    value = row.get(key)
+    if not isinstance(value, date):
+        raise ValueError(f"{key} must be a date")
+    return value
+
+
+def _require_float(row: Mapping[str, object], key: str) -> float:
+    value = row.get(key)
+    if (
+        value is None
+        or isinstance(value, bool)
+        or not isinstance(value, int | float | Decimal | str)
+    ):
+        raise ValueError(f"{key} must be a numeric scalar")
+    return float(value)
+
+
+__all__ = ["BacktestRow", "BacktestSummary", "run_backtest"]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -13,6 +13,7 @@ import yaml
 from kospi_decision_pipeline_core.backtest import BacktestRunner, WalkForwardSplitter
 from kospi_decision_pipeline_core.runtime.service import run_kospi_scenario, run_kospi_snapshot
 
+from .backtest import run_backtest
 from .connectors.kosis import UnsupportedDatasetError
 from .connectors.registry import LiveConnectorRegistry
 from .ingest.bronze import BronzeIngestor, FixtureConnectorRegistry
@@ -186,6 +187,31 @@ def run_backtest_command(
     return 0
 
 
+def backtest_command(
+    *,
+    features: str,
+    snapshot_root: str,
+    output_dir: str,
+    scenario: str,
+    agents: str,
+) -> int:
+    summary = run_backtest(
+        features_path=Path(features),
+        snapshot_root=Path(snapshot_root),
+        output_dir=Path(output_dir),
+        scenario_path=Path(scenario),
+        agents_path=Path(agents) if agents != "" else None,
+    )
+    print(
+        "backtest complete: "
+        f"evaluated_count={summary.evaluated_count} "
+        f"hit_rate={summary.hit_rate} "
+        f"skip_rate={summary.skip_rate} "
+        "(hit_rate excludes skip days from the denominator)"
+    )
+    return 0
+
+
 def _load_backtest_splitter(folds_config: str) -> WalkForwardSplitter:
     if folds_config == "":
         return WalkForwardSplitter()
@@ -235,7 +261,9 @@ class _CliArgs(argparse.Namespace):
     folds_config: str = ""
     live: bool = False
     snapshot_id: str = ""
+    snapshot_root: str = ""
     api_key: str = ""
+    agents: str = ""
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -293,8 +321,24 @@ def main(argv: list[str] | None = None) -> int:
     )
     _ = run_parser.add_argument("--features", default="")
     _ = run_parser.add_argument("--out", dest="output_dir", default="")
-    for name in ("backtest", "report"):
-        _ = sub.add_parser(name, help=f"{name} (not yet implemented)")
+    backtest_parser = sub.add_parser(
+        "backtest",
+        help="run chronological backtest; hit_rate excludes skip days",
+        description=(
+            "Run a chronological backtest over Gold features; "
+            "summary hit_rate excludes skip days from the denominator."
+        ),
+        epilog="hit_rate excludes skip days from the denominator.",
+    )
+    _ = backtest_parser.add_argument("--features", required=True)
+    _ = backtest_parser.add_argument("--snapshot-root", required=True)
+    _ = backtest_parser.add_argument("--out", dest="output_dir", required=True)
+    _ = backtest_parser.add_argument(
+        "--scenario",
+        default="apps/kr-kospi/config/scenario.kospi.next_day.yaml",
+    )
+    _ = backtest_parser.add_argument("--agents", default="")
+    _ = sub.add_parser("report", help="report (not yet implemented)")
     args = parser.parse_args(argv, namespace=_CliArgs())
     cmd = args.cmd
     if cmd is None:
@@ -354,6 +398,14 @@ def main(argv: list[str] | None = None) -> int:
             scenario=str(args.scenario),
             output_dir=str(args.output_dir),
             folds_config=str(args.folds_config),
+        )
+    if cmd == "backtest":
+        return backtest_command(
+            features=str(args.features),
+            snapshot_root=str(args.snapshot_root),
+            output_dir=str(args.output_dir),
+            scenario=str(args.scenario),
+            agents=str(args.agents),
         )
     print(f"{cmd}: not yet implemented")
     return 0

--- a/apps/kr-kospi/tests/contract/test_cli_stub.py
+++ b/apps/kr-kospi/tests/contract/test_cli_stub.py
@@ -31,9 +31,19 @@ def test_cli_version() -> None:
     assert result.stdout.strip() == "0.0.1"
 
 
-def test_cli_help_lists_stubbed_subcommands() -> None:
+def test_cli_help_lists_supported_subcommands() -> None:
     result = run_cli("--help")
 
     assert result.returncode == 0
     for name in ("ingest", "build-features", "run", "backtest", "report"):
         assert name in result.stdout
+
+
+def test_backtest_help_is_not_a_stub() -> None:
+    result = run_cli("backtest", "--help")
+
+    assert result.returncode == 0
+    assert "not yet implemented" not in result.stdout
+    assert "--features" in result.stdout
+    assert "--snapshot-root" in result.stdout
+    assert "hit_rate excludes skip days" in result.stdout

--- a/apps/kr-kospi/tests/integration/test_backtest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_backtest_cli.py
@@ -8,8 +8,6 @@ from typing import Protocol, cast
 
 import pyarrow as pa
 import pyarrow.parquet as pq
-import yaml
-
 from kospi_decision_pipeline_app_kr_kospi.cli import main
 from kospi_decision_pipeline_app_kr_kospi.transforms.calendar import TradingCalendar
 from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
@@ -178,6 +176,11 @@ def test_backtest_cli_is_deterministic_on_fixed_gold_window(tmp_path: Path) -> N
     silver_root = tmp_path / "silver"
     snapshot_root = tmp_path / "snapshot-root"
     _build_complete_history(silver_root, snapshot_root, days)
+    _write_bronze_close(
+        snapshot_root,
+        TradingCalendar().next_trading_day(days[-1]),
+        Decimal(100 + len(days)),
+    )
     features_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
         silver_root=silver_root,
         start=days[-3],

--- a/apps/kr-kospi/tests/integration/test_backtest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_backtest_cli.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+from decimal import Decimal
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import yaml
+
+from kospi_decision_pipeline_app_kr_kospi.cli import main
+from kospi_decision_pipeline_app_kr_kospi.transforms.calendar import TradingCalendar
+from kospi_decision_pipeline_app_kr_kospi.transforms.gold_features import GoldFeatureBuilder
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCENARIO_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "scenario.kospi.next_day.yaml"
+AGENTS_PATH = REPO_ROOT / "apps" / "kr-kospi" / "config" / "agents.yaml"
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_parquet(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _write_silver_partition(
+    root: Path,
+    dataset_id: str,
+    partition_date: date,
+    row: dict[str, object],
+) -> None:
+    _write_parquet(root / dataset_id / f"{partition_date.isoformat()}.parquet", [row])
+
+
+def _write_bronze_close(snapshot_root: Path, trading_date: date, close: Decimal) -> None:
+    _write_parquet(
+        snapshot_root / "krx" / "kospi_index" / f"{trading_date.isoformat()}.parquet",
+        [
+            {
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "trade_date": trading_date,
+                "open": close - Decimal("1"),
+                "high": close + Decimal("5"),
+                "low": close - Decimal("5"),
+                "close": close,
+                "volume_shares": 1_000_000,
+                "turnover_krw": Decimal("1000"),
+            }
+        ],
+    )
+
+
+def _trading_days(count: int) -> list[date]:
+    calendar = TradingCalendar()
+    current = date(2024, 1, 2)
+    days: list[date] = []
+    while len(days) < count:
+        if calendar.is_trading_day(current):
+            days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def _build_complete_history(silver_root: Path, snapshot_root: Path, days: list[date]) -> None:
+    for index, as_of_date in enumerate(days):
+        close = Decimal(100 + index)
+        _write_bronze_close(snapshot_root, as_of_date, close)
+        _write_silver_partition(
+            silver_root,
+            "kospi_index",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "open": close - Decimal("1"),
+                "high": close + Decimal("5"),
+                "low": close - Decimal("5"),
+                "close": close,
+                "volume_shares": 1_000_000 + index,
+                "turnover_krw": Decimal(1000 + (10 * index)),
+            },
+        )
+        _write_silver_partition(
+            silver_root,
+            "investor_flow",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "investor_flow",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "foreign_net_buy_krw": Decimal(100 + (2 * index)),
+                "institution_net_buy_krw": Decimal(200 + (3 * index)),
+                "individual_net_buy_krw": Decimal(-(300 + (5 * index))),
+            },
+        )
+        _write_silver_partition(
+            silver_root,
+            "base_rate",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "base_rate",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "base_rate_pct": Decimal("3.00"),
+            },
+        )
+        _write_silver_partition(
+            silver_root,
+            "usd_krw",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "usd_krw",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "usd_krw_rate": Decimal(1200 + index),
+            },
+        )
+        _write_silver_partition(
+            silver_root,
+            "bond_yield",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "ecos",
+                "source_series_id": "bond_yield",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "maturity_code": "3Y",
+                "yield_rate_pct": Decimal("2.00"),
+            },
+        )
+        _write_silver_partition(
+            silver_root,
+            "market_valuation",
+            as_of_date,
+            {
+                "as_of_date": as_of_date,
+                "source_name": "krx",
+                "source_series_id": "market_valuation",
+                "fetched_at": "2024-01-10T09:00:00+00:00",
+                "market_cap_krw": Decimal(2_000_000 + (1000 * index)),
+                "trailing_per": Decimal("10.00"),
+                "trailing_pbr": Decimal("1.00"),
+            },
+        )
+
+
+def test_backtest_cli_is_deterministic_on_fixed_gold_window(tmp_path: Path) -> None:
+    days = _trading_days(275)
+    silver_root = tmp_path / "silver"
+    snapshot_root = tmp_path / "snapshot-root"
+    _build_complete_history(silver_root, snapshot_root, days)
+    features_path = GoldFeatureBuilder(output_root=tmp_path / "gold").build(
+        silver_root=silver_root,
+        start=days[-3],
+        end=days[-1],
+    )
+    first_output = tmp_path / "backtest-first"
+    second_output = tmp_path / "backtest-second"
+
+    assert (
+        main(
+            [
+                "backtest",
+                "--features",
+                str(features_path),
+                "--snapshot-root",
+                str(snapshot_root),
+                "--out",
+                str(first_output),
+                "--scenario",
+                str(SCENARIO_PATH),
+                "--agents",
+                str(AGENTS_PATH),
+            ]
+        )
+        == 0
+    )
+    assert (
+        main(
+            [
+                "backtest",
+                "--features",
+                str(features_path),
+                "--snapshot-root",
+                str(snapshot_root),
+                "--out",
+                str(second_output),
+                "--scenario",
+                str(SCENARIO_PATH),
+                "--agents",
+                str(AGENTS_PATH),
+            ]
+        )
+        == 0
+    )
+
+    assert (first_output / "rows.jsonl").read_bytes() == (second_output / "rows.jsonl").read_bytes()
+    assert (first_output / "summary.json").read_bytes() == (
+        second_output / "summary.json"
+    ).read_bytes()
+
+    rows_payload = [
+        json.loads(line)
+        for line in (first_output / "rows.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [(row["decision"], row["truth_label"], row["hit"]) for row in rows_payload] == [
+        ("up", "up", True),
+        ("up", "up", True),
+        ("up", "up", True),
+    ]
+    assert json.loads((first_output / "summary.json").read_text(encoding="utf-8")) == {
+        "evaluated_count": 3,
+        "hit_count": 3,
+        "skip_count": 0,
+        "hit_rate": 1.0,
+        "skip_rate": 0.0,
+        "hit_rate_denominator": "evaluated_count - skip_count (skip excluded)",
+    }

--- a/apps/kr-kospi/tests/unit/test_backtest_cli.py
+++ b/apps/kr-kospi/tests/unit/test_backtest_cli.py
@@ -10,7 +10,7 @@ import pyarrow.parquet as pq
 import pytest
 import yaml
 
-from kospi_decision_pipeline_core.schemas import DecisionResult
+from kospi_decision_pipeline_core.schemas import DecisionResult, ModelLabel
 
 
 class _ArrowTable(Protocol):
@@ -21,10 +21,64 @@ class _ArrowTableFactory(Protocol):
     def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
 
 
+class _ReadTable(Protocol):
+    def __call__(self, source: Path) -> _ArrowTable: ...
+
+
 class _WriteTable(Protocol):
     def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
 
 
+class _ScenarioInvoker(Protocol):
+    def __call__(
+        self,
+        scenario_path: Path | str,
+        decision_date: date,
+        features_path: Path | None,
+        output_dir: Path | None,
+    ) -> DecisionResult: ...
+
+
+class _LoadFeatureRows(Protocol):
+    def __call__(self, features_path: Path) -> tuple[dict[str, object], ...]: ...
+
+
+class _WriteRuntimeScenarioOverride(Protocol):
+    def __call__(
+        self,
+        *,
+        scenario_path: Path,
+        features_path: Path,
+        output_dir: Path,
+        agents_path: Path | None,
+    ) -> Path: ...
+
+
+class _TruthLabel(Protocol):
+    def __call__(self, snapshot_root: Path, *, decision_date: date) -> str | None: ...
+
+
+class _LoadKrxClose(Protocol):
+    def __call__(self, snapshot_root: Path, trading_date: date) -> float | None: ...
+
+
+class _SummaryLike(Protocol):
+    def to_mapping(self) -> dict[str, object]: ...
+
+
+class _Summarize(Protocol):
+    def __call__(self, rows: list[object]) -> _SummaryLike: ...
+
+
+class _RequireDate(Protocol):
+    def __call__(self, row: dict[str, object], key: str) -> date: ...
+
+
+class _RequireFloatField(Protocol):
+    def __call__(self, row: dict[str, object], key: str) -> float: ...
+
+
+READ_TABLE = cast(_ReadTable, getattr(pq, "read_table"))
 WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
 
 
@@ -58,6 +112,18 @@ def _write_krx_close(snapshot_root: Path, trading_date: date, close: float) -> N
     )
 
 
+def _require_model_label(value: object) -> ModelLabel:
+    if value not in {"up", "down", "skip"}:
+        raise ValueError(f"unexpected model label: {value}")
+    return cast(ModelLabel, value)
+
+
+def _require_float(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise ValueError(f"unexpected numeric value: {value}")
+    return float(value)
+
+
 def _features_rows() -> list[dict[str, object]]:
     return [
         {"as_of_date": date(2025, 2, 3), "expected_decision": "up", "marker": 1},
@@ -82,7 +148,7 @@ def _scenario_payload(
     }
 
 
-def _decision_invoker_factory() -> object:
+def _decision_invoker_factory() -> _ScenarioInvoker:
     def fake_scenario_invoker(
         scenario_path: Path | str,
         decision_date: date,
@@ -92,7 +158,7 @@ def _decision_invoker_factory() -> object:
         assert output_dir is not None
         assert Path(scenario_path).is_file()
         assert features_path is not None
-        rows = cast(list[dict[str, object]], pq.read_table(features_path).to_pylist())
+        rows = READ_TABLE(features_path).to_pylist()
         assert rows
         current_row = rows[-1]
         current_as_of_date = cast(date, current_row["as_of_date"])
@@ -104,8 +170,8 @@ def _decision_invoker_factory() -> object:
         ][: len(rows)]
         return DecisionResult(
             decision_date=decision_date,
-            label=cast(str, current_row["expected_decision"]),
-            aggregate_score=float(current_row["marker"]),
+            label=_require_model_label(current_row["expected_decision"]),
+            aggregate_score=_require_float(current_row["marker"]),
             threshold_up=0.25,
             threshold_down=-0.25,
             votes=(),
@@ -249,3 +315,151 @@ def test_backtest_command_is_identical_when_future_rows_are_removed(
     assert (full_output_dir / "rows.jsonl").read_text(encoding="utf-8") == (
         prefix_output_dir / "rows.jsonl"
     ).read_text(encoding="utf-8")
+
+
+def test_backtest_runner_rejects_empty_features_and_duplicate_dates(tmp_path: Path) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.backtest import runner as runner_module
+
+    load_feature_rows = cast(_LoadFeatureRows, getattr(runner_module, "_load_feature_rows"))
+    empty_path = tmp_path / "empty.parquet"
+    duplicate_path = tmp_path / "duplicate.parquet"
+    _write_parquet(empty_path, [])
+    _write_parquet(
+        duplicate_path,
+        [
+            {"as_of_date": date(2025, 2, 3)},
+            {"as_of_date": date(2025, 2, 3)},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="features parquet must not be empty"):
+        load_feature_rows(empty_path)
+    with pytest.raises(ValueError, match="expected unique as_of_date values in gold features"):
+        load_feature_rows(duplicate_path)
+
+
+def test_backtest_runner_validates_scenario_runtime_shape_and_optional_agents(
+    tmp_path: Path,
+) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.backtest import runner as runner_module
+
+    write_runtime_scenario_override = cast(
+        _WriteRuntimeScenarioOverride,
+        getattr(runner_module, "_write_runtime_scenario_override"),
+    )
+    scenario_path = tmp_path / "scenario.yaml"
+    features_path = tmp_path / "gold.parquet"
+    output_dir = tmp_path / "out"
+    _ = scenario_path.write_text("[]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="scenario payload must be a mapping"):
+        write_runtime_scenario_override(
+            scenario_path=scenario_path,
+            features_path=features_path,
+            output_dir=output_dir,
+            agents_path=None,
+        )
+
+    _write_yaml(scenario_path, {"scenario_id": "broken"})
+    _write_parquet(features_path, [{"as_of_date": date(2025, 2, 3)}])
+
+    with pytest.raises(ValueError, match="runtime must be a mapping"):
+        write_runtime_scenario_override(
+            scenario_path=scenario_path,
+            features_path=features_path,
+            output_dir=output_dir,
+            agents_path=None,
+        )
+
+    _write_yaml(
+        scenario_path,
+        {
+            "scenario_id": "kospi.next_day",
+            "runtime": {
+                "agents_config_path": "agents.yaml",
+                "features_path": "old.parquet",
+                "output_dir": "old-out",
+            },
+        },
+    )
+    override_path = write_runtime_scenario_override(
+        scenario_path=scenario_path,
+        features_path=features_path,
+        output_dir=output_dir,
+        agents_path=None,
+    )
+    payload = yaml.safe_load(override_path.read_text(encoding="utf-8"))
+    assert payload["runtime"]["features_path"] == str(features_path)
+    assert payload["runtime"]["output_dir"] == str(output_dir)
+    assert payload["runtime"]["agents_config_path"] == "agents.yaml"
+
+
+def test_backtest_runner_validates_bronze_truth_inputs(tmp_path: Path) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.backtest import runner as runner_module
+
+    truth_label = cast(_TruthLabel, getattr(runner_module, "_truth_label"))
+    load_krx_close = cast(_LoadKrxClose, getattr(runner_module, "_load_krx_close"))
+    snapshot_root = tmp_path / "snapshot-root"
+    _write_krx_close(snapshot_root, date(2025, 2, 4), 100.0)
+
+    with pytest.raises(ValueError, match="missing KRX close for 2025-02-03"):
+        truth_label(snapshot_root, decision_date=date(2025, 2, 3))
+
+    _write_krx_close(snapshot_root, date(2025, 2, 3), 0.0)
+    with pytest.raises(ValueError, match="KRX closes must be positive"):
+        truth_label(snapshot_root, decision_date=date(2025, 2, 3))
+
+    multirow_path = snapshot_root / "krx" / "kospi_index" / "2025-02-05.parquet"
+    _write_parquet(
+        multirow_path,
+        [
+            {"trade_date": date(2025, 2, 5), "close": 100.0},
+            {"trade_date": date(2025, 2, 5), "close": 101.0},
+        ],
+    )
+    with pytest.raises(ValueError, match="expected exactly one KRX row for 2025-02-05"):
+        load_krx_close(snapshot_root, date(2025, 2, 5))
+
+
+def test_backtest_runner_rejects_non_evaluable_run_and_invalid_scalars(tmp_path: Path) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.backtest import runner as runner_module
+
+    summarize = cast(_Summarize, getattr(runner_module, "_summarize"))
+    require_date = cast(_RequireDate, getattr(runner_module, "_require_date"))
+    require_float_field = cast(_RequireFloatField, getattr(runner_module, "_require_float"))
+    features_path = tmp_path / "gold" / "decision_features.parquet"
+    snapshot_root = tmp_path / "snapshot-root"
+    output_dir = tmp_path / "backtest"
+    scenario_path = tmp_path / "scenario.yaml"
+    agents_path = tmp_path / "agents.yaml"
+    _write_parquet(
+        features_path, [{"as_of_date": date(2025, 2, 3), "expected_decision": "skip", "marker": 1}]
+    )
+    _write_krx_close(snapshot_root, date(2025, 2, 3), 100.0)
+    _write_yaml(
+        agents_path, {"weights": {}, "thresholds": {"up": 0.25, "down": -0.25}, "agents": {}}
+    )
+    _write_yaml(scenario_path, _scenario_payload(agents_path, features_path, output_dir))
+
+    with pytest.raises(ValueError, match="backtest produced no evaluable rows"):
+        runner_module.run_backtest(
+            features_path=features_path,
+            snapshot_root=snapshot_root,
+            output_dir=output_dir,
+            scenario_path=scenario_path,
+            agents_path=agents_path,
+            scenario_invoker=_decision_invoker_factory(),
+        )
+
+    assert summarize([]).to_mapping() == {
+        "evaluated_count": 0,
+        "hit_count": 0,
+        "skip_count": 0,
+        "hit_rate": None,
+        "skip_rate": None,
+        "hit_rate_denominator": "evaluated_count - skip_count (skip excluded)",
+    }
+    with pytest.raises(ValueError, match="as_of_date must be a date"):
+        require_date({"as_of_date": "2025-02-03"}, "as_of_date")
+    with pytest.raises(ValueError, match="close must be a numeric scalar"):
+        require_float_field({"close": object()}, "close")

--- a/apps/kr-kospi/tests/unit/test_backtest_cli.py
+++ b/apps/kr-kospi/tests/unit/test_backtest_cli.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from typing import Protocol, cast
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import yaml
+
+from kospi_decision_pipeline_core.schemas import DecisionResult
+
+
+class _ArrowTable(Protocol):
+    def to_pylist(self) -> list[dict[str, object]]: ...
+
+
+class _ArrowTableFactory(Protocol):
+    def from_pylist(self, mapping: list[dict[str, object]]) -> _ArrowTable: ...
+
+
+class _WriteTable(Protocol):
+    def __call__(self, table: _ArrowTable, where: Path, *, compression: str) -> None: ...
+
+
+WRITE_TABLE = cast(_WriteTable, getattr(pq, "write_table"))
+
+
+def _table_from_pylist(rows: list[dict[str, object]]) -> _ArrowTable:
+    factory = cast(_ArrowTableFactory, pa.Table)
+    return factory.from_pylist(rows)
+
+
+def _write_parquet(path: Path, rows: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    WRITE_TABLE(_table_from_pylist(rows), path, compression="snappy")
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    _ = path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_krx_close(snapshot_root: Path, trading_date: date, close: float) -> None:
+    _write_parquet(
+        snapshot_root / "krx" / "kospi_index" / f"{trading_date.isoformat()}.parquet",
+        [
+            {
+                "source_name": "krx",
+                "source_series_id": "kospi_index",
+                "fetched_at": "2025-02-10T09:00:00+00:00",
+                "trade_date": trading_date,
+                "close": close,
+            }
+        ],
+    )
+
+
+def _features_rows() -> list[dict[str, object]]:
+    return [
+        {"as_of_date": date(2025, 2, 3), "expected_decision": "up", "marker": 1},
+        {"as_of_date": date(2025, 2, 4), "expected_decision": "skip", "marker": 2},
+        {"as_of_date": date(2025, 2, 5), "expected_decision": "down", "marker": 3},
+        {"as_of_date": date(2025, 2, 6), "expected_decision": "up", "marker": 4},
+    ]
+
+
+def _scenario_payload(
+    agents_path: Path, features_path: Path, output_dir: Path
+) -> dict[str, object]:
+    return {
+        "scenario_id": "kospi.next_day",
+        "horizon": "next_day",
+        "agents": ["technical", "domestic_macro", "flow", "valuation", "volatility", "decision"],
+        "runtime": {
+            "agents_config_path": str(agents_path),
+            "features_path": str(features_path),
+            "output_dir": str(output_dir),
+        },
+    }
+
+
+def _decision_invoker_factory() -> object:
+    def fake_scenario_invoker(
+        scenario_path: Path | str,
+        decision_date: date,
+        features_path: Path | None,
+        output_dir: Path | None,
+    ) -> DecisionResult:
+        assert output_dir is not None
+        assert Path(scenario_path).is_file()
+        assert features_path is not None
+        rows = cast(list[dict[str, object]], pq.read_table(features_path).to_pylist())
+        assert rows
+        current_row = rows[-1]
+        current_as_of_date = cast(date, current_row["as_of_date"])
+        assert decision_date > current_as_of_date
+        assert [cast(date, row["as_of_date"]) for row in rows] == [
+            date(2025, 2, 3),
+            date(2025, 2, 4),
+            date(2025, 2, 5),
+        ][: len(rows)]
+        return DecisionResult(
+            decision_date=decision_date,
+            label=cast(str, current_row["expected_decision"]),
+            aggregate_score=float(current_row["marker"]),
+            threshold_up=0.25,
+            threshold_down=-0.25,
+            votes=(),
+            config_signature="config-signature",
+            snapshot_id=f"gold:{current_as_of_date.isoformat()}",
+        )
+
+    return fake_scenario_invoker
+
+
+def test_backtest_command_writes_rows_and_summary_without_skip_leakage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.cli import backtest_command
+
+    features_path = tmp_path / "gold" / "decision_features.parquet"
+    snapshot_root = tmp_path / "snapshot-root"
+    output_dir = tmp_path / "backtest"
+    scenario_path = tmp_path / "scenario.yaml"
+    agents_path = tmp_path / "agents.yaml"
+    _write_parquet(features_path, _features_rows())
+    _write_krx_close(snapshot_root, date(2025, 2, 3), 100.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 4), 101.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 5), 101.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 6), 100.0)
+    _write_yaml(
+        agents_path, {"weights": {}, "thresholds": {"up": 0.25, "down": -0.25}, "agents": {}}
+    )
+    _write_yaml(scenario_path, _scenario_payload(agents_path, features_path, output_dir))
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.backtest.runner.run_kospi_scenario",
+        _decision_invoker_factory(),
+    )
+
+    assert (
+        backtest_command(
+            features=str(features_path),
+            snapshot_root=str(snapshot_root),
+            output_dir=str(output_dir),
+            scenario=str(scenario_path),
+            agents=str(agents_path),
+        )
+        == 0
+    )
+
+    rows_payload = [
+        json.loads(line)
+        for line in (output_dir / "rows.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert rows_payload == [
+        {
+            "decision_date": "2025-02-03",
+            "next_trading_date": "2025-02-04",
+            "decision": "up",
+            "truth_label": "up",
+            "hit": True,
+            "aggregate_score": 1.0,
+            "snapshot_id": "gold:2025-02-03",
+            "config_signature": "config-signature",
+        },
+        {
+            "decision_date": "2025-02-04",
+            "next_trading_date": "2025-02-05",
+            "decision": "skip",
+            "truth_label": "flat",
+            "hit": None,
+            "aggregate_score": 2.0,
+            "snapshot_id": "gold:2025-02-04",
+            "config_signature": "config-signature",
+        },
+        {
+            "decision_date": "2025-02-05",
+            "next_trading_date": "2025-02-06",
+            "decision": "down",
+            "truth_label": "down",
+            "hit": True,
+            "aggregate_score": 3.0,
+            "snapshot_id": "gold:2025-02-05",
+            "config_signature": "config-signature",
+        },
+    ]
+    assert json.loads((output_dir / "summary.json").read_text(encoding="utf-8")) == {
+        "evaluated_count": 3,
+        "hit_count": 2,
+        "skip_count": 1,
+        "hit_rate": 1.0,
+        "skip_rate": 1 / 3,
+        "hit_rate_denominator": "evaluated_count - skip_count (skip excluded)",
+    }
+
+
+def test_backtest_command_is_identical_when_future_rows_are_removed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from kospi_decision_pipeline_app_kr_kospi.cli import backtest_command
+
+    full_features_path = tmp_path / "gold" / "decision_features.parquet"
+    prefix_features_path = tmp_path / "gold" / "decision_features_prefix.parquet"
+    snapshot_root = tmp_path / "snapshot-root"
+    scenario_path = tmp_path / "scenario.yaml"
+    agents_path = tmp_path / "agents.yaml"
+    full_output_dir = tmp_path / "backtest-full"
+    prefix_output_dir = tmp_path / "backtest-prefix"
+    rows = _features_rows()
+    _write_parquet(full_features_path, rows)
+    _write_parquet(prefix_features_path, rows[:3])
+    _write_krx_close(snapshot_root, date(2025, 2, 3), 100.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 4), 101.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 5), 101.0)
+    _write_krx_close(snapshot_root, date(2025, 2, 6), 100.0)
+    _write_yaml(
+        agents_path, {"weights": {}, "thresholds": {"up": 0.25, "down": -0.25}, "agents": {}}
+    )
+    _write_yaml(scenario_path, _scenario_payload(agents_path, full_features_path, full_output_dir))
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.backtest.runner.run_kospi_scenario",
+        _decision_invoker_factory(),
+    )
+
+    assert (
+        backtest_command(
+            features=str(full_features_path),
+            snapshot_root=str(snapshot_root),
+            output_dir=str(full_output_dir),
+            scenario=str(scenario_path),
+            agents=str(agents_path),
+        )
+        == 0
+    )
+    assert (
+        backtest_command(
+            features=str(prefix_features_path),
+            snapshot_root=str(snapshot_root),
+            output_dir=str(prefix_output_dir),
+            scenario=str(scenario_path),
+            agents=str(agents_path),
+        )
+        == 0
+    )
+
+    assert (full_output_dir / "rows.jsonl").read_text(encoding="utf-8") == (
+        prefix_output_dir / "rows.jsonl"
+    ).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- replace the `kospi-pipeline backtest` stub with an app-side chronological backtest runner that slices Gold features per decision date, reuses scenario execution, derives next-day KOSPI truth from the same bronze snapshot root, and writes typed `rows.jsonl` plus `summary.json`
- make hit-rate semantics explicit in CLI help/stdout and JSON output by excluding `skip` days from the denominator while still reporting `skip_rate` and evaluated counts
- add RED/GREEN regression coverage for non-stub CLI wiring, deterministic fixture-backed output, and a no-look-ahead leakage proof based on identical results after future Gold rows are removed