### PR TITLE
Implement Issue #50 — Nightly live smoke workflow and v0.2 operator docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,15 @@
+# Live connector credentials (leave blank locally until you opt into live mode).
 ECOS_API_KEY=
 # Bronze-only KOSIS live ingest in v0.2 uses this key.
 KOSIS_API_KEY=
+
+# Test and smoke toggles for opt-in live checks.
+# Set to 1 only when you intentionally want live upstream calls.
+KOSPI_PIPELINE_LIVE_ECOS=0
+KOSPI_PIPELINE_LIVE_KRX=0
+
+# Snapshot-aware live ingest reminders:
+# - pass --live plus --snapshot-id to `kospi-pipeline ingest`
+# - logical snapshot-aware bronze contract: data/bronze/<source>/<dataset>/<snapshot_id>/<date>.parquet
+# - current CLI stores that under a snapshot-scoped root on disk: data/bronze/<snapshot_id>/<source>/<dataset>/<date>.parquet
+# - reruns against the same snapshot skip already-written partitions

--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ ECOS_API_KEY=
 # Bronze-only KOSIS live ingest in v0.2 uses this key.
 KOSIS_API_KEY=
 
+# Set to 1 to activate live ingest mode without passing `--live`.
+KOSPI_LIVE=0
+
 # Test and smoke toggles for opt-in live checks.
 # Set to 1 only when you intentionally want live upstream calls.
 KOSPI_PIPELINE_LIVE_ECOS=0

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -1,0 +1,401 @@
+name: Live Smoke
+
+on:
+  schedule:
+    - cron: "0 18 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: live-smoke-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  live-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      CI: "true"
+      DEBIAN_FRONTEND: noninteractive
+      GIT_TERMINAL_PROMPT: "0"
+      GIT_EDITOR: ":"
+      EDITOR: ":"
+      VISUAL: ""
+      GIT_PAGER: cat
+      PAGER: cat
+      ECOS_API_KEY: ${{ secrets.ECOS_API_KEY }}
+      KOSIS_API_KEY: ${{ secrets.KOSIS_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf '\n========== uv sync --extra dev =========='"\n"
+          uv sync --extra dev
+
+      - name: Run nightly live smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          header() {
+            printf '\n========== %s =========='"\n" "$1"
+          }
+
+          run_fixture_smoke() {
+            local fixture_root
+            fixture_root="${RUNNER_TEMP}/kospi-fixture-smoke"
+            local fixture_bronze="${fixture_root}/bronze"
+            local fixture_silver="${fixture_root}/silver"
+            local fixture_runtime="${fixture_root}/runtime"
+
+            header "Fixture smoke: ingest"
+            uv run --python 3.12 kospi-pipeline ingest \
+              --source krx \
+              --dataset kospi_index \
+              --from 2024-01-02 \
+              --to 2024-01-05 \
+              --out "${fixture_bronze}"
+
+            header "Fixture smoke: silver normalization"
+            uv run --python 3.12 kospi-pipeline build-features \
+              --layer silver \
+              --source krx \
+              --dataset kospi_index \
+              --from 2024-01-02 \
+              --to 2024-01-05 \
+              --bronze-dir "${fixture_bronze}" \
+              --silver-dir "${fixture_silver}" \
+              --out "${fixture_silver}"
+
+            header "Fixture smoke: synthetic gold + backtest dataset"
+            FIXTURE_RUNTIME="${fixture_runtime}" uv run --python 3.12 python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from datetime import date, timedelta
+          from pathlib import Path
+
+          import pyarrow as pa
+          import pyarrow.parquet as pq
+          import yaml
+
+          root = Path(os.environ["FIXTURE_RUNTIME"])
+          config_dir = root / "config"
+          gold_dir = root / "data" / "gold"
+          backtest_dir = root / "data" / "backtests"
+          config_dir.mkdir(parents=True, exist_ok=True)
+          gold_dir.mkdir(parents=True, exist_ok=True)
+          backtest_dir.mkdir(parents=True, exist_ok=True)
+
+          agents_payload = {
+              "weights": {
+                  "technical": 0.30,
+                  "domestic_macro": 0.20,
+                  "flow": 0.25,
+                  "valuation": 0.10,
+                  "volatility": 0.15,
+              },
+              "thresholds": {"up": 0.25, "down": -0.25},
+              "agents": {
+                  "technical": {
+                      "rule_version": "technical@1.0.0",
+                      "thresholds": {
+                          "ma5_gap_up_min": 0.005,
+                          "close_position_up_min": 0.60,
+                          "return_5d_up_min": 0.010,
+                          "ma5_gap_down_max": -0.005,
+                          "close_position_down_max": 0.40,
+                          "return_5d_down_max": -0.010,
+                      },
+                  },
+                  "domestic_macro": {
+                      "rule_version": "domestic_macro@1.0.0",
+                      "thresholds": {
+                          "bok_rate_change_up_max": 0.00,
+                          "usdkrw_return_5d_up_max": 0.010,
+                          "bond_yield_change_30d_up_max": 0.05,
+                          "bok_rate_change_down_min": 0.25,
+                          "usdkrw_return_5d_down_min": 0.020,
+                          "bond_yield_change_30d_down_min": 0.10,
+                          "usdkrw_return_5d_mixed_pos_min": 0.015,
+                          "usdkrw_return_5d_mixed_neg_max": -0.015,
+                          "bond_yield_change_30d_mixed_pos_min": 0.05,
+                          "bond_yield_change_30d_mixed_neg_max": 0.00,
+                      },
+                  },
+                  "flow": {
+                      "rule_version": "flow@1.0.0",
+                      "thresholds": {
+                          "foreign_pct_up_min": 0.010,
+                          "foreign_pct_down_max": -0.010,
+                          "foreign_pct_neutral_abs_max": 0.003,
+                      },
+                  },
+                  "valuation": {
+                      "rule_version": "valuation@1.0.0",
+                      "thresholds": {
+                          "per_percentile_up_max": 0.30,
+                          "pbr_percentile_up_max": 0.30,
+                          "per_percentile_down_min": 0.70,
+                          "pbr_percentile_down_min": 0.70,
+                          "fair_value_center": 0.50,
+                          "fair_value_half_band": 0.10,
+                      },
+                  },
+                  "volatility": {
+                      "rule_version": "volatility@1.0.0",
+                      "thresholds": {
+                          "realized_vol_20d_up_max": 0.18,
+                          "realized_vol_pct_up_max": 0.30,
+                          "atr_14d_up_max": 35.0,
+                          "realized_vol_pct_down_min": 0.80,
+                          "realized_vol_20d_down_min": 0.25,
+                          "atr_14d_down_min": 45.0,
+                          "realized_vol_pct_mid_low": 0.30,
+                          "realized_vol_pct_mid_high": 0.80,
+                      },
+                  },
+              },
+          }
+          scenario_payload = {
+              "scenario_id": "kospi.next_day",
+              "horizon": "next_day",
+              "agents": [
+                  "technical",
+                  "domestic_macro",
+                  "flow",
+                  "valuation",
+                  "volatility",
+                  "decision",
+              ],
+              "runtime": {
+                  "agents_config_path": str(config_dir / "agents.yaml"),
+                  "features_path": str(gold_dir / "decision_features.parquet"),
+                  "output_dir": str(root / "out" / "decisions"),
+              },
+          }
+          rows = [
+              {
+                  "as_of_date": date(2025, 2, 13),
+                  "kospi_return_1d": 0.01,
+                  "kospi_return_5d": 0.02,
+                  "kospi_ma5_gap": 0.01,
+                  "kospi_close_position": 0.75,
+                  "bok_base_rate_change_30d": 0.0,
+                  "usd_krw_return_5d": 0.0,
+                  "kr_bond_yield_change_30d": 0.0,
+                  "foreign_net_buy_krw_5d_sum": 10.0,
+                  "institution_net_buy_krw_5d_sum": 5.0,
+                  "individual_net_buy_krw_5d_sum": -15.0,
+                  "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                  "kospi_per": 10.0,
+                  "kospi_pbr": 1.0,
+                  "kospi_per_percentile_252d": 0.2,
+                  "kospi_pbr_percentile_252d": 0.2,
+                  "kospi_realized_vol_20d": 0.15,
+                  "kospi_realized_vol_20d_percentile_252d": 0.2,
+                  "kospi_atr_14d": 12.0,
+              }
+          ]
+          backtest_rows = []
+          start = date(2025, 2, 3)
+          targets = ["down", "down", "up", "down", "up"]
+          for index, target in enumerate(targets):
+              trade_date = start + timedelta(days=index)
+              backtest_rows.append(
+                  {
+                      "trade_date": trade_date,
+                      "kospi_return_1d": 0.01,
+                      "kospi_return_3d": 0.015,
+                      "kospi_return_5d": 0.02,
+                      "kospi_ma5": 100.0 + index,
+                      "kospi_ma20": 98.0 + index,
+                      "kospi_ma5_gap": 0.01,
+                      "kospi_close_position": 0.75,
+                      "bok_base_rate": 3.0,
+                      "bok_base_rate_change_30d": 0.0,
+                      "usd_krw_close": 1300.0,
+                      "usd_krw_return_5d": 0.0,
+                      "kr_bond_yield_3y": 2.5,
+                      "kr_bond_yield_change_30d": 0.0,
+                      "foreign_net_buy_krw_5d_sum": 10.0,
+                      "institution_net_buy_krw_5d_sum": 5.0,
+                      "individual_net_buy_krw_5d_sum": -15.0,
+                      "foreign_net_buy_5d_pct_of_turnover": 0.02,
+                      "kospi_per": 10.0,
+                      "kospi_pbr": 1.0,
+                      "kospi_per_percentile_252d": 0.2,
+                      "kospi_pbr_percentile_252d": 0.2,
+                      "kospi_realized_vol_20d": 0.15,
+                      "kospi_realized_vol_20d_percentile_252d": 0.2,
+                      "kospi_atr_14d": 12.0,
+                      "target_next_day_simple_return": 0.01,
+                      "target_next_day_log_return": 0.01,
+                      "target_direction_label": target,
+                  }
+              )
+
+          (config_dir / "agents.yaml").write_text(
+              yaml.safe_dump(agents_payload, sort_keys=False),
+              encoding="utf-8",
+          )
+          (config_dir / "scenario.yaml").write_text(
+              yaml.safe_dump(scenario_payload, sort_keys=False),
+              encoding="utf-8",
+          )
+          (config_dir / "folds.yaml").write_text(
+              yaml.safe_dump(
+                  {"min_train_rows": 2, "test_fold_size": 2, "gap_days": 0},
+                  sort_keys=False,
+              ),
+              encoding="utf-8",
+          )
+          pq.write_table(pa.Table.from_pylist(rows), gold_dir / "decision_features.parquet", compression="snappy")
+          pq.write_table(
+              pa.Table.from_pylist(backtest_rows),
+              gold_dir / "backtest_dataset.parquet",
+              compression="snappy",
+          )
+          PY
+
+            header "Fixture smoke: run"
+            uv run --python 3.12 kospi-pipeline run \
+              --scenario "${fixture_runtime}/config/scenario.yaml" \
+              --features "${fixture_runtime}/data/gold/decision_features.parquet" \
+              --out "${fixture_runtime}/out/decisions"
+
+            header "Fixture smoke: run-backtest"
+            uv run --python 3.12 kospi-pipeline run-backtest \
+              --dataset "${fixture_runtime}/data/gold/backtest_dataset.parquet" \
+              --scenario "${fixture_runtime}/config/scenario.yaml" \
+              --out "${fixture_runtime}/out/backtests" \
+              --folds-config "${fixture_runtime}/config/folds.yaml"
+          }
+
+          if [[ -z "${ECOS_API_KEY:-}" ]]; then
+            echo "::warning title=Live smoke skipped::ECOS_API_KEY is not configured. Running pure-fixture CLI smoke instead."
+            run_fixture_smoke
+            exit 0
+          fi
+
+          header "Compute live smoke window"
+          LIVE_START="$(uv run --python 3.12 python - <<'PY'
+          from datetime import date, timedelta
+          print((date.today() - timedelta(days=430)).isoformat())
+          PY
+          )"
+          LIVE_END="$(uv run --python 3.12 python - <<'PY'
+          from datetime import date, timedelta
+          print((date.today() - timedelta(days=1)).isoformat())
+          PY
+          )"
+          SNAPSHOT_ID="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+          BRONZE_ROOT="data/live-smoke/bronze"
+          SNAPSHOT_BRONZE_ROOT="${BRONZE_ROOT}/${SNAPSHOT_ID}"
+          SILVER_ROOT="data/live-smoke/silver/${SNAPSHOT_ID}"
+          GOLD_ROOT="data/live-smoke/gold/${SNAPSHOT_ID}"
+          DECISION_ROOT="data/live-smoke/decisions/${SNAPSHOT_ID}"
+          BACKTEST_ROOT="data/live-smoke/backtests/${SNAPSHOT_ID}"
+          printf 'snapshot_id=%s\nwindow=%s..%s\n' "${SNAPSHOT_ID}" "${LIVE_START}" "${LIVE_END}"
+
+          header "Live ingest: KRX"
+          uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset kospi_index --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset investor_flow --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset market_valuation --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
+
+          header "Live ingest: ECOS"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset usd_krw --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset bond_yield --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
+
+          if [[ -n "${KOSIS_API_KEY:-}" ]]; then
+            header "Live ingest: KOSIS bronze-only"
+            uv run --python 3.12 kospi-pipeline ingest --live --source kosis --dataset macro_indicators --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${KOSIS_API_KEY}" --out "${BRONZE_ROOT}"
+          else
+            echo "::warning title=KOSIS skipped::KOSIS_API_KEY is not configured. Skipping bronze-only KOSIS ingest for this run."
+          fi
+
+          header "Build silver and gold"
+          uv run --python 3.12 kospi-pipeline build-features \
+            --layer all \
+            --from "${LIVE_START}" \
+            --to "${LIVE_END}" \
+            --bronze-dir "${SNAPSHOT_BRONZE_ROOT}" \
+            --silver-dir "${SILVER_ROOT}" \
+            --out "${GOLD_ROOT}"
+
+          header "Run snapshot decision"
+          uv run --python 3.12 kospi-pipeline run \
+            --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
+            --features "${GOLD_ROOT}/decision_features.parquet" \
+            --out "${DECISION_ROOT}"
+
+          header "Build backtest dataset"
+          GOLD_ROOT="${GOLD_ROOT}" uv run --python 3.12 python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from pathlib import Path
+
+          from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset
+
+          gold_root = Path(os.environ["GOLD_ROOT"])
+          build_backtest_dataset(
+              gold_root / "decision_features.parquet",
+              gold_root / "backtest_dataset.parquet",
+          )
+          PY
+
+          header "Trim short backtest smoke window"
+          GOLD_ROOT="${GOLD_ROOT}" BACKTEST_ROOT="${BACKTEST_ROOT}" uv run --python 3.12 python - <<'PY'
+          from __future__ import annotations
+
+          import os
+          from pathlib import Path
+
+          import pyarrow as pa
+          import pyarrow.parquet as pq
+          import yaml
+
+          gold_root = Path(os.environ["GOLD_ROOT"])
+          backtest_root = Path(os.environ["BACKTEST_ROOT"])
+          backtest_root.mkdir(parents=True, exist_ok=True)
+
+          table = pq.read_table(gold_root / "backtest_dataset.parquet")
+          rows = table.to_pylist()
+          short_rows = rows[-30:]
+          if len(short_rows) < 25:
+              raise SystemExit(
+                  f"expected at least 25 backtest rows for live smoke, found {len(short_rows)}"
+              )
+          pq.write_table(
+              pa.Table.from_pylist(short_rows),
+              backtest_root / "backtest_dataset_last_30.parquet",
+              compression="snappy",
+          )
+          (backtest_root / "folds.yaml").write_text(
+              yaml.safe_dump(
+                  {"min_train_rows": 20, "test_fold_size": 5, "gap_days": 0},
+                  sort_keys=False,
+              ),
+              encoding="utf-8",
+          )
+          PY
+
+          header "Run short backtest smoke"
+          uv run --python 3.12 kospi-pipeline run-backtest \
+            --dataset "${BACKTEST_ROOT}/backtest_dataset_last_30.parquet" \
+            --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
+            --out "${BACKTEST_ROOT}/results" \
+            --folds-config "${BACKTEST_ROOT}/folds.yaml"

--- a/README.md
+++ b/README.md
@@ -228,10 +228,11 @@ uv run --python 3.12 kospi-pipeline run-backtest \
 ### Nightly workflow and secret setup
 
 - GitHub Actions workflow: `.github/workflows/live-smoke.yml`
-- Required secret for full live smoke: `ECOS_API_KEY`
-- Optional bronze-only secret: `KOSIS_API_KEY`
+- `ECOS_API_KEY` is required for the full live path.
+- `KOSIS_API_KEY` is optional and only enables the bronze-only KOSIS ingest path in v0.2.
 - When `ECOS_API_KEY` is missing, the workflow prints a warning and falls back to fixture-backed CLI smoke (`ingest`, `build-features`, `run`, `run-backtest`) instead of failing silently.
 - When `KOSIS_API_KEY` is missing, the workflow still runs KRX + ECOS + Silver/Gold + runtime smoke and prints that KOSIS was skipped.
+- The acceptance text may say `backtest` informally, but the shipped CLI command used by the workflow is `run-backtest`.
 - Upstream auth failures, schema drift, and missing required inputs are intentionally loud because each workflow shell step runs with `set -euo pipefail` and explicit step headers.
 
 ### Expected outputs

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Public-data-first ABDP-based KOSPI next-day direction prediction pipeline for re
 ![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)
 ![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-green)
 
-- Release target: **v0.1**
+- Release target: **v0.2**
 - Project posture: **research-grade, deterministic, public-data-first**
-- Out of scope for v0.1: S&P 500, real-time FX, broker reports, individual stocks, production trading automation
+- Out of scope for v0.2: S&P 500, real-time FX, broker reports, individual stocks, production trading automation
+- KOSIS in v0.2: **bronze-only live ingest**; it is not part of the shipped Silver/Gold/runtime path unless a later cadence-normalization issue lands
 
 ## Architecture overview
 
@@ -59,7 +60,8 @@ TechnicalAgent   DomesticMacroAgent   FlowAgent   ValuationAgent   VolatilityAge
 - Python 3.12+
 - `uv`
 - Fixture-backed local runs for documentation and CI-style dry runs
-- API credentials for KRX, ECOS, and KOSIS only if live connectors are introduced later; the shipped v0.1 `LiveConnectorRegistry` is not yet implemented
+- `ECOS_API_KEY` for live ECOS ingest; `KOSIS_API_KEY` only if you want the optional bronze-only KOSIS live ingest in v0.2
+- KRX live smoke does not require a repository secret, but the scheduled GitHub Actions workflow falls back to fixture smoke when required live secrets are absent
 
 Environment variables typically used for live runs depend on the upstream data client configuration. For safe automation, export the non-interactive shell settings used in CI:
 
@@ -68,6 +70,19 @@ export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 \
   GCM_INTERACTIVE=never HOMEBREW_NO_AUTO_UPDATE=1 \
   PIP_DISABLE_PIP_VERSION_CHECK=1
 ```
+
+Live-mode variables documented in `.env.example`:
+
+```bash
+ECOS_API_KEY=
+KOSIS_API_KEY=
+KOSPI_PIPELINE_LIVE_ECOS=0
+KOSPI_PIPELINE_LIVE_KRX=0
+```
+
+- `ECOS_API_KEY` is required for live ECOS bronze ingest.
+- `KOSIS_API_KEY` is optional and only used for bronze-only KOSIS ingest in v0.2.
+- `KOSPI_PIPELINE_LIVE_ECOS=1` and `KOSPI_PIPELINE_LIVE_KRX=1` opt into the guarded live pytest smoke cases.
 
 ### Install
 
@@ -83,101 +98,152 @@ These commands are safe to run on a fresh checkout and match the current CLI/run
 uv run --python 3.12 kospi-pipeline --help
 uv run --python 3.12 kospi-pipeline ingest --help
 uv run --python 3.12 kospi-pipeline build-features --help
-uv run --python 3.12 python -c "from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; print(build_backtest_dataset.__name__)"
-uv run --python 3.12 kospi-pipeline run-scenario --help
+uv run --python 3.12 kospi-pipeline run --help
 uv run --python 3.12 kospi-pipeline run-backtest --help
+uv run --python 3.12 python -c "from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; print(build_backtest_dataset.__name__)"
 ```
 
-### End-to-end example
+### Live-mode snapshot example
 
-The shipped CLI implements `ingest`, `build-features`, `run-scenario`, and `run-backtest`. The backtest dataset builder is already implemented in Python (`transforms.target_labels.build_backtest_dataset`) but is not yet wired as a dedicated CLI subcommand in `cli.py`, so the release workflow below uses the shipped library entry point for that step.
+The shipped CLI implements `ingest`, `build-features`, `run`, `run-scenario`, and `run-backtest`. The backtest dataset builder is already implemented in Python (`transforms.target_labels.build_backtest_dataset`) but is not yet wired as a dedicated CLI subcommand in `cli.py`, so the live-smoke workflow and local runbook use the shipped library entry point for that step.
 
 Important constraints before running the full pipeline:
 
 - you need at least **272 trading days of upstream history** for the first non-empty Gold output
 - the repository's checked-in fixtures are **smoke-size only** and do not contain enough history for a full non-empty Gold/backtest run
-- therefore, the sequence below is a **command template** for a full run once you have sufficient Bronze coverage from expanded fixtures or a future live-ingest implementation
+- live runs are **snapshot-aware** and write under a snapshot root, so Silver/Gold should point at one chosen snapshot at a time
+- reruns against the **same** live snapshot are idempotent and skip already-written Bronze partitions instead of rewriting them
 
 ```bash
-# 1) Bronze ingest the six datasets required by `build-features --layer all`
+export ECOS_API_KEY="your-ecos-key"
+export KOSIS_API_KEY="your-kosis-key" # optional; KOSIS is bronze-only in v0.2
+SNAPSHOT_ID="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+LIVE_FROM="2024-01-01"
+LIVE_TO="2025-03-31"
+```
+
+```bash
+# 1) Bronze ingest the six Silver/Gold inputs into one snapshot root
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source krx \
   --dataset kospi_index \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source krx \
   --dataset investor_flow \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source krx \
   --dataset market_valuation \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source ecos \
   --dataset base_rate \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
+  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source ecos \
   --dataset usd_krw \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
+  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
+  --live \
   --source ecos \
   --dataset bond_yield \
-  --from 2023-01-01 \
-  --to 2025-03-31 \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
+  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
-# 2) Silver + Gold features
+# Optional bronze-only KOSIS ingest in v0.2. This does not feed Gold/runtime yet.
+uv run --python 3.12 kospi-pipeline ingest \
+  --live \
+  --source kosis \
+  --dataset macro_indicators \
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --snapshot-id "$SNAPSHOT_ID" \
+  --api-key "$KOSIS_API_KEY" \
+  --out data/bronze
+
+# 2) Silver + Gold features from one snapshot-aware Bronze root
 uv run --python 3.12 kospi-pipeline build-features \
   --layer all \
-  --from 2024-01-02 \
-  --to 2025-03-31 \
-  --bronze-dir data/bronze \
-  --silver-dir data/silver \
-  --out data/gold
+  --from "$LIVE_FROM" \
+  --to "$LIVE_TO" \
+  --bronze-dir "data/bronze/$SNAPSHOT_ID" \
+  --silver-dir "data/silver/$SNAPSHOT_ID" \
+  --out "data/gold/$SNAPSHOT_ID"
 
 # 3) Backtest dataset materialization (shipped transform API)
-uv run --python 3.12 python -c "from pathlib import Path; from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; build_backtest_dataset(Path('data/gold/decision_features.parquet'), Path('data/gold/backtest_dataset.parquet'))"
+uv run --python 3.12 python -c "import os; from pathlib import Path; from kospi_decision_pipeline_app_kr_kospi.transforms.target_labels import build_backtest_dataset; snapshot_id = os.environ['SNAPSHOT_ID']; build_backtest_dataset(Path(f'data/gold/{snapshot_id}/decision_features.parquet'), Path(f'data/gold/{snapshot_id}/backtest_dataset.parquet'))"
 
-# 4) Scenario execution
-uv run --python 3.12 kospi-pipeline run-scenario \
-  --date 2025-04-01 \
+# 4) Snapshot decision execution
+uv run --python 3.12 kospi-pipeline run \
   --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
-  --features data/gold/decision_features.parquet \
-  --out data/decisions
+  --features "data/gold/$SNAPSHOT_ID/decision_features.parquet" \
+  --out "data/decisions/$SNAPSHOT_ID"
 
 # 5) Walk-forward backtest
 uv run --python 3.12 kospi-pipeline run-backtest \
-  --dataset data/gold/backtest_dataset.parquet \
+  --dataset "data/gold/$SNAPSHOT_ID/backtest_dataset.parquet" \
   --scenario apps/kr-kospi/config/scenario.kospi.next_day.yaml \
-  --out data/backtests/v0_1
+  --out "data/backtests/$SNAPSHOT_ID"
 ```
+
+### Snapshot-aware Bronze roots and reruns
+
+- The snapshot-aware Bronze contract to reason about operationally is `data/bronze/<source>/<dataset>/<snapshot_id>/<date>.parquet`.
+- The current CLI realizes that contract by selecting a snapshot-scoped Bronze root first, so with the default `--out data/bronze` the physical path is `data/bronze/<snapshot_id>/<source>/<dataset>/<date>.parquet` on disk while each manifest entry remains dataset-relative as `<source>/<dataset>/<date>.parquet`.
+- Treat the snapshot directory as the immutable Bronze root for one run, then point `build-features --bronze-dir` at that exact snapshot path.
+- Re-running the same live ingest command with the same `--snapshot-id` is idempotent: existing partitions are skipped, new missing dates are appended, and the manifest records `written_dates` vs `skipped_dates`.
+- If you want a fresh replay, choose a new `snapshot-YYYYMMDDTHHMMSSZ` identifier instead of deleting old data in place.
+
+### Nightly workflow and secret setup
+
+- GitHub Actions workflow: `.github/workflows/live-smoke.yml`
+- Required secret for full live smoke: `ECOS_API_KEY`
+- Optional bronze-only secret: `KOSIS_API_KEY`
+- When `ECOS_API_KEY` is missing, the workflow prints a warning and falls back to fixture-backed CLI smoke (`ingest`, `build-features`, `run`, `run-backtest`) instead of failing silently.
+- When `KOSIS_API_KEY` is missing, the workflow still runs KRX + ECOS + Silver/Gold + runtime smoke and prints that KOSIS was skipped.
+- Upstream auth failures, schema drift, and missing required inputs are intentionally loud because each workflow shell step runs with `set -euo pipefail` and explicit step headers.
 
 ### Expected outputs
 
 | Step | Output |
 | --- | --- |
-| Bronze ingest | `data/bronze/<source>/<dataset>/<date>.parquet` |
+| Bronze ingest | `data/bronze/<snapshot_id>/<source>/<dataset>/<date>.parquet` for live runs; `data/bronze/<source>/<dataset>/<date>.parquet` for fixture runs |
 | Silver build | `data/silver/.../*.parquet` |
-| Gold build | `data/gold/decision_features.parquet` |
-| Backtest dataset build | `data/gold/backtest_dataset.parquet` |
-| Scenario run | `data/decisions/kospi.next_day/<decision-date>.jsonl` |
-| Backtest run | `data/backtests/v0_1/rows.jsonl`, `metrics.json`, `metrics.csv` |
+| Gold build | `data/gold/<snapshot_id>/decision_features.parquet` (or another chosen Gold root) |
+| Backtest dataset build | `data/gold/<snapshot_id>/backtest_dataset.parquet` |
+| Snapshot run | `data/decisions/<snapshot_id>/kospi.next_day/<decision-date>.jsonl` |
+| Backtest run | `data/backtests/<snapshot_id>/rows.jsonl`, `metrics.json`, `metrics.csv` |
 
 ## CLI reference
 
@@ -185,9 +251,11 @@ uv run --python 3.12 kospi-pipeline run-backtest \
 | --- | --- | --- |
 | `ingest` | implemented | Bronze parquet ingestion |
 | `build-features` | implemented | `silver`, `gold`, or `all` |
+| `run` | implemented | Run decisions over the latest Gold snapshot row |
 | `run-scenario` | implemented | ABDP scenario execution |
 | `run-backtest` | implemented | Walk-forward reports |
-| `build-backtest-dataset` | not yet exposed as CLI | Use `build_backtest_dataset(...)` from Python for v0.1 |
+| `build-backtest-dataset` | not yet exposed as CLI | Use `build_backtest_dataset(...)` from Python for v0.2 |
+| `backtest` | stubbed | Placeholder only; use `run-backtest` |
 
 ## Configuration reference
 
@@ -209,7 +277,7 @@ The scenario file defines the runtime envelope used by `run-scenario` and `run-b
 | Key | Current committed value | Meaning |
 | --- | --- | --- |
 | `scenario_id` | `kospi.next_day` | Scenario namespace for decision artifacts |
-| `horizon` | `next_day` | Fixed v0.1 horizon |
+| `horizon` | `next_day` | Fixed v0.2 horizon |
 | `agents` | `technical`, `domestic_macro`, `flow`, `valuation`, `volatility`, `decision` | ABDP participant order |
 | `runtime.agents_config_path` | `apps/kr-kospi/config/agents.yaml` | Agent config source |
 | `runtime.features_path` | `data/gold/features.parquet` | Default runtime features path in committed YAML |
@@ -280,9 +348,13 @@ Licensed under the [Apache License 2.0](LICENSE).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for Oracle review workflow, branch naming, TDD expectations, coverage policy, and squash-merge rules.
 
+## Operator runbook
+
+- Daily/nightly operations, secret rotation, snapshot conventions, and schema-drift response steps live in [docs/operator.md](docs/operator.md).
+
 ## Design contract
 
-The normative release contract lives in [docs/spec.md](docs/spec.md). ADR context begins with [docs/adr/001-project-foundation.md](docs/adr/001-project-foundation.md).
+The normative release contract lives in [docs/spec.md](docs/spec.md). That document still captures the binding v0.1 rules/runtime baseline; the v0.2 operator additions in this README and [docs/operator.md](docs/operator.md) layer on top without changing the published rule contracts. ADR context begins with [docs/adr/001-project-foundation.md](docs/adr/001-project-foundation.md).
 
 ## ABDP attribution
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -1,0 +1,126 @@
+# Operator runbook
+
+## Scope
+
+This runbook covers the v0.2 operating path for nightly or ad-hoc live smoke runs.
+
+- KRX + ECOS feed the shipped Silver/Gold/runtime path.
+- KOSIS live ingest is **bronze-only in v0.2** and must not be treated as a Gold/runtime dependency unless a later cadence-normalization issue lands.
+- Fixture smoke remains the fallback when required live secrets are absent.
+
+## Daily / nightly run procedure
+
+Primary automation lives in `.github/workflows/live-smoke.yml`.
+
+1. Trigger path
+   - scheduled daily at `0 18 * * *` UTC (`03:00` KST)
+   - or `workflow_dispatch` for ad-hoc replay
+2. Bootstrap
+   - checkout
+   - Python 3.12 setup
+   - `uv sync --extra dev`
+3. Live-mode decision tree
+   - if `ECOS_API_KEY` is present, run live KRX + ECOS ingest
+   - if `KOSIS_API_KEY` is also present, run optional bronze-only KOSIS ingest
+   - if `ECOS_API_KEY` is absent, print a warning and fall back to fixture-backed CLI smoke
+4. Materialization
+   - build Silver/Gold from one chosen snapshot-aware Bronze root
+   - run `kospi-pipeline run`
+   - build a backtest dataset with `build_backtest_dataset(...)`
+   - trim to a short recent window and run `kospi-pipeline run-backtest`
+
+All workflow shell blocks run with `set -euo pipefail` and explicit headers so auth failures, schema drift, and missing required inputs fail loudly in the job log.
+
+## Snapshot ID conventions
+
+Use UTC timestamped snapshot IDs:
+
+```text
+snapshot-YYYYMMDDTHHMMSSZ
+```
+
+Example:
+
+```text
+snapshot-20260426T180000Z
+```
+
+Guidelines:
+
+- one snapshot ID per ingest batch
+- do not mix multiple live ingest waves into one snapshot unless you are intentionally resuming the same batch
+- point downstream transforms at the exact snapshot root, for example `data/bronze/<snapshot_id>`
+- keep snapshots immutable after success; create a new snapshot for a true rerun
+
+Logical Bronze contract:
+
+```text
+data/bronze/<source>/<dataset>/<snapshot_id>/<date>.parquet
+```
+
+Current on-disk layout from the default Bronze output root:
+
+```text
+data/bronze/<snapshot_id>/<source>/<dataset>/<date>.parquet
+```
+
+## Rerun semantics
+
+Live Bronze ingest is idempotent for the same `--snapshot-id`.
+
+- existing partitions are skipped
+- missing partitions for the requested date range are appended
+- manifests record which dates were written, skipped, or failed
+
+Operationally:
+
+- use the same snapshot ID when you want a safe resume of an interrupted ingest
+- use a new snapshot ID when you want an auditable fresh replay
+- avoid mutating or deleting individual parquet partitions inside a completed snapshot unless you are handling an incident and recording that manual action elsewhere
+
+## Secret setup and rotation
+
+Repository / environment secrets:
+
+- `ECOS_API_KEY` — required for full live smoke
+- `KOSIS_API_KEY` — optional, bronze-only in v0.2
+
+Rotation procedure:
+
+1. generate the replacement key upstream
+2. update the GitHub Actions secret in the target repository or environment
+3. trigger `workflow_dispatch`
+4. confirm live ingest passes with the new key
+5. revoke the old key upstream once the smoke run is green
+
+Local operators can mirror the same names in a private `.env` file, but `.env.example` must stay credential-free.
+
+## Schema drift response
+
+Typical symptoms:
+
+- live ingest step fails with parsing or validation errors
+- Silver normalization fails after Bronze ingest succeeded
+- Gold build fails because expected columns are missing or renamed
+
+Response checklist:
+
+1. identify the failing step from the workflow header in the job log
+2. capture the upstream source, dataset, date range, and snapshot ID
+3. inspect the written Bronze snapshot and manifest to determine whether the break happened at fetch time or transform time
+4. if the issue is auth-related, rotate / re-enter the secret and rerun
+5. if the issue is schema-related, open a follow-up fix with the failing sample payload or parquet attached
+6. do not silently patch around required-column loss in the workflow; the failure is expected to stay loud
+
+## Manual ad-hoc commands
+
+```bash
+export ECOS_API_KEY="..."
+export KOSIS_API_KEY="..." # optional
+SNAPSHOT_ID="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
+
+uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset kospi_index --from 2024-01-01 --to 2025-03-31 --snapshot-id "$SNAPSHOT_ID" --out data/bronze
+uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from 2024-01-01 --to 2025-03-31 --snapshot-id "$SNAPSHOT_ID" --api-key "$ECOS_API_KEY" --out data/bronze
+uv run --python 3.12 kospi-pipeline build-features --layer all --from 2024-01-01 --to 2025-03-31 --bronze-dir "data/bronze/$SNAPSHOT_ID" --silver-dir "data/silver/$SNAPSHOT_ID" --out "data/gold/$SNAPSHOT_ID"
+uv run --python 3.12 kospi-pipeline run --features "data/gold/$SNAPSHOT_ID/decision_features.parquet" --out "data/decisions/$SNAPSHOT_ID"
+```


### PR DESCRIPTION
## Summary
- add a nightly `live-smoke` workflow that runs live KRX/ECOS ingest, optional bronze-only KOSIS ingest, Silver/Gold materialization, `run`, and a short `run-backtest` smoke, while falling back to fixture-backed CLI smoke when required secrets are absent
- document v0.2 live-mode setup, snapshot-aware bronze roots, rerun semantics, and GitHub Actions secret handling in the README, `.env.example`, and a new operator runbook
- make workflow failures loud with explicit step headers and strict shell settings so auth errors, schema drift, and missing required inputs surface clearly in CI output