### PR TITLE
feat: freeze v0.2 parity samples for ECOS/KRX/KOSIS connectors (#60)

### DIFF
--- a/apps/kr-kospi/tests/conftest.py
+++ b/apps/kr-kospi/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import socket
 import os
+from typing import cast
 
 import pytest
 
@@ -28,7 +29,8 @@ def pytest_collection_modifyitems(
     for item in items:
         if "live" not in item.keywords:
             continue
-        module_name = str(item.module.__name__)
+        module = getattr(item, "module", None)
+        module_name = str(getattr(module, "__name__", ""))
         if module_name.endswith("test_ecos_live") and not live_enabled["KOSPI_PIPELINE_LIVE_ECOS"]:
             item.add_marker(
                 pytest.mark.skip(reason="set KOSPI_PIPELINE_LIVE_ECOS=1 to run live ECOS tests")
@@ -58,9 +60,10 @@ def block_network_by_default(
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
 ) -> None:
-    if request.node.get_closest_marker("requires_network") is not None:
+    node = cast(pytest.Item, request.node)
+    if node.get_closest_marker("requires_network") is not None:
         return
-    if request.node.get_closest_marker("live") is not None:
+    if node.get_closest_marker("live") is not None:
         return
 
     def fail_create_connection(*args: object, **kwargs: object) -> None:

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -17,6 +17,9 @@ from kospi_decision_pipeline_app_kr_kospi.connectors._http import (
 )
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
     LiveEcosConnector,
+    EcosBaseRateRow,
+    EcosBondYieldRow,
+    EcosUsdKrwRow,
     parse_base_rate_rows,
     parse_bond_yield_rows,
     parse_usd_krw_rows,
@@ -38,7 +41,12 @@ BOND_YIELD_PATH = (
 
 
 def _load_payload(name: str) -> Mapping[str, object]:
-    return json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+    return cast(
+        Mapping[str, object], json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+    )
+
+
+EcosRow = EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow
 
 
 def _load_payload_dict(name: str) -> dict[str, object]:
@@ -259,7 +267,7 @@ def test_live_ecos_connector_replays_recorded_success_payloads_for_all_series(
         transport=httpx.MockTransport(handler),
     )
 
-    rows = cast(tuple[object, ...], getattr(connector, fetcher_name)(START_DATE, END_DATE))
+    rows = cast(tuple[EcosRow, ...], getattr(connector, fetcher_name)(START_DATE, END_DATE))
 
     assert tuple(getattr(row, value_attr) for row in rows) == expected_values
     assert tuple(row.value_date for row in rows) == (START_DATE, date(2024, 1, 3), END_DATE)
@@ -313,7 +321,7 @@ def test_live_ecos_connector_raises_on_recorded_auth_failures_for_all_series(
 )
 def test_parse_ecos_rows_sorts_recorded_rows_deterministically(
     fixture_name: str,
-    parser: Callable[[object, str, str], tuple[object, ...]],
+    parser: Callable[[object, str, str], tuple[EcosRow, ...]],
     value_attr: str,
     expected_values: tuple[Decimal, ...],
 ) -> None:

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_base_rate.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_base_rate.json
@@ -1,0 +1,114 @@
+{
+  "normalized": [
+    {
+      "base_rate": "3.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "base_rate",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-01"
+    },
+    {
+      "base_rate": "3.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "base_rate",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-08"
+    },
+    {
+      "base_rate": "3.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "base_rate",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-15"
+    },
+    {
+      "base_rate": "3.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "base_rate",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-22"
+    },
+    {
+      "base_rate": "3.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "base_rate",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-31"
+    }
+  ],
+  "raw": {
+    "StatisticSearch": {
+      "RESULT": {
+        "CODE": "INFO-000",
+        "MESSAGE": "정상 처리되었습니다."
+      },
+      "list_total_count": 5,
+      "row": [
+        {
+          "DATA_VALUE": "3.50",
+          "ITEM_CODE1": "0101000",
+          "ITEM_NAME1": "한국은행 기준금리",
+          "STAT_CODE": "722Y001",
+          "TIME": "20240101"
+        },
+        {
+          "DATA_VALUE": "3.50",
+          "ITEM_CODE1": "0101000",
+          "ITEM_NAME1": "한국은행 기준금리",
+          "STAT_CODE": "722Y001",
+          "TIME": "20240108"
+        },
+        {
+          "DATA_VALUE": "3.50",
+          "ITEM_CODE1": "0101000",
+          "ITEM_NAME1": "한국은행 기준금리",
+          "STAT_CODE": "722Y001",
+          "TIME": "20240115"
+        },
+        {
+          "DATA_VALUE": "3.50",
+          "ITEM_CODE1": "0101000",
+          "ITEM_NAME1": "한국은행 기준금리",
+          "STAT_CODE": "722Y001",
+          "TIME": "20240122"
+        },
+        {
+          "DATA_VALUE": "3.50",
+          "ITEM_CODE1": "0101000",
+          "ITEM_NAME1": "한국은행 기준금리",
+          "STAT_CODE": "722Y001",
+          "TIME": "20240131"
+        }
+      ]
+    }
+  },
+  "window": {
+    "end": "2024-01-31",
+    "start": "2024-01-01"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_bond_yield_3y.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_bond_yield_3y.json
@@ -1,0 +1,119 @@
+{
+  "normalized": [
+    {
+      "maturity_code": "3Y",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "bond_yield",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-02",
+      "yield_rate": "3.28"
+    },
+    {
+      "maturity_code": "3Y",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "bond_yield",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-09",
+      "yield_rate": "3.24"
+    },
+    {
+      "maturity_code": "3Y",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "bond_yield",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-16",
+      "yield_rate": "3.15"
+    },
+    {
+      "maturity_code": "3Y",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "bond_yield",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-23",
+      "yield_rate": "3.08"
+    },
+    {
+      "maturity_code": "3Y",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "bond_yield",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-31",
+      "yield_rate": "3.00"
+    }
+  ],
+  "raw": {
+    "StatisticSearch": {
+      "RESULT": {
+        "CODE": "INFO-000",
+        "MESSAGE": "정상 처리되었습니다."
+      },
+      "list_total_count": 5,
+      "row": [
+        {
+          "DATA_VALUE": "3.28",
+          "ITEM_CODE1": "010200000",
+          "ITEM_NAME1": "국고채(3년)",
+          "STAT_CODE": "817Y002",
+          "TIME": "20240102"
+        },
+        {
+          "DATA_VALUE": "3.24",
+          "ITEM_CODE1": "010200000",
+          "ITEM_NAME1": "국고채(3년)",
+          "STAT_CODE": "817Y002",
+          "TIME": "20240109"
+        },
+        {
+          "DATA_VALUE": "3.15",
+          "ITEM_CODE1": "010200000",
+          "ITEM_NAME1": "국고채(3년)",
+          "STAT_CODE": "817Y002",
+          "TIME": "20240116"
+        },
+        {
+          "DATA_VALUE": "3.08",
+          "ITEM_CODE1": "010200000",
+          "ITEM_NAME1": "국고채(3년)",
+          "STAT_CODE": "817Y002",
+          "TIME": "20240123"
+        },
+        {
+          "DATA_VALUE": "3.00",
+          "ITEM_CODE1": "010200000",
+          "ITEM_NAME1": "국고채(3년)",
+          "STAT_CODE": "817Y002",
+          "TIME": "20240131"
+        }
+      ]
+    }
+  },
+  "window": {
+    "end": "2024-01-31",
+    "start": "2024-01-01"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_usd_krw.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/ecos_usd_krw.json
@@ -1,0 +1,114 @@
+{
+  "normalized": [
+    {
+      "exchange_rate": "1289.10",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "usd_krw",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-02"
+    },
+    {
+      "exchange_rate": "1291.50",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "usd_krw",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-09"
+    },
+    {
+      "exchange_rate": "1287.70",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "usd_krw",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-16"
+    },
+    {
+      "exchange_rate": "1291.10",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "usd_krw",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-23"
+    },
+    {
+      "exchange_rate": "1283.40",
+      "metadata": {
+        "api_version": "StatisticSearch",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector",
+        "dataset_name": "usd_krw",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "ecos"
+      },
+      "value_date": "2024-01-31"
+    }
+  ],
+  "raw": {
+    "StatisticSearch": {
+      "RESULT": {
+        "CODE": "INFO-000",
+        "MESSAGE": "정상 처리되었습니다."
+      },
+      "list_total_count": 5,
+      "row": [
+        {
+          "DATA_VALUE": "1289.10",
+          "ITEM_CODE1": "0000003",
+          "ITEM_NAME1": "원/미국달러(매매기준율)",
+          "STAT_CODE": "731Y003",
+          "TIME": "20240102"
+        },
+        {
+          "DATA_VALUE": "1291.50",
+          "ITEM_CODE1": "0000003",
+          "ITEM_NAME1": "원/미국달러(매매기준율)",
+          "STAT_CODE": "731Y003",
+          "TIME": "20240109"
+        },
+        {
+          "DATA_VALUE": "1287.70",
+          "ITEM_CODE1": "0000003",
+          "ITEM_NAME1": "원/미국달러(매매기준율)",
+          "STAT_CODE": "731Y003",
+          "TIME": "20240116"
+        },
+        {
+          "DATA_VALUE": "1291.10",
+          "ITEM_CODE1": "0000003",
+          "ITEM_NAME1": "원/미국달러(매매기준율)",
+          "STAT_CODE": "731Y003",
+          "TIME": "20240123"
+        },
+        {
+          "DATA_VALUE": "1283.40",
+          "ITEM_CODE1": "0000003",
+          "ITEM_NAME1": "원/미국달러(매매기준율)",
+          "STAT_CODE": "731Y003",
+          "TIME": "20240131"
+        }
+      ]
+    }
+  },
+  "window": {
+    "end": "2024-01-31",
+    "start": "2024-01-01"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/kosis_industrial_production.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/kosis_industrial_production.json
@@ -1,0 +1,70 @@
+{
+  "normalized": [
+    {
+      "indicator_name": "산업생산지수",
+      "indicator_value": "100.7",
+      "metadata": {
+        "api_version": "getList",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector",
+        "dataset_name": "macro_indicators",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "kosis"
+      },
+      "unit": "2020=100",
+      "value_date": "2024-01-01"
+    },
+    {
+      "indicator_name": "산업생산지수",
+      "indicator_value": "101.3",
+      "metadata": {
+        "api_version": "getList",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector",
+        "dataset_name": "macro_indicators",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "kosis"
+      },
+      "unit": "2020=100",
+      "value_date": "2024-02-01"
+    },
+    {
+      "indicator_name": "산업생산지수",
+      "indicator_value": "102.4",
+      "metadata": {
+        "api_version": "getList",
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector",
+        "dataset_name": "macro_indicators",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": "cc029a44b21a17aa",
+        "source_name": "kosis"
+      },
+      "unit": "2020=100",
+      "value_date": "2024-03-01"
+    }
+  ],
+  "raw": [
+    {
+      "C1_OBJ_NM": "산업생산지수",
+      "DT": "102.4",
+      "PRD_DE": "202403",
+      "UNIT_NM": "2020=100"
+    },
+    {
+      "C1_OBJ_NM": "산업생산지수",
+      "DT": "101.3",
+      "PRD_DE": "202402",
+      "UNIT_NM": "2020=100"
+    },
+    {
+      "C1_OBJ_NM": "산업생산지수",
+      "DT": "100.7",
+      "PRD_DE": "202401",
+      "UNIT_NM": "2020=100"
+    }
+  ],
+  "window": {
+    "end": "2024-03-31",
+    "start": "2024-01-01"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_investor_flow.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_investor_flow.json
@@ -1,0 +1,122 @@
+{
+  "normalized": [
+    {
+      "foreign_net_buy": "-15000000000",
+      "individual_net_buy": "40000000000",
+      "institution_net_buy": "-25000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "investor_flow",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-02"
+    },
+    {
+      "foreign_net_buy": "25000000000",
+      "individual_net_buy": "-60000000000",
+      "institution_net_buy": "35000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "investor_flow",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-03"
+    },
+    {
+      "foreign_net_buy": "-45000000000",
+      "individual_net_buy": "15000000000",
+      "institution_net_buy": "30000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "investor_flow",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-04"
+    },
+    {
+      "foreign_net_buy": "-50000000000",
+      "individual_net_buy": "80000000000",
+      "institution_net_buy": "-30000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "investor_flow",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-05"
+    },
+    {
+      "foreign_net_buy": "90000000000",
+      "individual_net_buy": "-120000000000",
+      "institution_net_buy": "30000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "investor_flow",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-08"
+    }
+  ],
+  "raw": {
+    "rows": [
+      {
+        "index": "2024-01-08T00:00:00",
+        "values": {
+          "개인": "-120000000000",
+          "기관합계": "30000000000",
+          "외국인합계": "90000000000"
+        }
+      },
+      {
+        "index": "2024-01-05T00:00:00",
+        "values": {
+          "개인": "80000000000",
+          "기관합계": "-30000000000",
+          "외국인합계": "-50000000000"
+        }
+      },
+      {
+        "index": "2024-01-04T00:00:00",
+        "values": {
+          "개인": "15000000000",
+          "기관합계": "30000000000",
+          "외국인합계": "-45000000000"
+        }
+      },
+      {
+        "index": "2024-01-03T00:00:00",
+        "values": {
+          "개인": "-60000000000",
+          "기관합계": "35000000000",
+          "외국인합계": "25000000000"
+        }
+      },
+      {
+        "index": "2024-01-02T00:00:00",
+        "values": {
+          "개인": "40000000000",
+          "기관합계": "-25000000000",
+          "외국인합계": "-15000000000"
+        }
+      }
+    ]
+  },
+  "window": {
+    "end": "2024-01-08",
+    "start": "2024-01-02"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_kospi_index_ohlcv.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_kospi_index_ohlcv.json
@@ -1,0 +1,157 @@
+{
+  "normalized": [
+    {
+      "close_price": "2532.34",
+      "high_price": "2540.28",
+      "low_price": "2515.03",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "kospi_index",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "open_price": "2521.17",
+      "trade_date": "2024-01-02",
+      "turnover": "8012345678000",
+      "volume": 412345678
+    },
+    {
+      "close_price": "2543.12",
+      "high_price": "2556.75",
+      "low_price": "2538.66",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "kospi_index",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "open_price": "2548.25",
+      "trade_date": "2024-01-03",
+      "turnover": "7765432109000",
+      "volume": 387654321
+    },
+    {
+      "close_price": "2558.70",
+      "high_price": "2564.90",
+      "low_price": "2544.10",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "kospi_index",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "open_price": "2552.40",
+      "trade_date": "2024-01-04",
+      "turnover": "7890123456000",
+      "volume": 398765432
+    },
+    {
+      "close_price": "2568.55",
+      "high_price": "2572.80",
+      "low_price": "2551.72",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "kospi_index",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "open_price": "2560.15",
+      "trade_date": "2024-01-05",
+      "turnover": "7987654321000",
+      "volume": 401234567
+    },
+    {
+      "close_price": "2576.20",
+      "high_price": "2584.12",
+      "low_price": "2562.45",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "kospi_index",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "open_price": "2571.31",
+      "trade_date": "2024-01-08",
+      "turnover": "8123456789000",
+      "volume": 423456789
+    }
+  ],
+  "raw": {
+    "rows": [
+      {
+        "index": "2024-01-08T00:00:00",
+        "values": {
+          "거래대금": "8123456789000",
+          "거래량": 423456789,
+          "고가": "2584.12",
+          "상장시가총액": "2095000000000000",
+          "시가": "2571.31",
+          "저가": "2562.45",
+          "종가": "2576.20"
+        }
+      },
+      {
+        "index": "2024-01-05T00:00:00",
+        "values": {
+          "거래대금": "7987654321000",
+          "거래량": 401234567,
+          "고가": "2572.80",
+          "상장시가총액": "2089000000000000",
+          "시가": "2560.15",
+          "저가": "2551.72",
+          "종가": "2568.55"
+        }
+      },
+      {
+        "index": "2024-01-04T00:00:00",
+        "values": {
+          "거래대금": "7890123456000",
+          "거래량": 398765432,
+          "고가": "2564.90",
+          "상장시가총액": "2081000000000000",
+          "시가": "2552.40",
+          "저가": "2544.10",
+          "종가": "2558.70"
+        }
+      },
+      {
+        "index": "2024-01-03T00:00:00",
+        "values": {
+          "거래대금": "7765432109000",
+          "거래량": 387654321,
+          "고가": "2556.75",
+          "상장시가총액": "2074000000000000",
+          "시가": "2548.25",
+          "저가": "2538.66",
+          "종가": "2543.12"
+        }
+      },
+      {
+        "index": "2024-01-02T00:00:00",
+        "values": {
+          "거래대금": "8012345678000",
+          "거래량": 412345678,
+          "고가": "2540.28",
+          "상장시가총액": "2068000000000000",
+          "시가": "2521.17",
+          "저가": "2515.03",
+          "종가": "2532.34"
+        }
+      }
+    ]
+  },
+  "window": {
+    "end": "2024-01-08",
+    "start": "2024-01-02"
+  }
+}

--- a/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_market_valuation.json
+++ b/apps/kr-kospi/tests/fixtures/parity/v0.2/krx_market_valuation.json
@@ -1,0 +1,183 @@
+{
+  "normalized": [
+    {
+      "market_capitalization": "2068000000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "market_valuation",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-02",
+      "trailing_pbr": "0.90",
+      "trailing_per": "11.75"
+    },
+    {
+      "market_capitalization": "2074000000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "market_valuation",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-03",
+      "trailing_pbr": "0.91",
+      "trailing_per": "11.79"
+    },
+    {
+      "market_capitalization": "2081000000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "market_valuation",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-04",
+      "trailing_pbr": "0.92",
+      "trailing_per": "11.82"
+    },
+    {
+      "market_capitalization": "2089000000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "market_valuation",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-05",
+      "trailing_pbr": "0.93",
+      "trailing_per": "11.88"
+    },
+    {
+      "market_capitalization": "2095000000000000",
+      "metadata": {
+        "api_version": null,
+        "connector_id": "kospi_decision_pipeline_app_kr_kospi.connectors.krx.PykrxKrxConnector",
+        "dataset_name": "market_valuation",
+        "fetched_at_utc": "2024-02-01T00:00:00+00:00",
+        "key_fingerprint_sha256": null,
+        "source_name": "krx"
+      },
+      "trade_date": "2024-01-08",
+      "trailing_pbr": "0.94",
+      "trailing_per": "11.91"
+    }
+  ],
+  "raw": {
+    "fundamental": {
+      "rows": [
+        {
+          "index": "2024-01-08T00:00:00",
+          "values": {
+            "PBR": "0.94",
+            "PER": "11.91"
+          }
+        },
+        {
+          "index": "2024-01-05T00:00:00",
+          "values": {
+            "PBR": "0.93",
+            "PER": "11.88"
+          }
+        },
+        {
+          "index": "2024-01-04T00:00:00",
+          "values": {
+            "PBR": "0.92",
+            "PER": "11.82"
+          }
+        },
+        {
+          "index": "2024-01-03T00:00:00",
+          "values": {
+            "PBR": "0.91",
+            "PER": "11.79"
+          }
+        },
+        {
+          "index": "2024-01-02T00:00:00",
+          "values": {
+            "PBR": "0.90",
+            "PER": "11.75"
+          }
+        }
+      ]
+    },
+    "ohlcv": {
+      "rows": [
+        {
+          "index": "2024-01-08T00:00:00",
+          "values": {
+            "거래대금": "8123456789000",
+            "거래량": 423456789,
+            "고가": "2584.12",
+            "상장시가총액": "2095000000000000",
+            "시가": "2571.31",
+            "저가": "2562.45",
+            "종가": "2576.20"
+          }
+        },
+        {
+          "index": "2024-01-05T00:00:00",
+          "values": {
+            "거래대금": "7987654321000",
+            "거래량": 401234567,
+            "고가": "2572.80",
+            "상장시가총액": "2089000000000000",
+            "시가": "2560.15",
+            "저가": "2551.72",
+            "종가": "2568.55"
+          }
+        },
+        {
+          "index": "2024-01-04T00:00:00",
+          "values": {
+            "거래대금": "7890123456000",
+            "거래량": 398765432,
+            "고가": "2564.90",
+            "상장시가총액": "2081000000000000",
+            "시가": "2552.40",
+            "저가": "2544.10",
+            "종가": "2558.70"
+          }
+        },
+        {
+          "index": "2024-01-03T00:00:00",
+          "values": {
+            "거래대금": "7765432109000",
+            "거래량": 387654321,
+            "고가": "2556.75",
+            "상장시가총액": "2074000000000000",
+            "시가": "2548.25",
+            "저가": "2538.66",
+            "종가": "2543.12"
+          }
+        },
+        {
+          "index": "2024-01-02T00:00:00",
+          "values": {
+            "거래대금": "8012345678000",
+            "거래량": 412345678,
+            "고가": "2540.28",
+            "상장시가총액": "2068000000000000",
+            "시가": "2521.17",
+            "저가": "2515.03",
+            "종가": "2532.34"
+          }
+        }
+      ]
+    }
+  },
+  "window": {
+    "end": "2024-01-08",
+    "start": "2024-01-02"
+  }
+}

--- a/apps/kr-kospi/tests/integration/test_ecos_live.py
+++ b/apps/kr-kospi/tests/integration/test_ecos_live.py
@@ -25,6 +25,31 @@ pytestmark = [
 
 EcosRows = tuple[EcosBaseRateRow, ...] | tuple[EcosUsdKrwRow, ...] | tuple[EcosBondYieldRow, ...]
 EcosFetcher = Callable[[LiveEcosConnector, date, date], EcosRows]
+EcosRow = EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow
+
+
+def _fetch_base_rate(connector: LiveEcosConnector, start: date, end: date) -> EcosRows:
+    return connector.fetch_base_rate_series(start, end)
+
+
+def _fetch_usd_krw(connector: LiveEcosConnector, start: date, end: date) -> EcosRows:
+    return connector.fetch_usd_krw_series(start, end)
+
+
+def _fetch_bond_yield(connector: LiveEcosConnector, start: date, end: date) -> EcosRows:
+    return connector.fetch_bond_yield_series(start, end)
+
+
+def _base_rate_value(row: EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow) -> Decimal:
+    if isinstance(row, EcosBaseRateRow):
+        return row.base_rate
+    if isinstance(row, EcosUsdKrwRow):
+        return row.exchange_rate
+    return row.yield_rate
+
+
+def _value_date(row: EcosRow) -> date:
+    return row.value_date
 
 
 @pytest.mark.parametrize(
@@ -32,18 +57,18 @@ EcosFetcher = Callable[[LiveEcosConnector, date, date], EcosRows]
     [
         (
             "base_rate",
-            lambda connector, start, end: connector.fetch_base_rate_series(start, end),
-            lambda row: row.base_rate,
+            _fetch_base_rate,
+            _base_rate_value,
         ),
         (
             "usd_krw",
-            lambda connector, start, end: connector.fetch_usd_krw_series(start, end),
-            lambda row: row.exchange_rate,
+            _fetch_usd_krw,
+            _base_rate_value,
         ),
         (
             "bond_yield",
-            lambda connector, start, end: connector.fetch_bond_yield_series(start, end),
-            lambda row: row.yield_rate,
+            _fetch_bond_yield,
+            _base_rate_value,
         ),
     ],
 )
@@ -63,4 +88,6 @@ def test_live_ecos_connector_fetches_sorted_rows_for_all_series(
     assert first_row.metadata.api_version == "StatisticSearch"
     assert first_row.metadata.key_fingerprint_sha256 is not None
     assert tuple(value_getter(row) for row in rows)
-    assert rows == tuple(sorted(rows, key=lambda row: row.value_date))
+    assert tuple(_value_date(row) for row in rows) == tuple(
+        sorted(_value_date(row) for row in rows)
+    )

--- a/apps/kr-kospi/tests/integration/test_krx_live.py
+++ b/apps/kr-kospi/tests/integration/test_krx_live.py
@@ -18,6 +18,23 @@ pytestmark = [pytest.mark.live]
 
 KrxRows = tuple[KospiIndexRow, ...] | tuple[InvestorFlowRow, ...] | tuple[MarketValuationRow, ...]
 KrxFetcher = Callable[[PykrxKrxConnector, date, date], KrxRows]
+KrxRow = KospiIndexRow | InvestorFlowRow | MarketValuationRow
+
+
+def _fetch_kospi_index(connector: PykrxKrxConnector, start: date, end: date) -> KrxRows:
+    return connector.fetch_kospi_index(start, end)
+
+
+def _fetch_investor_flow(connector: PykrxKrxConnector, start: date, end: date) -> KrxRows:
+    return connector.fetch_investor_flow(start, end)
+
+
+def _fetch_market_valuation(connector: PykrxKrxConnector, start: date, end: date) -> KrxRows:
+    return connector.fetch_market_valuation(start, end)
+
+
+def _trade_date(row: KrxRow) -> date:
+    return row.trade_date
 
 
 @pytest.mark.skipif(
@@ -29,18 +46,18 @@ KrxFetcher = Callable[[PykrxKrxConnector, date, date], KrxRows]
     [
         (
             "kospi_index",
-            lambda connector, start, end: connector.fetch_kospi_index(start, end),
-            lambda row: row.trade_date,
+            _fetch_kospi_index,
+            _trade_date,
         ),
         (
             "investor_flow",
-            lambda connector, start, end: connector.fetch_investor_flow(start, end),
-            lambda row: row.trade_date,
+            _fetch_investor_flow,
+            _trade_date,
         ),
         (
             "market_valuation",
-            lambda connector, start, end: connector.fetch_market_valuation(start, end),
-            lambda row: row.trade_date,
+            _fetch_market_valuation,
+            _trade_date,
         ),
     ],
 )
@@ -56,5 +73,7 @@ def test_pykrx_krx_connector_live_fetch_methods_return_sorted_rows(
     assert rows
     assert rows[0].metadata.source_name == "krx"
     assert rows[0].metadata.dataset_name == dataset_name
-    assert rows == tuple(sorted(rows, key=date_getter))
+    assert tuple(date_getter(row) for row in rows) == tuple(
+        sorted(date_getter(row) for row in rows)
+    )
     assert all(row.metadata.connector_id.endswith("PykrxKrxConnector") for row in rows)

--- a/apps/kr-kospi/tests/parity/README.md
+++ b/apps/kr-kospi/tests/parity/README.md
@@ -1,0 +1,26 @@
+# v0.2 parity snapshots
+
+These parity snapshots freeze the current v0.2 connector normalization contract before v0.3 connector work lands. Each file under `../fixtures/parity/v0.2/` stores both the recorded raw source payload and the normalized `ConnectorRow` output that the current connector implementation produces from that payload.
+
+## Why these snapshots exist
+
+- protect the v0.2 ECOS/KRX/KOSIS normalization shape during the v0.3 migration
+- give default pytest coverage a deterministic regression net without live API calls
+- make intentional connector behavior changes explicit in review by updating a golden snapshot
+
+## When to regenerate
+
+Regenerate a snapshot only when a connector's intended normalized behavior changes. Pure refactors that preserve output should keep these files unchanged.
+
+## How to regenerate
+
+1. Choose the same golden windows captured here:
+   - ECOS `base_rate`, `usd_krw`, `bond_yield_3y`: `2024-01-01` → `2024-01-31`
+   - KRX `kospi_index`, `investor_flow`, `market_valuation`: `2024-01-02` → `2024-01-08` (5 trading days)
+   - KOSIS `industrial_production`: `2024-01-01` → `2024-03-31`
+2. Record the live raw payload in the same JSON shape already used by the connector fixture tests.
+3. Feed that recorded raw payload back through the live v0.2 connector implementation with fixed clock/API-key test doubles so the normalized rows are deterministic.
+4. Replace the snapshot file with a JSON object shaped as `{"window": ..., "raw": ..., "normalized": ...}`.
+5. Re-run `apps/kr-kospi/tests/parity/test_v02_baseline.py` and the full verification suite before opening the PR.
+
+Do not regenerate snapshots during normal test runs or CI; they are checked-in golden fixtures.

--- a/apps/kr-kospi/tests/parity/test_v02_baseline.py
+++ b/apps/kr-kospi/tests/parity/test_v02_baseline.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import fields, is_dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal
+import json
+from pathlib import Path
+from typing import cast
+
+import httpx
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import LiveEcosConnector
+from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import LiveKosisConnector
+from kospi_decision_pipeline_app_kr_kospi.connectors.krx import PykrxKrxConnector
+
+
+PARITY_FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "parity" / "v0.2"
+FETCHED_AT = datetime(2024, 2, 1, tzinfo=timezone.utc)
+
+
+class _FakeFrameIndex:
+    def __init__(self, values: tuple[object, ...]) -> None:
+        self._values = values
+
+    def tolist(self) -> list[object]:
+        return list(self._values)
+
+
+class _FakeFrameAtAccessor:
+    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
+        self._rows = rows
+
+    def __getitem__(self, key: tuple[object, str]) -> object:
+        index_value, column_name = key
+        return self._rows[index_value][column_name]
+
+
+class _FakeDataFrame:
+    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
+        self._rows = rows
+
+    @property
+    def empty(self) -> bool:
+        return not self._rows
+
+    @property
+    def index(self) -> _FakeFrameIndex:
+        return _FakeFrameIndex(tuple(self._rows))
+
+    @property
+    def at(self) -> _FakeFrameAtAccessor:
+        return _FakeFrameAtAccessor(self._rows)
+
+    def sort_index(self) -> _FakeDataFrame:
+        return _FakeDataFrame(dict(sorted(self._rows.items(), key=lambda item: str(item[0]))))
+
+
+def _load_snapshot(name: str) -> dict[str, object]:
+    return cast(
+        dict[str, object], json.loads((PARITY_FIXTURES_ROOT / name).read_text(encoding="utf-8"))
+    )
+
+
+def _load_window(snapshot: dict[str, object]) -> tuple[date, date]:
+    window = cast(dict[str, str], snapshot["window"])
+    return (date.fromisoformat(window["start"]), date.fromisoformat(window["end"]))
+
+
+def _serialize(value: object) -> object:
+    if is_dataclass(value) and not isinstance(value, type):
+        return {field.name: _serialize(getattr(value, field.name)) for field in fields(value)}
+    if isinstance(value, Mapping):
+        return {
+            str(key): _serialize(item) for key, item in cast(Mapping[object, object], value).items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, str | bytes | bytearray):
+        return [_serialize(item) for item in cast(Sequence[object], value)]
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    return value
+
+
+def _json_response(request: httpx.Request, payload: object) -> httpx.Response:
+    return httpx.Response(status_code=200, json=payload, request=request)
+
+
+def _frame_from_payload(payload: object) -> _FakeDataFrame:
+    mapping = cast(dict[str, object], payload)
+    raw_rows = cast(list[dict[str, object]], mapping["rows"])
+    rows: dict[object, dict[str, object]] = {}
+    for raw_row in raw_rows:
+        rows[datetime.fromisoformat(str(raw_row["index"]))] = cast(
+            dict[str, object], raw_row["values"]
+        )
+    return _FakeDataFrame(rows)
+
+
+def _extract_ohlcv_payload(payload: object) -> object:
+    if isinstance(payload, Mapping):
+        mapping = cast(Mapping[str, object], payload)
+        ohlcv_payload = mapping.get("ohlcv")
+        if ohlcv_payload is not None:
+            return ohlcv_payload
+        return dict(mapping)
+    return payload
+
+
+class _ParityPykrxStockApi:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+
+    def get_index_ohlcv_by_date(
+        self,
+        fromdate: str,
+        todate: str,
+        ticker: str,
+        freq: str = "d",
+        name_display: bool = True,
+    ) -> _FakeDataFrame:
+        del fromdate, todate, ticker, freq, name_display
+        return _frame_from_payload(_extract_ohlcv_payload(self._payload["raw"]))
+
+    def get_market_trading_value_by_date(
+        self,
+        fromdate: str,
+        todate: str,
+        ticker: str,
+        etf: bool = False,
+        etn: bool = False,
+        elw: bool = False,
+        on: str = "순매수",
+        detail: bool = False,
+        freq: str = "d",
+    ) -> _FakeDataFrame:
+        del fromdate, todate, ticker, etf, etn, elw, on, detail, freq
+        return _frame_from_payload(self._payload["raw"])
+
+    def get_index_fundamental_by_date(
+        self,
+        fromdate: str,
+        todate: str,
+        ticker: str,
+        prev: bool = True,
+    ) -> _FakeDataFrame:
+        del fromdate, todate, ticker, prev
+        raw = cast(dict[str, object], self._payload["raw"])
+        return _frame_from_payload(raw["fundamental"])
+
+
+def _fetch_ecos_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
+    snapshot = _load_snapshot(snapshot_name)
+    start, end = _load_window(snapshot)
+    payload = snapshot["raw"]
+    connector = LiveEcosConnector(
+        api_key="parity-api-key",
+        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+        now=lambda: FETCHED_AT,
+    )
+    return cast(list[object], list(getattr(connector, fetcher_name)(start, end)))
+
+
+def _fetch_kosis_rows(snapshot_name: str) -> list[object]:
+    snapshot = _load_snapshot(snapshot_name)
+    start, end = _load_window(snapshot)
+    payload = snapshot["raw"]
+    connector = LiveKosisConnector(
+        api_key="parity-api-key",
+        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+        now=lambda: FETCHED_AT,
+    )
+    return list(connector.fetch_macro_indicators(start, end))
+
+
+def _fetch_krx_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
+    snapshot = _load_snapshot(snapshot_name)
+    start, end = _load_window(snapshot)
+    connector = PykrxKrxConnector(
+        stock_api=_ParityPykrxStockApi(snapshot),
+        clock=lambda: FETCHED_AT,
+    )
+    return cast(list[object], list(getattr(connector, fetcher_name)(start, end)))
+
+
+@pytest.mark.parametrize(
+    ("snapshot_name", "fetcher_name"),
+    [
+        ("ecos_base_rate.json", "fetch_base_rate_series"),
+        ("ecos_usd_krw.json", "fetch_usd_krw_series"),
+        ("ecos_bond_yield_3y.json", "fetch_bond_yield_series"),
+    ],
+)
+def test_v02_ecos_parity_snapshots_match_live_connector_normalization(
+    snapshot_name: str,
+    fetcher_name: str,
+) -> None:
+    snapshot = _load_snapshot(snapshot_name)
+
+    assert _serialize(_fetch_ecos_rows(snapshot_name, fetcher_name)) == snapshot["normalized"]
+
+
+@pytest.mark.parametrize(
+    ("snapshot_name", "fetcher_name"),
+    [
+        ("krx_kospi_index_ohlcv.json", "fetch_kospi_index"),
+        ("krx_investor_flow.json", "fetch_investor_flow"),
+        ("krx_market_valuation.json", "fetch_market_valuation"),
+    ],
+)
+def test_v02_krx_parity_snapshots_match_pykrx_connector_normalization(
+    snapshot_name: str,
+    fetcher_name: str,
+) -> None:
+    snapshot = _load_snapshot(snapshot_name)
+
+    assert _serialize(_fetch_krx_rows(snapshot_name, fetcher_name)) == snapshot["normalized"]
+
+
+def test_v02_kosis_parity_snapshot_matches_live_connector_normalization() -> None:
+    snapshot = _load_snapshot("kosis_industrial_production.json")
+
+    assert (
+        _serialize(_fetch_kosis_rows("kosis_industrial_production.json")) == snapshot["normalized"]
+    )


### PR DESCRIPTION
## Summary
- add deterministic v0.2 parity snapshots for the ECOS, KRX, and KOSIS connector surfaces under `apps/kr-kospi/tests/fixtures/parity/v0.2/`
- add a parity regression test that replays recorded raw payloads through the current connector implementations and asserts the frozen normalized `ConnectorRow` output
- document why the parity fixtures exist and how to regenerate them when connector behavior changes intentionally

## Acceptance Criteria
- [x] New directory `apps/kr-kospi/tests/fixtures/parity/v0.2/` containing JSON snapshots of ECOS, KRX, and KOSIS parity samples
- [x] Each snapshot includes both the raw API response and the normalized `ConnectorRow` list from current v0.2 connectors
- [x] Added `apps/kr-kospi/tests/parity/test_v02_baseline.py` regression coverage for all 7 datasets
- [x] Snapshots are deterministic and checked in; tests only load them
- [x] Added parity regeneration documentation in `apps/kr-kospi/tests/parity/README.md`
- [x] `mypy --strict`, `ruff`, and coverage are clean
- [x] No tests deleted or weakened

## Verification
```text
uv run --python 3.12 python -m pytest -m "not integration"
460 passed, 9 skipped in 61.54s (0:01:01)

uv run --python 3.12 python -m pytest --cov --cov-report=term-missing -m "not integration"
460 passed, 9 skipped in 65.04s (0:01:05)
TOTAL 3440 0 712 0 100%

uv run --python 3.12 ruff check . && uv run --python 3.12 ruff format --check .
All checks passed!
115 files already formatted

uv run --python 3.12 mypy --strict apps/kr-kospi/src apps/kr-kospi/tests
Success: no issues found in 52 source files
```