### PR TITLE
feat: add kpubdata client_factory and migrate env vars to KPUBDATA_* (#61)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Live connector credentials (leave blank locally until you opt into live mode).
-ECOS_API_KEY=
+KPUBDATA_BOK_API_KEY=
 # Bronze-only KOSIS live ingest in v0.2 uses this key.
-KOSIS_API_KEY=
+KPUBDATA_KOSIS_API_KEY=
 
 # Set to 1 to activate live ingest mode without passing `--live`.
 KOSPI_LIVE=0

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -22,8 +22,8 @@ jobs:
       VISUAL: ""
       GIT_PAGER: cat
       PAGER: cat
-      ECOS_API_KEY: ${{ secrets.ECOS_API_KEY }}
-      KOSIS_API_KEY: ${{ secrets.KOSIS_API_KEY }}
+      KPUBDATA_BOK_API_KEY: ${{ secrets.KPUBDATA_BOK_API_KEY }}
+      KPUBDATA_KOSIS_API_KEY: ${{ secrets.KPUBDATA_KOSIS_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -283,8 +283,8 @@ jobs:
               --folds-config "${fixture_runtime}/config/folds.yaml"
           }
 
-          if [[ -z "${ECOS_API_KEY:-}" ]]; then
-            echo "::warning title=Live smoke skipped::ECOS_API_KEY is not configured. Running pure-fixture CLI smoke instead."
+          if [[ -z "${KPUBDATA_BOK_API_KEY:-}" ]]; then
+            echo "::warning title=Live smoke skipped::KPUBDATA_BOK_API_KEY is not configured. Running pure-fixture CLI smoke instead."
             run_fixture_smoke
             exit 0
           fi
@@ -315,15 +315,15 @@ jobs:
           uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset market_valuation --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
 
           header "Live ingest: ECOS"
-          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
-          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset usd_krw --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
-          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset bond_yield --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${ECOS_API_KEY}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset usd_krw --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
+          uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset bond_yield --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
 
-          if [[ -n "${KOSIS_API_KEY:-}" ]]; then
+          if [[ -n "${KPUBDATA_KOSIS_API_KEY:-}" ]]; then
             header "Live ingest: KOSIS bronze-only"
-            uv run --python 3.12 kospi-pipeline ingest --live --source kosis --dataset macro_indicators --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --api-key "${KOSIS_API_KEY}" --out "${BRONZE_ROOT}"
+            uv run --python 3.12 kospi-pipeline ingest --live --source kosis --dataset macro_indicators --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
           else
-            echo "::warning title=KOSIS skipped::KOSIS_API_KEY is not configured. Skipping bronze-only KOSIS ingest for this run."
+            echo "::warning title=KOSIS skipped::KPUBDATA_KOSIS_API_KEY is not configured. Skipping bronze-only KOSIS ingest for this run."
           fi
 
           header "Build silver and gold"

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ TechnicalAgent   DomesticMacroAgent   FlowAgent   ValuationAgent   VolatilityAge
 - Python 3.12+
 - `uv`
 - Fixture-backed local runs for documentation and CI-style dry runs
-- `ECOS_API_KEY` for live ECOS ingest; `KOSIS_API_KEY` only if you want the optional bronze-only KOSIS live ingest in v0.2
+- `KPUBDATA_BOK_API_KEY` for live ECOS ingest; `KPUBDATA_KOSIS_API_KEY` only if you want the optional bronze-only KOSIS live ingest in v0.2
 - KRX live smoke does not require a repository secret, but the scheduled GitHub Actions workflow falls back to fixture smoke when required live secrets are absent
 
 Environment variables typically used for live runs depend on the upstream data client configuration. For safe automation, export the non-interactive shell settings used in CI:
@@ -74,14 +74,14 @@ export CI=true DEBIAN_FRONTEND=noninteractive GIT_TERMINAL_PROMPT=0 \
 Live-mode variables documented in `.env.example`:
 
 ```bash
-ECOS_API_KEY=
-KOSIS_API_KEY=
+KPUBDATA_BOK_API_KEY=
+KPUBDATA_KOSIS_API_KEY=
 KOSPI_PIPELINE_LIVE_ECOS=0
 KOSPI_PIPELINE_LIVE_KRX=0
 ```
 
-- `ECOS_API_KEY` is required for live ECOS bronze ingest.
-- `KOSIS_API_KEY` is optional and only used for bronze-only KOSIS ingest in v0.2.
+- `KPUBDATA_BOK_API_KEY` is required for live ECOS bronze ingest.
+- `KPUBDATA_KOSIS_API_KEY` is optional and only used for bronze-only KOSIS ingest in v0.2.
 - `KOSPI_PIPELINE_LIVE_ECOS=1` and `KOSPI_PIPELINE_LIVE_KRX=1` opt into the guarded live pytest smoke cases.
 
 ### Install
@@ -115,8 +115,8 @@ Important constraints before running the full pipeline:
 - reruns against the **same** live snapshot are idempotent and skip already-written Bronze partitions instead of rewriting them
 
 ```bash
-export ECOS_API_KEY="your-ecos-key"
-export KOSIS_API_KEY="your-kosis-key" # optional; KOSIS is bronze-only in v0.2
+export KPUBDATA_BOK_API_KEY="your-bok-key"
+export KPUBDATA_KOSIS_API_KEY="your-kosis-key" # optional; KOSIS is bronze-only in v0.2
 SNAPSHOT_ID="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
 LIVE_FROM="2024-01-01"
 LIVE_TO="2025-03-31"
@@ -158,7 +158,6 @@ uv run --python 3.12 kospi-pipeline ingest \
   --from "$LIVE_FROM" \
   --to "$LIVE_TO" \
   --snapshot-id "$SNAPSHOT_ID" \
-  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
@@ -168,7 +167,6 @@ uv run --python 3.12 kospi-pipeline ingest \
   --from "$LIVE_FROM" \
   --to "$LIVE_TO" \
   --snapshot-id "$SNAPSHOT_ID" \
-  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
 uv run --python 3.12 kospi-pipeline ingest \
@@ -178,7 +176,6 @@ uv run --python 3.12 kospi-pipeline ingest \
   --from "$LIVE_FROM" \
   --to "$LIVE_TO" \
   --snapshot-id "$SNAPSHOT_ID" \
-  --api-key "$ECOS_API_KEY" \
   --out data/bronze
 
 # Optional bronze-only KOSIS ingest in v0.2. This does not feed Gold/runtime yet.
@@ -189,7 +186,6 @@ uv run --python 3.12 kospi-pipeline ingest \
   --from "$LIVE_FROM" \
   --to "$LIVE_TO" \
   --snapshot-id "$SNAPSHOT_ID" \
-  --api-key "$KOSIS_API_KEY" \
   --out data/bronze
 
 # 2) Silver + Gold features from one snapshot-aware Bronze root
@@ -228,10 +224,10 @@ uv run --python 3.12 kospi-pipeline run-backtest \
 ### Nightly workflow and secret setup
 
 - GitHub Actions workflow: `.github/workflows/live-smoke.yml`
-- `ECOS_API_KEY` is required for the full live path.
-- `KOSIS_API_KEY` is optional and only enables the bronze-only KOSIS ingest path in v0.2.
-- When `ECOS_API_KEY` is missing, the workflow prints a warning and falls back to fixture-backed CLI smoke (`ingest`, `build-features`, `run`, `run-backtest`) instead of failing silently.
-- When `KOSIS_API_KEY` is missing, the workflow still runs KRX + ECOS + Silver/Gold + runtime smoke and prints that KOSIS was skipped.
+- `KPUBDATA_BOK_API_KEY` is required for the full live path.
+- `KPUBDATA_KOSIS_API_KEY` is optional and only enables the bronze-only KOSIS ingest path in v0.2.
+- When `KPUBDATA_BOK_API_KEY` is missing, the workflow prints a warning and falls back to fixture-backed CLI smoke (`ingest`, `build-features`, `run`, `run-backtest`) instead of failing silently.
+- When `KPUBDATA_KOSIS_API_KEY` is missing, the workflow still runs KRX + ECOS + Silver/Gold + runtime smoke and prints that KOSIS was skipped.
 - The acceptance text may say `backtest` informally, but the shipped CLI command used by the workflow is `run-backtest`.
 - Upstream auth failures, schema drift, and missing required inputs are intentionally loud because each workflow shell step runs with `set -euo pipefail` and explicit step headers.
 

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/cli.py
@@ -47,7 +47,6 @@ def run_ingest_command(
     output_dir: str,
     live: bool,
     snapshot_id: str | None = None,
-    api_key: str | None = None,
     connector_registry: ConnectorRegistry | None = None,
     deterministic_run_timestamp: datetime | None = None,
 ) -> int:
@@ -58,7 +57,7 @@ def run_ingest_command(
         else cast(ConnectorRegistry, FixtureConnectorRegistry(fixtures_root()))
     )
     connector = (
-        registry.get_connector(source, api_key=api_key)
+        registry.get_connector(source)
         if live_mode
         else cast(FixtureConnectorRegistry, registry).get_connector(source)
     )
@@ -262,7 +261,6 @@ class _CliArgs(argparse.Namespace):
     live: bool = False
     snapshot_id: str = ""
     snapshot_root: str = ""
-    api_key: str = ""
     agents: str = ""
 
 
@@ -284,7 +282,6 @@ def main(argv: list[str] | None = None) -> int:
     _ = ingest_parser.add_argument("--out", dest="output_dir", default="data/bronze")
     _ = ingest_parser.add_argument("--live", action="store_true")
     _ = ingest_parser.add_argument("--snapshot-id", default="")
-    _ = ingest_parser.add_argument("--api-key", default="")
     build_features_parser = sub.add_parser("build-features", help="build typed features")
     _ = build_features_parser.add_argument(
         "--layer", choices=("silver", "gold", "all"), required=True
@@ -357,7 +354,6 @@ def main(argv: list[str] | None = None) -> int:
                 output_dir=str(args.output_dir),
                 live=live_mode,
                 snapshot_id=str(args.snapshot_id) or None,
-                api_key=str(args.api_key) or None,
             )
         except UnsupportedDatasetError as error:
             print(str(error), file=sys.stderr)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/_secrets.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/_secrets.py
@@ -4,8 +4,8 @@ from collections.abc import Mapping
 
 
 SOURCE_API_KEY_ENV_VARS: dict[str, str] = {
-    "ecos": "ECOS_API_KEY",
-    "kosis": "KOSIS_API_KEY",
+    "ecos": "KPUBDATA_BOK_API_KEY",
+    "kosis": "KPUBDATA_KOSIS_API_KEY",
 }
 
 
@@ -25,4 +25,4 @@ def resolve_live_api_key(
         return from_environment
 
     source_name = source.upper()
-    raise ValueError(f"{source_name} API key is required via --api-key or {env_var_name}")
+    raise ValueError(f"{source_name} API key is required via {env_var_name}")

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/client_factory.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/client_factory.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+
+import click
+from kpubdata import Client
+
+REQUIRED_PROVIDERS: tuple[str, ...] = ("bok", "kosis")
+
+
+def _env_var_name(provider: str) -> str:
+    return f"KPUBDATA_{provider.upper()}_API_KEY"
+
+
+def _missing_providers() -> list[str]:
+    missing: list[str] = []
+    for provider in REQUIRED_PROVIDERS:
+        if not os.environ.get(_env_var_name(provider)):
+            missing.append(provider)
+    return missing
+
+
+def build_client() -> Client:
+    missing = _missing_providers()
+    if missing:
+        expected = ", ".join(_env_var_name(provider) for provider in missing)
+        message = (
+            f"Missing kpubdata API key(s) for: {', '.join(missing)}."
+            f" Set the following environment variable(s): {expected}."
+        )
+        raise click.ClickException(message)
+    return Client.from_env()
+
+
+__all__ = ["REQUIRED_PROVIDERS", "build_client"]

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -106,7 +106,7 @@ def test_live_ecos_connector_prefers_explicit_api_key_over_environment() -> None
 
     connector = LiveEcosConnector(
         api_key="explicit-api-key",
-        environment={"ECOS_API_KEY": "env-api-key"},
+        environment={"KPUBDATA_BOK_API_KEY": "env-api-key"},
         transport=httpx.MockTransport(handler),
     )
 
@@ -115,7 +115,10 @@ def test_live_ecos_connector_prefers_explicit_api_key_over_environment() -> None
     assert rows
 
 
-def test_live_ecos_connector_requires_api_key_when_no_auth_source_exists() -> None:
+def test_live_ecos_connector_requires_api_key_when_no_auth_source_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KPUBDATA_BOK_API_KEY", raising=False)
     with pytest.raises(ValueError, match="ECOS API key"):
         LiveEcosConnector(environment={})
 
@@ -128,7 +131,7 @@ def test_live_ecos_connector_uses_environment_api_key() -> None:
         return _json_response(request, payload)
 
     connector = LiveEcosConnector(
-        environment={"ECOS_API_KEY": "env-api-key"},
+        environment={"KPUBDATA_BOK_API_KEY": "env-api-key"},
         transport=httpx.MockTransport(handler),
     )
 

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -84,7 +84,7 @@ def test_live_kosis_connector_uses_explicit_api_key_over_environment() -> None:
 
     connector = LiveKosisConnector(
         api_key="explicit-kosis-key",
-        environment={"KOSIS_API_KEY": "env-kosis-key"},
+        environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"},
         transport=httpx.MockTransport(handler),
         now=lambda: FETCHED_AT,
     )
@@ -94,7 +94,10 @@ def test_live_kosis_connector_uses_explicit_api_key_over_environment() -> None:
     assert rows[0].metadata.key_fingerprint_sha256 == expected_fingerprint
 
 
-def test_live_kosis_connector_requires_api_key_when_no_auth_source_exists() -> None:
+def test_live_kosis_connector_requires_api_key_when_no_auth_source_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("KPUBDATA_KOSIS_API_KEY", raising=False)
     with pytest.raises(ValueError, match="KOSIS API key is required"):
         LiveKosisConnector(environment={})
 
@@ -187,7 +190,11 @@ def test_kosis_period_helpers_cover_supported_and_unsupported_paths(
     assert _utc_now().tzinfo == timezone.utc
 
 
-@pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")
+@pytest.mark.requires_network
+@pytest.mark.skipif(
+    os.getenv("KPUBDATA_KOSIS_API_KEY") is None,
+    reason="KPUBDATA_KOSIS_API_KEY not set",
+)
 def test_live_kosis_connector_smoke_fetches_verified_bronze_series() -> None:
     connector = LiveKosisConnector(now=lambda: FETCHED_AT)
 

--- a/apps/kr-kospi/tests/contract/test_live_connector_registry.py
+++ b/apps/kr-kospi/tests/contract/test_live_connector_registry.py
@@ -32,7 +32,7 @@ def test_live_connector_registry_prefers_explicit_key_over_environment() -> None
         resolve_live_api_key(
             source="ecos",
             api_key="explicit-ecos-key",
-            environment={"ECOS_API_KEY": "env-ecos-key"},
+            environment={"KPUBDATA_BOK_API_KEY": "env-ecos-key"},
         )
         == "explicit-ecos-key"
     )
@@ -43,7 +43,7 @@ def test_live_connector_registry_reads_source_specific_environment_key() -> None
         resolve_live_api_key(
             source="ecos",
             api_key=None,
-            environment={"ECOS_API_KEY": "env-ecos-key"},
+            environment={"KPUBDATA_BOK_API_KEY": "env-ecos-key"},
         )
         == "env-ecos-key"
     )
@@ -71,20 +71,20 @@ def test_live_connector_registry_reads_kosis_environment_key() -> None:
         resolve_live_api_key(
             source="kosis",
             api_key=None,
-            environment={"KOSIS_API_KEY": "env-kosis-key"},
+            environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"},
         )
         == "env-kosis-key"
     )
 
 
 def test_live_connector_registry_passes_environment_to_live_kosis_connector() -> None:
-    registry = LiveConnectorRegistry(environment={"KOSIS_API_KEY": "env-kosis-key"})
+    registry = LiveConnectorRegistry(environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"})
 
     connector = registry.get_connector("kosis")
 
     environment = getattr(connector, "_environment")
     assert isinstance(environment, Mapping)
-    assert environment["KOSIS_API_KEY"] == "env-kosis-key"
+    assert environment["KPUBDATA_KOSIS_API_KEY"] == "env-kosis-key"
 
 
 def test_live_connector_registry_rejects_unknown_source() -> None:

--- a/apps/kr-kospi/tests/integration/test_ecos_live.py
+++ b/apps/kr-kospi/tests/integration/test_ecos_live.py
@@ -18,8 +18,8 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
 pytestmark = [
     pytest.mark.live,
     pytest.mark.skipif(
-        os.getenv("ECOS_API_KEY") in {None, ""},
-        reason="set ECOS_API_KEY to run live ECOS tests",
+        os.getenv("KPUBDATA_BOK_API_KEY") in {None, ""},
+        reason="set KPUBDATA_BOK_API_KEY to run live ECOS tests",
     ),
 ]
 

--- a/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
@@ -214,8 +214,12 @@ def test_cli_main_live_ingest_writes_snapshot_partition_layout(
 
 
 def test_cli_main_fails_clearly_for_unsupported_live_kosis_dataset(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-api-key")
+
     assert (
         main(
             [

--- a/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
@@ -115,7 +115,6 @@ def test_run_ingest_command_live_mode_is_idempotent_for_existing_snapshot_partit
             output_dir=str(tmp_path),
             live=True,
             snapshot_id="snapshot-20240115T000000Z",
-            api_key="cli-key",
             connector_registry=registry,
             deterministic_run_timestamp=RUN_TIMESTAMP,
         )
@@ -136,7 +135,6 @@ def test_run_ingest_command_live_mode_is_idempotent_for_existing_snapshot_partit
             output_dir=str(tmp_path),
             live=True,
             snapshot_id="snapshot-20240115T000000Z",
-            api_key="cli-key",
             connector_registry=registry,
             deterministic_run_timestamp=RUN_TIMESTAMP,
         )
@@ -147,7 +145,7 @@ def test_run_ingest_command_live_mode_is_idempotent_for_existing_snapshot_partit
         tmp_path / "snapshot-20240115T000000Z" / "ecos" / "base_rate" / "manifest.json"
     )
 
-    assert registry.calls == [("ecos", "cli-key"), ("ecos", "cli-key")]
+    assert registry.calls == [("ecos", None), ("ecos", None)]
     assert connector.requested_ranges == []
     assert isinstance(manifest, LiveIngestManifest)
     assert manifest.written_dates == ()
@@ -187,8 +185,6 @@ def test_cli_main_live_ingest_writes_snapshot_partition_layout(
             "2024-01-03",
             "--snapshot-id",
             "snapshot-20240115T000000Z",
-            "--api-key",
-            "cli-key",
             "--out",
             str(tmp_path),
         ]
@@ -199,7 +195,7 @@ def test_cli_main_live_ingest_writes_snapshot_partition_layout(
     )
 
     assert exit_code == 0
-    assert registry.calls == [("ecos", "cli-key")]
+    assert registry.calls == [("ecos", None)]
     assert connector.requested_ranges == [
         (date(2024, 1, 2), date(2024, 1, 2)),
         (date(2024, 1, 3), date(2024, 1, 3)),
@@ -235,8 +231,6 @@ def test_cli_main_fails_clearly_for_unsupported_live_kosis_dataset(
                 "2024-01-31",
                 "--snapshot-id",
                 "snapshot-20240115T000000Z",
-                "--api-key",
-                "cli-key",
                 "--out",
                 str(tmp_path),
             ]
@@ -247,7 +241,11 @@ def test_cli_main_fails_clearly_for_unsupported_live_kosis_dataset(
     assert "per_pbr_percentiles" in capsys.readouterr().err
 
 
-@pytest.mark.skipif(os.getenv("KOSIS_API_KEY") is None, reason="KOSIS_API_KEY not set")
+@pytest.mark.requires_network
+@pytest.mark.skipif(
+    os.getenv("KPUBDATA_KOSIS_API_KEY") is None,
+    reason="KPUBDATA_KOSIS_API_KEY not set",
+)
 def test_run_ingest_command_live_kosis_writes_verified_bronze_partition(tmp_path: Path) -> None:
     assert (
         run_ingest_command(

--- a/apps/kr-kospi/tests/unit/test_cli_commands.py
+++ b/apps/kr-kospi/tests/unit/test_cli_commands.py
@@ -241,7 +241,6 @@ def test_cli_main_runs_fixture_ingest(monkeypatch: pytest.MonkeyPatch) -> None:
         "output_dir": "tmp/bronze",
         "live": False,
         "snapshot_id": None,
-        "api_key": None,
     }
 
 
@@ -280,7 +279,7 @@ def test_cli_main_enables_live_mode_with_flag(monkeypatch: pytest.MonkeyPatch) -
     assert captured["snapshot_id"] == "snapshot-20240115T000000Z"
 
 
-def test_cli_main_routes_live_snapshot_id_and_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_main_routes_live_snapshot_id(monkeypatch: pytest.MonkeyPatch) -> None:
     captured: dict[str, object] = {}
 
     def fake_run_ingest_command(**kwargs: object) -> int:
@@ -307,15 +306,12 @@ def test_cli_main_routes_live_snapshot_id_and_api_key(monkeypatch: pytest.Monkey
                 "2024-01-04",
                 "--snapshot-id",
                 "snapshot-20240115T000000Z",
-                "--api-key",
-                "cli-key",
             ]
         )
         == 0
     )
     assert captured["live"] is True
     assert captured["snapshot_id"] == "snapshot-20240115T000000Z"
-    assert captured["api_key"] == "cli-key"
 
 
 def test_cli_main_enables_live_mode_with_env_var(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/kr-kospi/tests/unit/test_client_factory.py
+++ b/apps/kr-kospi/tests/unit/test_client_factory.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import click
+from kpubdata import Client
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors.client_factory import build_client
+
+
+def _clear_auth_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("KPUBDATA_BOK_API_KEY", "KPUBDATA_KOSIS_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_build_client_raises_when_both_keys_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+
+    with pytest.raises(click.ClickException) as exc_info:
+        build_client()
+
+    assert "KPUBDATA_BOK_API_KEY" in str(exc_info.value)
+    assert "KPUBDATA_KOSIS_API_KEY" in str(exc_info.value)
+
+
+def test_build_client_raises_when_only_bok_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-key")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        build_client()
+
+    assert "KPUBDATA_BOK_API_KEY" in str(exc_info.value)
+    assert "KPUBDATA_KOSIS_API_KEY" not in str(exc_info.value)
+
+
+def test_build_client_raises_when_only_kosis_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("KPUBDATA_BOK_API_KEY", "test-bok-key")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        build_client()
+
+    assert "KPUBDATA_KOSIS_API_KEY" in str(exc_info.value)
+    assert "KPUBDATA_BOK_API_KEY" not in str(exc_info.value)
+
+
+def test_build_client_ignores_legacy_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("ECOS_API_KEY", "legacy-ecos-key")
+    monkeypatch.setenv("KOSIS_API_KEY", "legacy-kosis-key")
+
+    with pytest.raises(click.ClickException) as exc_info:
+        build_client()
+
+    assert "KPUBDATA_BOK_API_KEY" in str(exc_info.value)
+    assert "KPUBDATA_KOSIS_API_KEY" in str(exc_info.value)
+
+
+def test_build_client_succeeds_when_both_keys_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("KPUBDATA_BOK_API_KEY", "test-bok-key")
+    monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-key")
+
+    client = build_client()
+
+    assert client is not None
+
+
+def test_returned_client_is_kpubdata_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("KPUBDATA_BOK_API_KEY", "test-bok-key")
+    monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-key")
+
+    client = build_client()
+
+    assert isinstance(client, Client)

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -20,9 +20,9 @@ Primary automation lives in `.github/workflows/live-smoke.yml`.
    - Python 3.12 setup
    - `uv sync --extra dev`
 3. Live-mode decision tree
-   - if `ECOS_API_KEY` is present, run live KRX + ECOS ingest
-   - if `KOSIS_API_KEY` is also present, run optional bronze-only KOSIS ingest
-   - if `ECOS_API_KEY` is absent, print a warning and fall back to fixture-backed CLI smoke
+   - if `KPUBDATA_BOK_API_KEY` is present, run live KRX + ECOS ingest
+   - if `KPUBDATA_KOSIS_API_KEY` is also present, run optional bronze-only KOSIS ingest
+   - if `KPUBDATA_BOK_API_KEY` is absent, print a warning and fall back to fixture-backed CLI smoke
 4. Materialization
    - build Silver/Gold from one chosen snapshot-aware Bronze root
    - run `kospi-pipeline run`
@@ -82,8 +82,8 @@ Operationally:
 
 Repository / environment secrets:
 
-- `ECOS_API_KEY` — required for full live smoke
-- `KOSIS_API_KEY` — optional, bronze-only in v0.2
+- `KPUBDATA_BOK_API_KEY` — required for full live smoke
+- `KPUBDATA_KOSIS_API_KEY` — optional, bronze-only in v0.2
 
 Rotation procedure:
 
@@ -115,12 +115,12 @@ Response checklist:
 ## Manual ad-hoc commands
 
 ```bash
-export ECOS_API_KEY="..."
-export KOSIS_API_KEY="..." # optional
+export KPUBDATA_BOK_API_KEY="..."
+export KPUBDATA_KOSIS_API_KEY="..." # optional
 SNAPSHOT_ID="snapshot-$(date -u +%Y%m%dT%H%M%SZ)"
 
 uv run --python 3.12 kospi-pipeline ingest --live --source krx --dataset kospi_index --from 2024-01-01 --to 2025-03-31 --snapshot-id "$SNAPSHOT_ID" --out data/bronze
-uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from 2024-01-01 --to 2025-03-31 --snapshot-id "$SNAPSHOT_ID" --api-key "$ECOS_API_KEY" --out data/bronze
+uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset base_rate --from 2024-01-01 --to 2025-03-31 --snapshot-id "$SNAPSHOT_ID" --out data/bronze
 uv run --python 3.12 kospi-pipeline build-features --layer all --from 2024-01-01 --to 2025-03-31 --bronze-dir "data/bronze/$SNAPSHOT_ID" --silver-dir "data/silver/$SNAPSHOT_ID" --out "data/gold/$SNAPSHOT_ID"
 uv run --python 3.12 kospi-pipeline run --features "data/gold/$SNAPSHOT_ID/decision_features.parquet" --out "data/decisions/$SNAPSHOT_ID"
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,13 +10,13 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "abdp @ git+https://github.com/yeongseon/agent-based-decision-pipeline.git@9520cfed7e150f644fb5d01bb1a9b32eb0082f8d",
+  "click>=8",
   "pydantic>=2",
   "pyyaml",
   "pyarrow",
   "pandas",
   "httpx>=0.27",
-  "kpubdata>=0",
-  "pykrx>=1.0.51",
+  "kpubdata[krx]>=0.5.0",
   "setuptools<81",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -123,6 +123,18 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -503,12 +515,12 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "abdp" },
+    { name = "click" },
     { name = "httpx" },
-    { name = "kpubdata" },
+    { name = "kpubdata", extra = ["krx"] },
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pydantic" },
-    { name = "pykrx" },
     { name = "pyyaml" },
     { name = "setuptools" },
 ]
@@ -531,14 +543,14 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "abdp", git = "https://github.com/yeongseon/agent-based-decision-pipeline.git?rev=9520cfed7e150f644fb5d01bb1a9b32eb0082f8d" },
+    { name = "click", specifier = ">=8" },
     { name = "httpx", specifier = ">=0.27" },
-    { name = "kpubdata", specifier = ">=0" },
+    { name = "kpubdata", extras = ["krx"], specifier = ">=0.5.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
     { name = "pandas" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2" },
-    { name = "pykrx", specifier = ">=1.0.51" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5" },
     { name = "pyyaml" },
@@ -553,14 +565,19 @@ dev = [{ name = "pandas-stubs", specifier = ">=3.0.0.260204" }]
 
 [[package]]
 name = "kpubdata"
-version = "0.4.0"
+version = "0.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/00/53f4beec4770b7588c7df079cd0b1ecfe1ceedca2870cb4220296073604f/kpubdata-0.4.0.tar.gz", hash = "sha256:6cec6c30718597f371727ab3068184d45500c8323dd1942c1a33e6cad9c78d53", size = 335150, upload-time = "2026-04-23T15:12:55.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/58/2f0a8d1b4ec6cd8152f951ffc5849c64628b10a0ee81f890ea3c97ba8fda/kpubdata-0.5.0.tar.gz", hash = "sha256:89e9b60afdc4c2f129b17207dc16c8531fbfdd1d7ef2048e4a1e0282c24c4905", size = 434771, upload-time = "2026-04-27T15:36:01.894Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/0e/2c6b8c03bee28335dd1da7f4be268dfe0120cb21210a51612e0147f5f677/kpubdata-0.4.0-py3-none-any.whl", hash = "sha256:6dfd7bcaab5dc991a25990b7db7fb9fd3686150c82a13da77e16d14a98975702", size = 89421, upload-time = "2026-04-23T15:12:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/88/47574191c71ca22a840cfde858854f908c62f3b0609a2c8a98b554b96b65/kpubdata-0.5.0-py3-none-any.whl", hash = "sha256:e0c5d49bdd6abd5a4138f2d3945bd39ff0c3db926f6050ad17a009854192cf67", size = 104145, upload-time = "2026-04-27T15:36:00.024Z" },
+]
+
+[package.optional-dependencies]
+krx = [
+    { name = "pykrx" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `connectors/client_factory.py` with strict `KPUBDATA_BOK_API_KEY` / `KPUBDATA_KOSIS_API_KEY` validation and `Client.from_env()` construction
- remove the apps/kr-kospi CLI `--api-key` surface and migrate live connector env lookups/tests to the `KPUBDATA_*` namespace without legacy fallback
- update dependency/runtime docs and live-smoke workflow to use `kpubdata[krx]>=0.5.0` and `KPUBDATA_*` auth variables

## Acceptance Criteria
- [x] `pyproject.toml` uses `kpubdata[krx]>=0.5.0` for apps/kr-kospi runtime dependencies
- [x] added `apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/client_factory.py`
- [x] `build_client()` validates missing BOK/KOSIS keys in one `click.ClickException` message and returns `Client.from_env()`
- [x] `.env.example` migrated to `KPUBDATA_BOK_API_KEY` and `KPUBDATA_KOSIS_API_KEY`
- [x] old vars are no longer read by app-side validation / `_secrets.py` mapping
- [x] CLI `--api-key` flag removed from apps/kr-kospi and tests updated instead of deleted
- [x] `_secrets.py` and `_http.py` kept in place
- [x] unit tests cover missing-both, missing-one, success, and `kpubdata.Client` instance behavior
- [x] mypy strict, ruff, and coverage verification passed locally

## Verification
```text
uv run --python 3.12 --extra dev python -m pytest -m "not integration"
466 passed, 9 skipped

uv run --python 3.12 --extra dev python -m pytest --cov --cov-report=term-missing -m "not integration"
466 passed, 9 skipped
TOTAL 100%
client_factory.py 100%

uv run --python 3.12 --extra dev ruff check . && uv run --python 3.12 --extra dev ruff format --check .
All checks passed!
117 files already formatted

uv run --python 3.12 --extra dev mypy --strict apps/kr-kospi/src apps/kr-kospi/tests
Success: no issues found in 54 source files
```

## Review Notes
- Oracle goal/constraint review: PASS
- Oracle code quality review: PASS
- Oracle security review: PASS
- QA fallback executed locally because the QA subagent failed to start; verified `test_client_factory.py`, `kospi-pipeline ingest --help` (no `--api-key`), and representative CLI tests