### PR TITLE
v0.3-3: Migrate ECOS + KOSIS connectors to kpubdata.Client (#62)

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -283,8 +283,8 @@ jobs:
               --folds-config "${fixture_runtime}/config/folds.yaml"
           }
 
-          if [[ -z "${KPUBDATA_BOK_API_KEY:-}" ]]; then
-            echo "::warning title=Live smoke skipped::KPUBDATA_BOK_API_KEY is not configured. Running pure-fixture CLI smoke instead."
+          if [[ -z "${KPUBDATA_BOK_API_KEY:-}" || -z "${KPUBDATA_KOSIS_API_KEY:-}" ]]; then
+            echo "::warning title=Live smoke skipped::KPUBDATA_BOK_API_KEY and KPUBDATA_KOSIS_API_KEY are both required for kpubdata-backed live smoke. Running pure-fixture CLI smoke instead."
             run_fixture_smoke
             exit 0
           fi
@@ -319,12 +319,8 @@ jobs:
           uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset usd_krw --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
           uv run --python 3.12 kospi-pipeline ingest --live --source ecos --dataset bond_yield --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
 
-          if [[ -n "${KPUBDATA_KOSIS_API_KEY:-}" ]]; then
-            header "Live ingest: KOSIS bronze-only"
-            uv run --python 3.12 kospi-pipeline ingest --live --source kosis --dataset macro_indicators --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
-          else
-            echo "::warning title=KOSIS skipped::KPUBDATA_KOSIS_API_KEY is not configured. Skipping bronze-only KOSIS ingest for this run."
-          fi
+          header "Live ingest: KOSIS bronze-only"
+          uv run --python 3.12 kospi-pipeline ingest --live --source kosis --dataset macro_indicators --from "${LIVE_START}" --to "${LIVE_END}" --snapshot-id "${SNAPSHOT_ID}" --out "${BRONZE_ROOT}"
 
           header "Build silver and gold"
           uv run --python 3.12 kospi-pipeline build-features \

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/__init__.py
@@ -15,7 +15,7 @@ from .fixture import (
 )
 from .kosis import KosisConnector, KosisMacroIndicatorRow, PerPbrPercentileRow
 from .krx import InvestorFlowRow, KospiIndexRow, KrxConnector, MarketValuationRow, PykrxKrxConnector
-from .registry import LiveConnectorRegistry, resolve_live_api_key
+from .registry import LiveConnectorRegistry
 
 __all__ = [
     "ConnectorRow",
@@ -40,5 +40,4 @@ __all__ = [
     "PykrxKrxConnector",
     "LiveConnectorRegistry",
     "SourceMetadata",
-    "resolve_live_api_key",
 ]

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -8,7 +8,6 @@ import hashlib
 from typing import Protocol, TypedDict, cast, final, runtime_checkable
 
 from kpubdata import Client
-from kpubdata.core.models import Query
 
 from .base import ConnectorRowBase, SourceMetadata
 
@@ -51,10 +50,6 @@ class _EcosResponseRow(TypedDict):
     DATA_VALUE: str
 
 
-class _BatchLike(Protocol):
-    items: Sequence[Mapping[str, object]]
-
-
 @final
 class LiveEcosConnector:
     _client: Client
@@ -84,15 +79,14 @@ class LiveEcosConnector:
         start: date,
         end: date,
     ) -> tuple[Mapping[str, object], ...]:
-        batch = _query_record_batch(
-            dataset=self._client.dataset(dataset_id),
-            query=Query(
-                start_date=start.isoformat(),
-                end_date=end.isoformat(),
-                extra={"frequency": _ECOS_DAILY_CYCLE},
-            ),
+        batch = self._client.dataset(dataset_id).list(
+            filters={
+                "start_date": start.isoformat(),
+                "end_date": end.isoformat(),
+                "frequency": _ECOS_DAILY_CYCLE,
+            }
         )
-        return tuple(batch.items)
+        return tuple(cast(Sequence[Mapping[str, object]], batch.items))
 
     def _fetched_at_utc(self) -> str:
         return self._now().replace(microsecond=0).isoformat()
@@ -242,23 +236,6 @@ def _provider_keys(client: Client) -> Mapping[str, str] | None:
         if isinstance(key, str) and isinstance(value, str):
             typed_items.append((key, value))
     return dict(typed_items)
-
-
-def _query_record_batch(dataset: object, query: Query) -> _BatchLike:
-    query_records = getattr(dataset, "query_records", None)
-    if callable(query_records):
-        return cast(_BatchLike, query_records(query))
-
-    list_records = getattr(dataset, "list", None)
-    if callable(list_records):
-        list_kwargs: dict[str, object] = {
-            "start_date": query.start_date,
-            "end_date": query.end_date,
-            "frequency": cast(str, query.extra["frequency"]),
-        }
-        return cast(_BatchLike, list_records(**list_kwargs))
-
-    raise TypeError("kpubdata dataset must provide query_records(Query) or list(...)")
 
 
 def _utc_now() -> datetime:

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
 import hashlib
-import os
-from typing import Callable, Mapping, Protocol, TypedDict, cast, final, runtime_checkable
+from typing import Protocol, TypedDict, cast, final, runtime_checkable
 
-import httpx
+from kpubdata import Client
+from kpubdata.core.models import Query
 
-from ._http import HttpRetryPolicy, SyncHttpRequester
-from ._secrets import resolve_live_api_key
 from .base import ConnectorRowBase, SourceMetadata
 
 
@@ -42,21 +41,9 @@ class EcosConnector(Protocol):
     def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]: ...
 
 
-_ECOS_API_BASE_URL = "https://ecos.bok.or.kr"
-_ECOS_RESULT_OK = "INFO-000"
-_ECOS_FORMAT = "json"
-_ECOS_LANGUAGE = "kr"
-_ECOS_START_ROW = 1
-_ECOS_END_ROW = 100000
-_ECOS_DAILY_CYCLE = "D"
 _ECOS_API_VERSION = "StatisticSearch"
+_ECOS_DAILY_CYCLE = "D"
 _LIVE_CONNECTOR_ID = "kospi_decision_pipeline_app_kr_kospi.connectors.ecos.LiveEcosConnector"
-
-
-@dataclass(frozen=True, slots=True)
-class _EcosSeriesDefinition:
-    stat_code: str
-    item_code1: str
 
 
 class _EcosResponseRow(TypedDict):
@@ -64,86 +51,57 @@ class _EcosResponseRow(TypedDict):
     DATA_VALUE: str
 
 
-_BASE_RATE_SERIES = _EcosSeriesDefinition(
-    stat_code="722Y001",
-    item_code1="0101000",
-)
-_USD_KRW_SERIES = _EcosSeriesDefinition(
-    stat_code="731Y003",
-    item_code1="0000003",
-)
-_BOND_YIELD_SERIES = _EcosSeriesDefinition(
-    stat_code="817Y002",
-    item_code1="010200000",
-)
+class _BatchLike(Protocol):
+    items: Sequence[Mapping[str, object]]
 
 
 @final
 class LiveEcosConnector:
-    _api_key: str
-    _key_fingerprint_sha256: str
-    _http_requester: SyncHttpRequester
-    _transport: httpx.BaseTransport | None
+    _client: Client
+    _key_fingerprint_sha256: str | None
     _now: Callable[[], datetime]
 
-    def __init__(
-        self,
-        api_key: str | None = None,
-        *,
-        environment: Mapping[str, str] | None = None,
-        transport: httpx.BaseTransport | None = None,
-        retry_policy: HttpRetryPolicy | None = None,
-        sleep: Callable[[float], None] | None = None,
-        now: Callable[[], datetime] | None = None,
-    ) -> None:
-        self._api_key = cast(
-            str,
-            resolve_live_api_key(
-                source="ecos",
-                api_key=api_key,
-                environment=environment or os.environ,
-            ),
-        )
-        self._key_fingerprint_sha256 = hashlib.sha256(self._api_key.encode("utf-8")).hexdigest()[
-            :16
-        ]
-        self._http_requester = SyncHttpRequester(retry_policy, sleep=sleep or _default_sleep)
-        self._transport = transport
+    def __init__(self, *, client: Client, now: Callable[[], datetime] | None = None) -> None:
+        self._client = client
+        self._key_fingerprint_sha256 = _provider_key_fingerprint_sha256(client, "bok")
         self._now = now or _utc_now
 
     def fetch_base_rate_series(self, start: date, end: date) -> tuple[EcosBaseRateRow, ...]:
-        payload = self._fetch_payload(_BASE_RATE_SERIES, start, end)
-        return parse_base_rate_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+        rows = self._query_series("bok.base_rate", start, end)
+        return parse_base_rate_rows(rows, self._fetched_at_utc(), self._key_fingerprint_sha256)
 
     def fetch_usd_krw_series(self, start: date, end: date) -> tuple[EcosUsdKrwRow, ...]:
-        payload = self._fetch_payload(_USD_KRW_SERIES, start, end)
-        return parse_usd_krw_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+        rows = self._query_series("bok.usd_krw", start, end)
+        return parse_usd_krw_rows(rows, self._fetched_at_utc(), self._key_fingerprint_sha256)
 
     def fetch_bond_yield_series(self, start: date, end: date) -> tuple[EcosBondYieldRow, ...]:
-        payload = self._fetch_payload(_BOND_YIELD_SERIES, start, end)
-        return parse_bond_yield_rows(payload, self._fetched_at_utc(), self._key_fingerprint_sha256)
+        rows = self._query_series("bok.bond_yield_3y", start, end)
+        return parse_bond_yield_rows(rows, self._fetched_at_utc(), self._key_fingerprint_sha256)
 
-    def _fetch_payload(self, definition: _EcosSeriesDefinition, start: date, end: date) -> object:
-        path = _statistic_search_path(
-            api_key=self._api_key,
-            stat_code=definition.stat_code,
-            start=start,
-            end=end,
-            item_code1=definition.item_code1,
+    def _query_series(
+        self,
+        dataset_id: str,
+        start: date,
+        end: date,
+    ) -> tuple[Mapping[str, object], ...]:
+        batch = _query_record_batch(
+            dataset=self._client.dataset(dataset_id),
+            query=Query(
+                start_date=start.isoformat(),
+                end_date=end.isoformat(),
+                extra={"frequency": _ECOS_DAILY_CYCLE},
+            ),
         )
-        with httpx.Client(
-            base_url=_ECOS_API_BASE_URL,
-            timeout=httpx.Timeout(self._http_requester.retry_policy.timeout_seconds),
-            transport=self._transport,
-        ) as client:
-            return self._http_requester.get(client, path)
+        return tuple(batch.items)
 
     def _fetched_at_utc(self) -> str:
         return self._now().replace(microsecond=0).isoformat()
 
 
 def parse_base_rate_rows(
-    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+    payload: object,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str | None,
 ) -> tuple[EcosBaseRateRow, ...]:
     metadata = _source_metadata("base_rate", fetched_at_utc, key_fingerprint_sha256)
     return tuple(
@@ -162,7 +120,9 @@ def parse_base_rate_rows(
 
 
 def parse_usd_krw_rows(
-    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+    payload: object,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str | None,
 ) -> tuple[EcosUsdKrwRow, ...]:
     metadata = _source_metadata("usd_krw", fetched_at_utc, key_fingerprint_sha256)
     return tuple(
@@ -181,7 +141,9 @@ def parse_usd_krw_rows(
 
 
 def parse_bond_yield_rows(
-    payload: object, fetched_at_utc: str, key_fingerprint_sha256: str
+    payload: object,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str | None,
 ) -> tuple[EcosBondYieldRow, ...]:
     metadata = _source_metadata("bond_yield", fetched_at_utc, key_fingerprint_sha256)
     return tuple(
@@ -201,7 +163,9 @@ def parse_bond_yield_rows(
 
 
 def _source_metadata(
-    dataset_name: str, fetched_at_utc: str, key_fingerprint_sha256: str
+    dataset_name: str,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str | None,
 ) -> SourceMetadata:
     return SourceMetadata(
         source_name="ecos",
@@ -214,40 +178,30 @@ def _source_metadata(
 
 
 def _ecos_rows(payload: object) -> tuple[_EcosResponseRow, ...]:
-    statistic_search = _require_nested_mapping(_require_payload_mapping(payload), "StatisticSearch")
-    result = _require_nested_mapping(statistic_search, "RESULT")
-    result_code = _require_string(result, "CODE")
-    if result_code != _ECOS_RESULT_OK:
-        message = _require_string(result, "MESSAGE")
-        if "인증" in message or result_code.startswith("ERROR-3"):
-            raise PermissionError(f"ECOS authentication failed: {result_code}: {message}")
-        raise RuntimeError(f"ECOS request failed: {result_code}: {message}")
-    raw_rows = statistic_search.get("row")
-    if raw_rows is None:
-        return ()
     rows: list[_EcosResponseRow] = []
-    for raw_row in _require_object_list(raw_rows, "row"):
-        mapping = _require_payload_mapping(raw_row)
+    for raw_row in _require_record_sequence(payload, "ECOS record batch payload"):
         rows.append(
             {
-                "TIME": _require_string(mapping, "TIME"),
-                "DATA_VALUE": _require_string(mapping, "DATA_VALUE"),
+                "TIME": _require_string(raw_row, "TIME"),
+                "DATA_VALUE": _require_string(raw_row, "DATA_VALUE"),
             }
         )
     return tuple(rows)
 
 
-def _require_payload_mapping(payload: object) -> Mapping[str, object]:
-    if isinstance(payload, dict):
-        return cast(dict[str, object], payload)
-    raise ValueError("ECOS payload must be a JSON object")
-
-
-def _require_nested_mapping(mapping: Mapping[str, object], key: str) -> Mapping[str, object]:
-    nested = mapping.get(key)
-    if isinstance(nested, dict):
-        return cast(dict[str, object], nested)
-    raise ValueError(f"missing ECOS mapping field: {key}")
+def _require_record_sequence(
+    payload: object,
+    message: str,
+) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(payload, Sequence) or isinstance(payload, str | bytes | bytearray):
+        raise ValueError(message)
+    raw_payload = cast(Sequence[object], payload)
+    rows: list[Mapping[str, object]] = []
+    for raw_row in raw_payload:
+        if not isinstance(raw_row, Mapping):
+            raise ValueError("ECOS record payload must be an object")
+        rows.append(cast(Mapping[str, object], raw_row))
+    return tuple(rows)
 
 
 def _require_string(mapping: Mapping[str, object], key: str) -> str:
@@ -255,12 +209,6 @@ def _require_string(mapping: Mapping[str, object], key: str) -> str:
     if not isinstance(value, str):
         raise ValueError(f"missing ECOS string field: {key}")
     return value
-
-
-def _require_object_list(payload: object, key: str) -> tuple[object, ...]:
-    if isinstance(payload, list):
-        return tuple(cast(list[object], payload))
-    raise ValueError(f"ECOS {key} payload must be a list")
 
 
 def _parse_ecos_date(value: str) -> date:
@@ -271,21 +219,47 @@ def _parse_decimal(value: str) -> Decimal:
     return Decimal(value)
 
 
-def _statistic_search_path(
-    *, api_key: str, stat_code: str, start: date, end: date, item_code1: str
-) -> str:
-    return (
-        f"/api/StatisticSearch/{api_key}/{_ECOS_FORMAT}/{_ECOS_LANGUAGE}/"
-        f"{_ECOS_START_ROW}/{_ECOS_END_ROW}/{stat_code}/{_ECOS_DAILY_CYCLE}/"
-        f"{start.strftime('%Y%m%d')}/{end.strftime('%Y%m%d')}/{item_code1}"
-    )
+def _provider_key_fingerprint_sha256(client: Client, provider: str) -> str | None:
+    provider_keys = _provider_keys(client)
+    if provider_keys is None:
+        return None
+    provider_key = provider_keys.get(provider)
+    if not isinstance(provider_key, str) or provider_key == "":
+        return None
+    return hashlib.sha256(provider_key.encode("utf-8")).hexdigest()[:16]
+
+
+def _provider_keys(client: Client) -> Mapping[str, str] | None:
+    config = getattr(client, "_config", None)
+    if config is None:
+        return None
+    provider_keys = getattr(config, "provider_keys", None)
+    if not isinstance(provider_keys, Mapping):
+        return None
+    typed_provider_keys = cast(Mapping[object, object], provider_keys)
+    typed_items: list[tuple[str, str]] = []
+    for key, value in typed_provider_keys.items():
+        if isinstance(key, str) and isinstance(value, str):
+            typed_items.append((key, value))
+    return dict(typed_items)
+
+
+def _query_record_batch(dataset: object, query: Query) -> _BatchLike:
+    query_records = getattr(dataset, "query_records", None)
+    if callable(query_records):
+        return cast(_BatchLike, query_records(query))
+
+    list_records = getattr(dataset, "list", None)
+    if callable(list_records):
+        list_kwargs: dict[str, object] = {
+            "start_date": query.start_date,
+            "end_date": query.end_date,
+            "frequency": cast(str, query.extra["frequency"]),
+        }
+        return cast(_BatchLike, list_records(**list_kwargs))
+
+    raise TypeError("kpubdata dataset must provide query_records(Query) or list(...)")
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _default_sleep(seconds: float) -> None:
-    from time import sleep
-
-    sleep(seconds)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/ecos.py
@@ -80,11 +80,9 @@ class LiveEcosConnector:
         end: date,
     ) -> tuple[Mapping[str, object], ...]:
         batch = self._client.dataset(dataset_id).list(
-            filters={
-                "start_date": start.isoformat(),
-                "end_date": end.isoformat(),
-                "frequency": _ECOS_DAILY_CYCLE,
-            }
+            start_date=start.isoformat(),
+            end_date=end.isoformat(),
+            frequency=_ECOS_DAILY_CYCLE,
         )
         return tuple(cast(Sequence[Mapping[str, object]], batch.items))
 

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -1,19 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
 import hashlib
-import os
-from typing import Callable, Mapping, Protocol, cast, final, runtime_checkable
-from urllib.parse import urlencode
+from typing import Protocol, cast, final, runtime_checkable
 
-import httpx
+from kpubdata import Client
+from kpubdata.core.models import Query
+from kpubdata.exceptions import DatasetNotFoundError
 
-from ._http import HttpRequestError, HttpRetryPolicy, SyncHttpRequester
-from ._secrets import resolve_live_api_key
-from .base import ConnectorRowBase
-from .base import SourceMetadata
+from .base import ConnectorRowBase, SourceMetadata
 
 
 class UnsupportedDatasetError(ValueError):
@@ -46,72 +44,23 @@ class KosisConnector(Protocol):
     ) -> tuple[KosisMacroIndicatorRow, ...]: ...
 
 
-_KOSIS_API_BASE_URL = "https://kosis.kr"
-_KOSIS_API_PATH = "/openapi/Param/statisticsParameterData.do"
-_KOSIS_API_METHOD = "getList"
-_KOSIS_API_FORMAT = "json"
-_KOSIS_JSON_VD = "Y"
 _KOSIS_API_VERSION = "getList"
 _LIVE_CONNECTOR_ID = "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector"
 
 
-@dataclass(frozen=True, slots=True)
-class _KosisSeriesDefinition:
-    dataset_name: str
-    org_id: str
-    table_id: str
-    item_id: str
-    object_level_1: str
-    period_type: str
-    series_name: str
-    unit: str
-
-
-_MACRO_INDICATORS_SERIES = _KosisSeriesDefinition(
-    dataset_name="macro_indicators",
-    org_id="101",
-    table_id="DT_1J22003",
-    item_id="T",
-    object_level_1="T10",
-    period_type="M",
-    series_name="T10",
-    unit="",
-)
+class _BatchLike(Protocol):
+    items: Sequence[Mapping[str, object]]
 
 
 @final
 class LiveKosisConnector:
-    _api_key: str
-    _key_fingerprint_sha256: str
-    _http_requester: SyncHttpRequester
-    _environment: Mapping[str, str]
-    _transport: httpx.BaseTransport | None
+    _client: Client
+    _key_fingerprint_sha256: str | None
     _now: Callable[[], datetime]
 
-    def __init__(
-        self,
-        api_key: str | None = None,
-        *,
-        environment: Mapping[str, str] | None = None,
-        transport: httpx.BaseTransport | None = None,
-        retry_policy: HttpRetryPolicy | None = None,
-        sleep: Callable[[float], None] | None = None,
-        now: Callable[[], datetime] | None = None,
-    ) -> None:
-        self._environment = environment or os.environ
-        self._api_key = cast(
-            str,
-            resolve_live_api_key(
-                source="kosis",
-                api_key=api_key,
-                environment=self._environment,
-            ),
-        )
-        self._key_fingerprint_sha256 = hashlib.sha256(self._api_key.encode("utf-8")).hexdigest()[
-            :16
-        ]
-        self._http_requester = SyncHttpRequester(retry_policy, sleep=sleep or _default_sleep)
-        self._transport = transport
+    def __init__(self, *, client: Client, now: Callable[[], datetime] | None = None) -> None:
+        self._client = client
+        self._key_fingerprint_sha256 = _provider_key_fingerprint_sha256(client, "kosis")
         self._now = now or _utc_now
 
     def fetch_per_pbr_percentiles(self, start: date, end: date) -> tuple[PerPbrPercentileRow, ...]:
@@ -122,43 +71,24 @@ class LiveKosisConnector:
         )
 
     def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
-        payload = self._fetch_payload(_MACRO_INDICATORS_SERIES, start, end)
+        try:
+            batch = _query_record_batch(
+                dataset=self._client.dataset("kosis.industrial_production"),
+                query=Query(start_date=start.isoformat(), end_date=end.isoformat()),
+            )
+        except DatasetNotFoundError as error:
+            raise UnsupportedDatasetError(
+                "KOSIS live ingest requires kpubdata dataset kosis.industrial_production"
+            ) from error
+
         return parse_macro_indicator_rows(
-            payload=payload,
-            dataset_name=_MACRO_INDICATORS_SERIES.dataset_name,
+            payload=batch.items,
+            dataset_name="macro_indicators",
             fetched_at_utc=self._fetched_at_utc(),
             key_fingerprint_sha256=self._key_fingerprint_sha256,
-            series_name=_MACRO_INDICATORS_SERIES.series_name,
-            unit=_MACRO_INDICATORS_SERIES.unit,
+            series_name="T10",
+            unit="",
         )
-
-    def _fetch_payload(self, definition: _KosisSeriesDefinition, start: date, end: date) -> object:
-        params = {
-            "method": _KOSIS_API_METHOD,
-            "apiKey": self._api_key,
-            "format": _KOSIS_API_FORMAT,
-            "jsonVD": _KOSIS_JSON_VD,
-            "orgId": definition.org_id,
-            "tblId": definition.table_id,
-            "itmId": definition.item_id,
-            "objL1": definition.object_level_1,
-            "prdSe": definition.period_type,
-            "startPrdDe": _format_period(start, definition.period_type),
-            "endPrdDe": _format_period(end, definition.period_type),
-        }
-        path = f"{_KOSIS_API_PATH}?{urlencode(params)}"
-        try:
-            with httpx.Client(
-                base_url=_KOSIS_API_BASE_URL,
-                timeout=httpx.Timeout(self._http_requester.retry_policy.timeout_seconds),
-                transport=self._transport,
-            ) as client:
-                return self._http_requester.get(client, path)
-        except HttpRequestError as error:
-            message = str(error)
-            if message.startswith("HTTP 401") or message.startswith("HTTP 403"):
-                raise PermissionError(f"KOSIS authentication failed: {message}") from error
-            raise
 
     def _fetched_at_utc(self) -> str:
         return self._now().replace(microsecond=0).isoformat()
@@ -169,7 +99,7 @@ def parse_macro_indicator_rows(
     payload: object,
     dataset_name: str,
     fetched_at_utc: str,
-    key_fingerprint_sha256: str,
+    key_fingerprint_sha256: str | None,
     series_name: str,
     unit: str,
 ) -> tuple[KosisMacroIndicatorRow, ...]:
@@ -191,7 +121,9 @@ def parse_macro_indicator_rows(
 
 
 def _source_metadata(
-    dataset_name: str, fetched_at_utc: str, key_fingerprint_sha256: str
+    dataset_name: str,
+    fetched_at_utc: str,
+    key_fingerprint_sha256: str | None,
 ) -> SourceMetadata:
     return SourceMetadata(
         source_name="kosis",
@@ -204,13 +136,14 @@ def _source_metadata(
 
 
 def _kosis_rows(payload: object) -> tuple[Mapping[str, object], ...]:
-    if not isinstance(payload, list):
-        raise ValueError("KOSIS payload must be a JSON array")
+    if not isinstance(payload, Sequence) or isinstance(payload, str | bytes | bytearray):
+        raise ValueError("KOSIS record batch payload must be a sequence")
+    raw_payload = cast(Sequence[object], payload)
     rows: list[Mapping[str, object]] = []
-    for raw_row in cast(list[object], payload):
-        if not isinstance(raw_row, dict):
-            raise ValueError("KOSIS row payload must be a JSON object")
-        rows.append(cast(dict[str, object], raw_row))
+    for raw_row in raw_payload:
+        if not isinstance(raw_row, Mapping):
+            raise ValueError("KOSIS record payload must be an object")
+        rows.append(cast(Mapping[str, object], raw_row))
     return tuple(rows)
 
 
@@ -236,17 +169,45 @@ def _parse_kosis_period(value: str) -> date:
     return date.fromisoformat(f"{value[0:4]}-{value[4:6]}-01")
 
 
-def _format_period(value: date, period_type: str) -> str:
-    if period_type != "M":
-        raise ValueError(f"unsupported KOSIS period type: {period_type}")
-    return value.strftime("%Y%m")
+def _provider_key_fingerprint_sha256(client: Client, provider: str) -> str | None:
+    provider_keys = _provider_keys(client)
+    if provider_keys is None:
+        return None
+    provider_key = provider_keys.get(provider)
+    if not isinstance(provider_key, str) or provider_key == "":
+        return None
+    return hashlib.sha256(provider_key.encode("utf-8")).hexdigest()[:16]
+
+
+def _provider_keys(client: Client) -> Mapping[str, str] | None:
+    config = getattr(client, "_config", None)
+    if config is None:
+        return None
+    provider_keys = getattr(config, "provider_keys", None)
+    if not isinstance(provider_keys, Mapping):
+        return None
+    typed_provider_keys = cast(Mapping[object, object], provider_keys)
+    typed_items: list[tuple[str, str]] = []
+    for key, value in typed_provider_keys.items():
+        if isinstance(key, str) and isinstance(value, str):
+            typed_items.append((key, value))
+    return dict(typed_items)
+
+
+def _query_record_batch(dataset: object, query: Query) -> _BatchLike:
+    query_records = getattr(dataset, "query_records", None)
+    if callable(query_records):
+        return cast(_BatchLike, query_records(query))
+
+    list_records = getattr(dataset, "list", None)
+    if callable(list_records):
+        return cast(
+            _BatchLike,
+            list_records(start_date=query.start_date, end_date=query.end_date),
+        )
+
+    raise TypeError("kpubdata dataset must provide query_records(Query) or list(...)")
 
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _default_sleep(seconds: float) -> None:
-    from time import sleep
-
-    sleep(seconds)

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -8,7 +8,6 @@ import hashlib
 from typing import Protocol, cast, final, runtime_checkable
 
 from kpubdata import Client
-from kpubdata.core.models import Query
 from kpubdata.exceptions import DatasetNotFoundError
 
 from .base import ConnectorRowBase, SourceMetadata
@@ -48,10 +47,6 @@ _KOSIS_API_VERSION = "getList"
 _LIVE_CONNECTOR_ID = "kospi_decision_pipeline_app_kr_kospi.connectors.kosis.LiveKosisConnector"
 
 
-class _BatchLike(Protocol):
-    items: Sequence[Mapping[str, object]]
-
-
 @final
 class LiveKosisConnector:
     _client: Client
@@ -72,9 +67,11 @@ class LiveKosisConnector:
 
     def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
         try:
-            batch = _query_record_batch(
-                dataset=self._client.dataset("kosis.industrial_production"),
-                query=Query(start_date=start.isoformat(), end_date=end.isoformat()),
+            batch = self._client.dataset("kosis.industrial_production").list(
+                filters={
+                    "start_date": start.isoformat(),
+                    "end_date": end.isoformat(),
+                }
             )
         except DatasetNotFoundError as error:
             raise UnsupportedDatasetError(
@@ -82,7 +79,7 @@ class LiveKosisConnector:
             ) from error
 
         return parse_macro_indicator_rows(
-            payload=batch.items,
+            payload=cast(Sequence[Mapping[str, object]], batch.items),
             dataset_name="macro_indicators",
             fetched_at_utc=self._fetched_at_utc(),
             key_fingerprint_sha256=self._key_fingerprint_sha256,
@@ -192,21 +189,6 @@ def _provider_keys(client: Client) -> Mapping[str, str] | None:
         if isinstance(key, str) and isinstance(value, str):
             typed_items.append((key, value))
     return dict(typed_items)
-
-
-def _query_record_batch(dataset: object, query: Query) -> _BatchLike:
-    query_records = getattr(dataset, "query_records", None)
-    if callable(query_records):
-        return cast(_BatchLike, query_records(query))
-
-    list_records = getattr(dataset, "list", None)
-    if callable(list_records):
-        return cast(
-            _BatchLike,
-            list_records(start_date=query.start_date, end_date=query.end_date),
-        )
-
-    raise TypeError("kpubdata dataset must provide query_records(Query) or list(...)")
 
 
 def _utc_now() -> datetime:

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/kosis.py
@@ -68,10 +68,8 @@ class LiveKosisConnector:
     def fetch_macro_indicators(self, start: date, end: date) -> tuple[KosisMacroIndicatorRow, ...]:
         try:
             batch = self._client.dataset("kosis.industrial_production").list(
-                filters={
-                    "start_date": start.isoformat(),
-                    "end_date": end.isoformat(),
-                }
+                start_date=start.isoformat(),
+                end_date=end.isoformat(),
             )
         except DatasetNotFoundError as error:
             raise UnsupportedDatasetError(

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import os
-from collections.abc import Mapping
 from typing import final
 
-from ._secrets import resolve_live_api_key
+from . import client_factory
 from .ecos import LiveEcosConnector
 from .kosis import LiveKosisConnector
 from .krx import PykrxKrxConnector
@@ -12,33 +10,18 @@ from .krx import PykrxKrxConnector
 
 @final
 class LiveConnectorRegistry:
-    _environment: Mapping[str, str]
-
-    def __init__(self, environment: Mapping[str, str] | None = None) -> None:
-        self._environment = environment or os.environ
+    def __init__(self) -> None:
+        pass
 
     def get_connector(self, source: str, *, api_key: str | None = None) -> object:
+        del api_key
         if source == "krx":
             return PykrxKrxConnector()
         if source == "ecos":
-            return LiveEcosConnector(
-                api_key=resolve_live_api_key(
-                    source=source,
-                    api_key=api_key,
-                    environment=self._environment,
-                ),
-                environment=self._environment,
-            )
+            return LiveEcosConnector(client=client_factory.build_client())
         if source == "kosis":
-            return LiveKosisConnector(
-                api_key=resolve_live_api_key(
-                    source=source,
-                    api_key=api_key,
-                    environment=self._environment,
-                ),
-                environment=self._environment,
-            )
+            return LiveKosisConnector(client=client_factory.build_client())
         raise ValueError(f"unsupported source: {source}")
 
 
-__all__ = ["LiveConnectorRegistry", "resolve_live_api_key"]
+__all__ = ["LiveConnectorRegistry"]

--- a/apps/kr-kospi/tests/contract/test_connector_http_and_secrets.py
+++ b/apps/kr-kospi/tests/contract/test_connector_http_and_secrets.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kospi_decision_pipeline_app_kr_kospi.connectors._http import (
+    HttpRequestError,
+    HttpRetryPolicy,
+    SyncHttpRequester,
+)
+from kospi_decision_pipeline_app_kr_kospi.connectors._secrets import resolve_live_api_key
+
+
+def test_sync_http_requester_returns_json_response() -> None:
+    requester = SyncHttpRequester()
+
+    with httpx.Client(
+        base_url="https://example.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=200, json={"ok": True}, request=request)
+        ),
+    ) as client:
+        payload = requester.get(client, "/ecos")
+
+    assert payload == {"ok": True}
+
+
+def test_sync_http_requester_retries_transport_errors_then_succeeds() -> None:
+    attempts = 0
+    slept: list[float] = []
+    requester = SyncHttpRequester(sleep=slept.append)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(status_code=200, json={"ok": True}, request=request)
+
+    with httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        payload = requester.get(client, "/ecos")
+
+    assert payload == {"ok": True}
+    assert attempts == 2
+    assert slept == [0.5]
+
+
+def test_sync_http_requester_raises_after_max_transport_errors() -> None:
+    requester = SyncHttpRequester(retry_policy=HttpRetryPolicy(max_attempts=1))
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=request)
+
+    with httpx.Client(
+        base_url="https://example.test", transport=httpx.MockTransport(handler)
+    ) as client:
+        with pytest.raises(HttpRequestError, match="1 attempts"):
+            requester.get(client, "/ecos")
+
+
+def test_sync_http_requester_retries_retryable_status_then_raises_after_max_attempts() -> None:
+    slept: list[float] = []
+    requester = SyncHttpRequester(sleep=slept.append)
+
+    with httpx.Client(
+        base_url="https://example.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=503, request=request)
+        ),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="3 attempts"):
+            requester.get(client, "/ecos")
+
+    assert slept == [0.5, 1.0]
+
+
+def test_sync_http_requester_raises_immediately_for_non_retryable_status() -> None:
+    requester = SyncHttpRequester()
+
+    with httpx.Client(
+        base_url="https://example.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=404, request=request)
+        ),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="HTTP 404"):
+            requester.get(client, "/ecos")
+
+
+def test_sync_http_requester_raises_without_attempts_when_max_attempts_is_zero() -> None:
+    requester = SyncHttpRequester(retry_policy=HttpRetryPolicy(max_attempts=0))
+
+    with httpx.Client(
+        base_url="https://example.test",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(status_code=200, json={"ok": True}, request=request)
+        ),
+    ) as client:
+        with pytest.raises(HttpRequestError, match="without response"):
+            requester.get(client, "/ecos")
+
+
+def test_sync_http_requester_exposes_retry_policy_and_backoff_configuration() -> None:
+    policy = HttpRetryPolicy(timeout_seconds=9.0, backoff_base_seconds=0.25)
+    requester = SyncHttpRequester(retry_policy=policy)
+
+    assert requester.retry_policy is policy
+    assert requester.retry_policy.backoff_base_seconds == 0.25
+
+
+def test_resolve_live_api_key_prefers_explicit_over_environment() -> None:
+    assert (
+        resolve_live_api_key(
+            source="ecos",
+            api_key=" explicit-key ",
+            environment={"KPUBDATA_BOK_API_KEY": "env-key"},
+        )
+        == "explicit-key"
+    )
+
+
+def test_resolve_live_api_key_reads_source_specific_environment_key() -> None:
+    assert (
+        resolve_live_api_key(
+            source="kosis",
+            api_key=None,
+            environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"},
+        )
+        == "env-kosis-key"
+    )
+
+
+def test_resolve_live_api_key_returns_none_for_sources_without_api_keys() -> None:
+    assert resolve_live_api_key(source="krx", api_key=None, environment={}) is None
+
+
+@pytest.mark.parametrize(
+    ("source", "message"),
+    [("ecos", "KPUBDATA_BOK_API_KEY"), ("kosis", "KPUBDATA_KOSIS_API_KEY")],
+)
+def test_resolve_live_api_key_requires_expected_environment_variable(
+    source: str,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        resolve_live_api_key(source=source, api_key=None, environment={})

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -1,25 +1,24 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
+import hashlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
-import httpx
 import pytest
+from kpubdata import Client
+from kpubdata.core.models import Query
 
-from kospi_decision_pipeline_app_kr_kospi.connectors._http import (
-    HttpRequestError,
-    HttpRetryPolicy,
-    SyncHttpRequester,
-)
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
-    LiveEcosConnector,
     EcosBaseRateRow,
     EcosBondYieldRow,
     EcosUsdKrwRow,
+    LiveEcosConnector,
     parse_base_rate_rows,
     parse_bond_yield_rows,
     parse_usd_krw_rows,
@@ -29,15 +28,52 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
 FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "ecos"
 START_DATE = date(2024, 1, 2)
 END_DATE = date(2024, 1, 4)
-BASE_RATE_PATH = (
-    "/api/StatisticSearch/test-api-key/json/kr/1/100000/722Y001/D/20240102/20240104/0101000"
-)
-USD_KRW_PATH = (
-    "/api/StatisticSearch/test-api-key/json/kr/1/100000/731Y003/D/20240102/20240104/0000003"
-)
-BOND_YIELD_PATH = (
-    "/api/StatisticSearch/test-api-key/json/kr/1/100000/817Y002/D/20240102/20240104/010200000"
-)
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeRecordBatch:
+    items: tuple[Mapping[str, object], ...]
+
+
+class _FakeDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+        self.queries: list[Query] = []
+
+    def query_records(self, query: Query) -> _FakeRecordBatch:
+        self.queries.append(query)
+        return self._batch
+
+
+class _ListOnlyDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+        self.calls: list[dict[str, object]] = []
+
+    def list(self, **kwargs: object) -> _FakeRecordBatch:
+        self.calls.append(dict(kwargs))
+        return self._batch
+
+
+class _FakeClient:
+    def __init__(self, provider_key: str, datasets: Mapping[str, _FakeDataset]) -> None:
+        self._config = SimpleNamespace(provider_keys={"bok": provider_key})
+        self._datasets = dict(datasets)
+        self.dataset_calls: list[str] = []
+
+    def dataset(self, dataset_id: str) -> _FakeDataset:
+        self.dataset_calls.append(dataset_id)
+        return self._datasets[dataset_id]
+
+
+class _ConfigurableClient:
+    def __init__(self, dataset_id: str, dataset: object, config: object | None) -> None:
+        self._datasets = {dataset_id: dataset}
+        if config is not None:
+            self._config = config
+
+    def dataset(self, dataset_id: str) -> object:
+        return self._datasets[dataset_id]
 
 
 def _load_payload(name: str) -> Mapping[str, object]:
@@ -46,257 +82,123 @@ def _load_payload(name: str) -> Mapping[str, object]:
     )
 
 
-EcosRow = EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow
-
-
 def _load_payload_dict(name: str) -> dict[str, object]:
     return cast(dict[str, object], json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8")))
 
 
-def _json_response(request: httpx.Request, payload: Mapping[str, object]) -> httpx.Response:
-    return httpx.Response(status_code=200, json=payload, request=request)
+def _records_from_payload(name: str) -> tuple[Mapping[str, object], ...]:
+    payload = _load_payload(name)
+    statistic_search = cast(Mapping[str, object], payload["StatisticSearch"])
+    raw_rows = cast(list[Mapping[str, object]], statistic_search["row"])
+    return tuple(raw_rows)
 
 
-def test_live_ecos_connector_fetches_base_rate_rows_from_recorded_payload() -> None:
-    payload = _load_payload("base_rate_statistic_search.json")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == BASE_RATE_PATH
-        return _json_response(request, payload)
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(handler),
-    )
-
-    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
-
-    assert [row.value_date for row in rows] == [START_DATE, date(2024, 1, 3), END_DATE]
-    assert [row.base_rate for row in rows] == [Decimal("3.50"), Decimal("3.50"), Decimal("3.50")]
-    assert rows[0].metadata.source_name == "ecos"
-    assert rows[0].metadata.dataset_name == "base_rate"
-    assert rows[0].metadata.api_version == "StatisticSearch"
-    assert rows[0].metadata.key_fingerprint_sha256 is not None
-    assert len(rows[0].metadata.key_fingerprint_sha256) == 16
-
-
-def test_live_ecos_connector_raises_on_ecos_auth_failure() -> None:
-    payload = {
-        "StatisticSearch": {
-            "RESULT": {"CODE": "ERROR-301", "MESSAGE": "인증키가 유효하지 않습니다."}
-        }
-    }
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
-    )
-
-    with pytest.raises(PermissionError, match="ERROR-301"):
-        connector.fetch_base_rate_series(START_DATE, END_DATE)
-
-
-def test_live_ecos_connector_prefers_explicit_api_key_over_environment() -> None:
-    payload = _load_payload("base_rate_statistic_search.json")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert "explicit-api-key" in request.url.path
-        assert "env-api-key" not in request.url.path
-        return _json_response(request, payload)
-
-    connector = LiveEcosConnector(
-        api_key="explicit-api-key",
-        environment={"KPUBDATA_BOK_API_KEY": "env-api-key"},
-        transport=httpx.MockTransport(handler),
-    )
-
-    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
-
-    assert rows
-
-
-def test_live_ecos_connector_requires_api_key_when_no_auth_source_exists(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("KPUBDATA_BOK_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="ECOS API key"):
-        LiveEcosConnector(environment={})
-
-
-def test_live_ecos_connector_uses_environment_api_key() -> None:
-    payload = _load_payload("usd_krw_statistic_search.json")
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert "env-api-key" in request.url.path
-        return _json_response(request, payload)
-
-    connector = LiveEcosConnector(
-        environment={"KPUBDATA_BOK_API_KEY": "env-api-key"},
-        transport=httpx.MockTransport(handler),
-    )
-
-    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
-
-    assert rows
-
-
-def test_live_ecos_connector_retries_transient_http_failures() -> None:
-    payload = _load_payload("usd_krw_statistic_search.json")
-    attempts = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            return httpx.Response(status_code=503, request=request)
-        return _json_response(request, payload)
-
-    slept: list[float] = []
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(handler),
-        sleep=slept.append,
-    )
-
-    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
-
-    assert attempts == 2
-    assert slept == [0.5]
-    assert [row.exchange_rate for row in rows] == [
-        Decimal("1293.10"),
-        Decimal("1288.40"),
-        Decimal("1290.00"),
-    ]
-
-
-def test_live_ecos_connector_uses_default_sleep_for_retries(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    payload = _load_payload("usd_krw_statistic_search.json")
-    attempts = 0
-    slept: list[float] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            return httpx.Response(status_code=503, request=request)
-        return _json_response(request, payload)
-
-    monkeypatch.setattr("time.sleep", slept.append)
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(handler),
-    )
-
-    rows = connector.fetch_usd_krw_series(START_DATE, END_DATE)
-
-    assert attempts == 2
-    assert slept == [0.5]
-    assert rows
-
-
-def test_live_ecos_connector_fetches_bond_yield_rows() -> None:
-    payload = _load_payload("bond_yield_statistic_search.json")
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
-    )
-
-    rows = connector.fetch_bond_yield_series(START_DATE, END_DATE)
-
-    assert tuple(row.yield_rate for row in rows) == (
-        Decimal("3.23"),
-        Decimal("3.20"),
-        Decimal("3.18"),
-    )
-    assert all(row.maturity_code == "3Y" for row in rows)
+EcosRow = EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow
 
 
 @pytest.mark.parametrize(
-    (
-        "fixture_name",
-        "request_path",
-        "fetcher_name",
-        "dataset_name",
-        "value_attr",
-        "expected_values",
-    ),
+    ("fixture_name", "dataset_id", "fetcher_name", "value_attr", "expected_values"),
     [
         (
             "base_rate_statistic_search.json",
-            BASE_RATE_PATH,
+            "bok.base_rate",
             "fetch_base_rate_series",
-            "base_rate",
             "base_rate",
             (Decimal("3.50"), Decimal("3.50"), Decimal("3.50")),
         ),
         (
             "usd_krw_statistic_search.json",
-            USD_KRW_PATH,
+            "bok.usd_krw",
             "fetch_usd_krw_series",
-            "usd_krw",
             "exchange_rate",
             (Decimal("1293.10"), Decimal("1288.40"), Decimal("1290.00")),
         ),
         (
             "bond_yield_statistic_search.json",
-            BOND_YIELD_PATH,
+            "bok.bond_yield_3y",
             "fetch_bond_yield_series",
-            "bond_yield",
             "yield_rate",
             (Decimal("3.23"), Decimal("3.20"), Decimal("3.18")),
         ),
     ],
 )
-def test_live_ecos_connector_replays_recorded_success_payloads_for_all_series(
+def test_live_ecos_connector_fetches_series_via_kpubdata_client(
     fixture_name: str,
-    request_path: str,
+    dataset_id: str,
     fetcher_name: str,
-    dataset_name: str,
     value_attr: str,
     expected_values: tuple[Decimal, ...],
 ) -> None:
-    payload = _load_payload(fixture_name)
+    dataset = _FakeDataset(_records_from_payload(fixture_name))
+    client = _FakeClient("test-api-key", {dataset_id: dataset})
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == request_path
-        return _json_response(request, payload)
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(handler),
-    )
+    connector = LiveEcosConnector(client=cast(Client, client))
 
     rows = cast(tuple[EcosRow, ...], getattr(connector, fetcher_name)(START_DATE, END_DATE))
 
+    assert client.dataset_calls == [dataset_id]
+    assert dataset.queries == [
+        Query(
+            start_date=START_DATE.isoformat(),
+            end_date=END_DATE.isoformat(),
+            extra={"frequency": "D"},
+        )
+    ]
     assert tuple(getattr(row, value_attr) for row in rows) == expected_values
     assert tuple(row.value_date for row in rows) == (START_DATE, date(2024, 1, 3), END_DATE)
-    assert rows[0].metadata.dataset_name == dataset_name
+    assert rows[0].metadata.source_name == "ecos"
+    assert rows[0].metadata.api_version == "StatisticSearch"
+    assert (
+        rows[0].metadata.key_fingerprint_sha256
+        == hashlib.sha256("test-api-key".encode("utf-8")).hexdigest()[:16]
+    )
+
+
+def test_live_ecos_connector_falls_back_to_dataset_list_when_query_records_is_unavailable() -> None:
+    dataset = _ListOnlyDataset(_records_from_payload("base_rate_statistic_search.json"))
+    client = _ConfigurableClient("bok.base_rate", dataset, SimpleNamespace(provider_keys={}))
+
+    connector = LiveEcosConnector(client=cast(Client, client))
+
+    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
+
+    assert rows
+    assert dataset.calls == [
+        {
+            "start_date": START_DATE.isoformat(),
+            "end_date": END_DATE.isoformat(),
+            "frequency": "D",
+        }
+    ]
 
 
 @pytest.mark.parametrize(
-    ("fixture_name", "fetcher_name"),
+    "config",
     [
-        ("base_rate_auth_error_statistic_search.json", "fetch_base_rate_series"),
-        ("usd_krw_auth_error_statistic_search.json", "fetch_usd_krw_series"),
-        ("bond_yield_auth_error_statistic_search.json", "fetch_bond_yield_series"),
+        None,
+        SimpleNamespace(provider_keys="bad"),
+        SimpleNamespace(provider_keys={1: "ignored", "bok": 1}),
     ],
 )
-def test_live_ecos_connector_raises_on_recorded_auth_failures_for_all_series(
-    fixture_name: str,
-    fetcher_name: str,
+def test_live_ecos_connector_leaves_fingerprint_empty_when_client_config_is_unusable(
+    config: object | None,
 ) -> None:
-    payload = _load_payload(fixture_name)
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
-    )
+    dataset = _FakeDataset(_records_from_payload("base_rate_statistic_search.json"))
+    client = _ConfigurableClient("bok.base_rate", dataset, config)
 
-    with pytest.raises(PermissionError, match="ERROR-301"):
-        _ = getattr(connector, fetcher_name)(START_DATE, END_DATE)
+    connector = LiveEcosConnector(client=cast(Client, client))
+
+    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
+
+    assert rows[0].metadata.key_fingerprint_sha256 is None
+
+
+def test_live_ecos_connector_raises_when_dataset_cannot_query_records() -> None:
+    client = _ConfigurableClient("bok.base_rate", object(), None)
+    connector = LiveEcosConnector(client=cast(Client, client))
+
+    with pytest.raises(TypeError, match="query_records"):
+        connector.fetch_base_rate_series(START_DATE, END_DATE)
 
 
 @pytest.mark.parametrize(
@@ -324,264 +226,63 @@ def test_live_ecos_connector_raises_on_recorded_auth_failures_for_all_series(
 )
 def test_parse_ecos_rows_sorts_recorded_rows_deterministically(
     fixture_name: str,
-    parser: Callable[[object, str, str], tuple[EcosRow, ...]],
+    parser: Callable[[tuple[Mapping[str, object], ...], str, str], tuple[EcosRow, ...]],
     value_attr: str,
     expected_values: tuple[Decimal, ...],
 ) -> None:
     payload = _load_payload_dict(fixture_name)
     statistic_search = cast(dict[str, object], payload["StatisticSearch"])
-    rows = cast(list[object], statistic_search["row"])
-    statistic_search["row"] = list(reversed(rows))
+    rows = cast(list[Mapping[str, object]], statistic_search["row"])
 
-    parsed_rows = parser(payload, "2024-01-15T00:00:00+00:00", "abc123def4567890")
+    parsed_rows = parser(
+        tuple(reversed(rows)),
+        "2024-01-15T00:00:00+00:00",
+        "abc123def4567890",
+    )
 
     assert tuple(row.value_date for row in parsed_rows) == (START_DATE, date(2024, 1, 3), END_DATE)
     assert tuple(getattr(row, value_attr) for row in parsed_rows) == expected_values
 
 
 @pytest.mark.parametrize(
-    ("fixture_name", "parser"),
+    ("parser", "row_type"),
     [
-        ("base_rate_empty_window_statistic_search.json", parse_base_rate_rows),
-        ("usd_krw_empty_window_statistic_search.json", parse_usd_krw_rows),
-        ("bond_yield_empty_window_statistic_search.json", parse_bond_yield_rows),
+        (parse_base_rate_rows, EcosBaseRateRow),
+        (parse_usd_krw_rows, EcosUsdKrwRow),
+        (parse_bond_yield_rows, EcosBondYieldRow),
     ],
 )
-def test_parse_ecos_rows_return_empty_tuple_for_recorded_empty_windows(
-    fixture_name: str,
-    parser: Callable[[object, str, str], tuple[object, ...]],
+def test_parse_ecos_rows_returns_empty_tuple_for_empty_record_batch(
+    parser: Callable[[tuple[Mapping[str, object], ...], str, str], tuple[object, ...]],
+    row_type: type[object],
 ) -> None:
-    rows = parser(
-        _load_payload(fixture_name),
-        "2024-01-15T00:00:00+00:00",
-        "abc123def4567890",
-    )
+    del row_type
+    rows = parser((), "2024-01-15T00:00:00+00:00", "abc123def4567890")
 
     assert rows == ()
 
 
 @pytest.mark.parametrize(
-    ("fixture_name", "fetcher_name", "value_attr", "expected_values"),
+    ("parser", "bad_rows", "message"),
     [
-        (
-            "base_rate_statistic_search.json",
-            "fetch_base_rate_series",
-            "base_rate",
-            (Decimal("3.50"), Decimal("3.50"), Decimal("3.50")),
-        ),
-        (
-            "usd_krw_statistic_search.json",
-            "fetch_usd_krw_series",
-            "exchange_rate",
-            (Decimal("1293.10"), Decimal("1288.40"), Decimal("1290.00")),
-        ),
-        (
-            "bond_yield_statistic_search.json",
-            "fetch_bond_yield_series",
-            "yield_rate",
-            (Decimal("3.23"), Decimal("3.20"), Decimal("3.18")),
-        ),
+        (parse_base_rate_rows, ({"DATA_VALUE": "3.50"},), "TIME"),
+        (parse_usd_krw_rows, ({"TIME": "20240102"},), "DATA_VALUE"),
+        (parse_bond_yield_rows, ({"TIME": 20240102, "DATA_VALUE": "3.20"},), "TIME"),
     ],
 )
-def test_live_ecos_connector_retries_5xx_for_all_series(
-    fixture_name: str,
-    fetcher_name: str,
-    value_attr: str,
-    expected_values: tuple[Decimal, ...],
+def test_parse_ecos_rows_validate_required_fields(
+    parser: Callable[[tuple[Mapping[str, object], ...], str, str], tuple[object, ...]],
+    bad_rows: tuple[Mapping[str, object], ...],
+    message: str,
 ) -> None:
-    payload = _load_payload(fixture_name)
-    attempts = 0
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            return httpx.Response(status_code=503, request=request)
-        return _json_response(request, payload)
-
-    connector = LiveEcosConnector(
-        api_key="test-api-key",
-        transport=httpx.MockTransport(handler),
-        sleep=lambda _seconds: None,
-    )
-
-    rows = cast(tuple[object, ...], getattr(connector, fetcher_name)(START_DATE, END_DATE))
-
-    assert attempts == 2
-    assert tuple(getattr(row, value_attr) for row in rows) == expected_values
-
-
-def test_parse_base_rate_rows_returns_empty_tuple_when_row_block_missing() -> None:
-    rows = parse_base_rate_rows(
-        {"StatisticSearch": {"RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."}}},
-        "2024-01-15T00:00:00+00:00",
-        "abc123def4567890",
-    )
-
-    assert rows == ()
-
-
-def test_parse_base_rate_rows_raises_runtime_error_for_non_auth_ecos_failure() -> None:
-    payload = {"StatisticSearch": {"RESULT": {"CODE": "ERROR-100", "MESSAGE": "잘못된 요청"}}}
-
-    with pytest.raises(RuntimeError, match="ERROR-100"):
-        parse_base_rate_rows(payload, "2024-01-15T00:00:00+00:00", "abc123def4567890")
-
-
-@pytest.mark.parametrize(
-    ("payload", "message"),
-    [
-        ("not-a-dict", "JSON object"),
-        ({"StatisticSearch": []}, "StatisticSearch"),
-        ({"StatisticSearch": {"RESULT": []}}, "RESULT"),
-        (
-            {"StatisticSearch": {"RESULT": {"CODE": 123, "MESSAGE": "정상 처리되었습니다."}}},
-            "CODE",
-        ),
-        (
-            {
-                "StatisticSearch": {
-                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
-                    "row": {},
-                }
-            },
-            "row payload must be a list",
-        ),
-        (
-            {
-                "StatisticSearch": {
-                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
-                    "row": ["not-a-dict"],
-                }
-            },
-            "JSON object",
-        ),
-        (
-            {
-                "StatisticSearch": {
-                    "RESULT": {"CODE": "INFO-000", "MESSAGE": "정상 처리되었습니다."},
-                    "row": [{"TIME": "20240102", "DATA_VALUE": 1.23}],
-                }
-            },
-            "DATA_VALUE",
-        ),
-    ],
-)
-def test_parse_base_rate_rows_validates_ecos_payload_shape(payload: object, message: str) -> None:
     with pytest.raises(ValueError, match=message):
+        parser(bad_rows, "2024-01-15T00:00:00+00:00", "abc123def4567890")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [{}, (1,)],
+)
+def test_parse_ecos_rows_validate_record_batch_shape(payload: object) -> None:
+    with pytest.raises(ValueError):
         parse_base_rate_rows(payload, "2024-01-15T00:00:00+00:00", "abc123def4567890")
-
-
-def test_sync_http_requester_retries_transport_errors() -> None:
-    attempts = 0
-    sleeps: list[float] = []
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            raise httpx.ReadTimeout("timeout", request=request)
-        return _json_response(request, _load_payload("base_rate_statistic_search.json"))
-
-    requester = SyncHttpRequester(sleep=sleeps.append)
-    with httpx.Client(
-        base_url="https://example.com", transport=httpx.MockTransport(handler)
-    ) as client:
-        payload = requester.get(client, "/payload")
-
-    assert attempts == 2
-    assert sleeps == [0.5]
-    assert isinstance(payload, Mapping)
-
-
-def test_sync_http_requester_raises_for_non_retryable_http_status() -> None:
-    requester = SyncHttpRequester()
-    with httpx.Client(
-        base_url="https://example.com",
-        transport=httpx.MockTransport(lambda request: httpx.Response(404, request=request)),
-    ) as client:
-        with pytest.raises(HttpRequestError, match="HTTP 404"):
-            requester.get(client, "/missing")
-
-
-def test_sync_http_requester_raises_after_retry_exhaustion() -> None:
-    requester = SyncHttpRequester(sleep=lambda _seconds: None)
-    with httpx.Client(
-        base_url="https://example.com",
-        transport=httpx.MockTransport(lambda request: httpx.Response(503, request=request)),
-    ) as client:
-        with pytest.raises(HttpRequestError, match="3 attempts"):
-            requester.get(client, "/retry")
-
-
-def test_sync_http_requester_raises_after_last_transport_error() -> None:
-    requester = SyncHttpRequester(HttpRetryPolicy(max_attempts=1), sleep=lambda _seconds: None)
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        raise httpx.ReadTimeout("timeout", request=request)
-
-    with httpx.Client(
-        base_url="https://example.com",
-        transport=httpx.MockTransport(handler),
-    ) as client:
-        with pytest.raises(HttpRequestError, match="1 attempts"):
-            requester.get(client, "/timeout")
-
-
-def test_sync_http_requester_rejects_zero_attempt_policy() -> None:
-    requester = SyncHttpRequester(HttpRetryPolicy(max_attempts=0))
-    with httpx.Client(
-        base_url="https://example.com",
-        transport=httpx.MockTransport(lambda request: _json_response(request, {})),
-    ) as client:
-        with pytest.raises(HttpRequestError, match="without response"):
-            requester.get(client, "/never-called")
-
-
-def test_parse_base_rate_rows_matches_recorded_payload() -> None:
-    rows = parse_base_rate_rows(
-        _load_payload("base_rate_statistic_search.json"),
-        "2024-01-15T00:00:00+00:00",
-        "abc123def4567890",
-    )
-
-    assert len(rows) == 3
-    assert tuple(row.base_rate for row in rows) == (
-        Decimal("3.50"),
-        Decimal("3.50"),
-        Decimal("3.50"),
-    )
-    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)
-
-
-def test_parse_usd_krw_rows_matches_recorded_payload() -> None:
-    rows = parse_usd_krw_rows(
-        _load_payload("usd_krw_statistic_search.json"),
-        "2024-01-15T00:00:00+00:00",
-        "abc123def4567890",
-    )
-
-    assert len(rows) == 3
-    assert tuple(row.exchange_rate for row in rows) == (
-        Decimal("1293.10"),
-        Decimal("1288.40"),
-        Decimal("1290.00"),
-    )
-    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)
-
-
-def test_parse_bond_yield_rows_matches_recorded_payload() -> None:
-    rows = parse_bond_yield_rows(
-        _load_payload("bond_yield_statistic_search.json"),
-        "2024-01-15T00:00:00+00:00",
-        "abc123def4567890",
-    )
-
-    assert len(rows) == 3
-    assert tuple(row.yield_rate for row in rows) == (
-        Decimal("3.23"),
-        Decimal("3.20"),
-        Decimal("3.18"),
-    )
-    assert all(row.maturity_code == "3Y" for row in rows)
-    assert all(row.metadata.key_fingerprint_sha256 == "abc123def4567890" for row in rows)

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -12,7 +12,6 @@ from typing import cast
 
 import pytest
 from kpubdata import Client
-from kpubdata.core.models import Query
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
     EcosBaseRateRow,
@@ -38,30 +37,20 @@ class _FakeRecordBatch:
 class _FakeDataset:
     def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
         self._batch = _FakeRecordBatch(items)
-        self.queries: list[Query] = []
-
-    def query_records(self, query: Query) -> _FakeRecordBatch:
-        self.queries.append(query)
-        return self._batch
-
-
-class _ListOnlyDataset:
-    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
-        self._batch = _FakeRecordBatch(items)
         self.calls: list[dict[str, object]] = []
 
-    def list(self, **kwargs: object) -> _FakeRecordBatch:
-        self.calls.append(dict(kwargs))
+    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
+        self.calls.append(dict(filters))
         return self._batch
 
 
 class _FakeClient:
-    def __init__(self, provider_key: str, datasets: Mapping[str, _FakeDataset]) -> None:
+    def __init__(self, provider_key: str, datasets: Mapping[str, object]) -> None:
         self._config = SimpleNamespace(provider_keys={"bok": provider_key})
         self._datasets = dict(datasets)
         self.dataset_calls: list[str] = []
 
-    def dataset(self, dataset_id: str) -> _FakeDataset:
+    def dataset(self, dataset_id: str) -> object:
         self.dataset_calls.append(dataset_id)
         return self._datasets[dataset_id]
 
@@ -137,12 +126,12 @@ def test_live_ecos_connector_fetches_series_via_kpubdata_client(
     rows = cast(tuple[EcosRow, ...], getattr(connector, fetcher_name)(START_DATE, END_DATE))
 
     assert client.dataset_calls == [dataset_id]
-    assert dataset.queries == [
-        Query(
-            start_date=START_DATE.isoformat(),
-            end_date=END_DATE.isoformat(),
-            extra={"frequency": "D"},
-        )
+    assert dataset.calls == [
+        {
+            "start_date": START_DATE.isoformat(),
+            "end_date": END_DATE.isoformat(),
+            "frequency": "D",
+        }
     ]
     assert tuple(getattr(row, value_attr) for row in rows) == expected_values
     assert tuple(row.value_date for row in rows) == (START_DATE, date(2024, 1, 3), END_DATE)
@@ -152,24 +141,6 @@ def test_live_ecos_connector_fetches_series_via_kpubdata_client(
         rows[0].metadata.key_fingerprint_sha256
         == hashlib.sha256("test-api-key".encode("utf-8")).hexdigest()[:16]
     )
-
-
-def test_live_ecos_connector_falls_back_to_dataset_list_when_query_records_is_unavailable() -> None:
-    dataset = _ListOnlyDataset(_records_from_payload("base_rate_statistic_search.json"))
-    client = _ConfigurableClient("bok.base_rate", dataset, SimpleNamespace(provider_keys={}))
-
-    connector = LiveEcosConnector(client=cast(Client, client))
-
-    rows = connector.fetch_base_rate_series(START_DATE, END_DATE)
-
-    assert rows
-    assert dataset.calls == [
-        {
-            "start_date": START_DATE.isoformat(),
-            "end_date": END_DATE.isoformat(),
-            "frequency": "D",
-        }
-    ]
 
 
 @pytest.mark.parametrize(
@@ -193,11 +164,11 @@ def test_live_ecos_connector_leaves_fingerprint_empty_when_client_config_is_unus
     assert rows[0].metadata.key_fingerprint_sha256 is None
 
 
-def test_live_ecos_connector_raises_when_dataset_cannot_query_records() -> None:
+def test_live_ecos_connector_raises_when_dataset_cannot_list_records() -> None:
     client = _ConfigurableClient("bok.base_rate", object(), None)
     connector = LiveEcosConnector(client=cast(Client, client))
 
-    with pytest.raises(TypeError, match="query_records"):
+    with pytest.raises(AttributeError, match="list"):
         connector.fetch_base_rate_series(START_DATE, END_DATE)
 
 

--- a/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_ecos_live_connector.py
@@ -39,8 +39,20 @@ class _FakeDataset:
         self._batch = _FakeRecordBatch(items)
         self.calls: list[dict[str, object]] = []
 
-    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
-        self.calls.append(dict(filters))
+    def list(
+        self,
+        *,
+        start_date: object,
+        end_date: object,
+        frequency: object | None = None,
+    ) -> _FakeRecordBatch:
+        self.calls.append(
+            {
+                "start_date": start_date,
+                "end_date": end_date,
+                "frequency": frequency,
+            }
+        )
         return self._batch
 
 

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -10,7 +10,6 @@ from typing import cast
 
 import pytest
 from kpubdata import Client
-from kpubdata.core.models import Query
 from kpubdata.exceptions import DatasetNotFoundError
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
@@ -33,20 +32,10 @@ class _FakeRecordBatch:
 class _FakeDataset:
     def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
         self._batch = _FakeRecordBatch(items)
-        self.queries: list[Query] = []
-
-    def query_records(self, query: Query) -> _FakeRecordBatch:
-        self.queries.append(query)
-        return self._batch
-
-
-class _ListOnlyDataset:
-    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
-        self._batch = _FakeRecordBatch(items)
         self.calls: list[dict[str, object]] = []
 
-    def list(self, **kwargs: object) -> _FakeRecordBatch:
-        self.calls.append(dict(kwargs))
+    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
+        self.calls.append(dict(filters))
         return self._batch
 
 
@@ -59,12 +48,12 @@ class _DatasetNotFoundClient:
 
 
 class _FakeClient:
-    def __init__(self, provider_key: str, datasets: Mapping[str, _FakeDataset]) -> None:
+    def __init__(self, provider_key: str, datasets: Mapping[str, object]) -> None:
         self._config = SimpleNamespace(provider_keys={"kosis": provider_key})
         self._datasets = dict(datasets)
         self.dataset_calls: list[str] = []
 
-    def dataset(self, dataset_id: str) -> _FakeDataset:
+    def dataset(self, dataset_id: str) -> object:
         self.dataset_calls.append(dataset_id)
         return self._datasets[dataset_id]
 
@@ -134,8 +123,11 @@ def test_live_kosis_connector_fetches_macro_indicators_via_kpubdata_client() -> 
     rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
 
     assert client.dataset_calls == ["kosis.industrial_production"]
-    assert dataset.queries == [
-        Query(start_date=START_DATE.isoformat(), end_date=END_DATE.isoformat())
+    assert dataset.calls == [
+        {
+            "start_date": START_DATE.isoformat(),
+            "end_date": END_DATE.isoformat(),
+        }
     ]
     assert [row.value_date for row in rows] == [date(2024, 1, 1), date(2024, 2, 1)]
     assert [row.indicator_value for row in rows] == [Decimal("100.1"), Decimal("101.2")]
@@ -143,38 +135,6 @@ def test_live_kosis_connector_fetches_macro_indicators_via_kpubdata_client() -> 
         rows[0].metadata.key_fingerprint_sha256
         == hashlib.sha256("explicit-kosis-key".encode("utf-8")).hexdigest()[:16]
     )
-
-
-def test_live_kosis_connector_falls_back_to_dataset_list_when_query_records_is_unavailable() -> (
-    None
-):
-    dataset = _ListOnlyDataset(
-        (
-            {
-                "PRD_DE": "202401",
-                "DT": "100.1",
-                "C1_OBJ_NM": "산업생산지수",
-                "UNIT_NM": "2020=100",
-            },
-        )
-    )
-    client = _ConfigurableClient(
-        "kosis.industrial_production",
-        dataset,
-        SimpleNamespace(provider_keys={}),
-    )
-
-    connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
-
-    rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
-
-    assert rows
-    assert dataset.calls == [
-        {
-            "start_date": START_DATE.isoformat(),
-            "end_date": END_DATE.isoformat(),
-        }
-    ]
 
 
 def test_live_kosis_connector_rejects_unsupported_live_dataset_shape() -> None:
@@ -212,11 +172,11 @@ def test_live_kosis_connector_leaves_fingerprint_empty_when_client_config_is_unu
     assert rows[0].metadata.key_fingerprint_sha256 is None
 
 
-def test_live_kosis_connector_raises_when_dataset_cannot_query_records() -> None:
+def test_live_kosis_connector_raises_when_dataset_cannot_list_records() -> None:
     client = _ConfigurableClient("kosis.industrial_production", object(), None)
     connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
 
-    with pytest.raises(TypeError, match="query_records"):
+    with pytest.raises(AttributeError, match="list"):
         connector.fetch_macro_indicators(START_DATE, END_DATE)
 
 

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -34,8 +34,20 @@ class _FakeDataset:
         self._batch = _FakeRecordBatch(items)
         self.calls: list[dict[str, object]] = []
 
-    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
-        self.calls.append(dict(filters))
+    def list(
+        self,
+        *,
+        start_date: object,
+        end_date: object,
+        frequency: object | None = None,
+    ) -> _FakeRecordBatch:
+        self.calls.append(
+            {
+                "start_date": start_date,
+                "end_date": end_date,
+                "frequency": frequency,
+            }
+        )
         return self._batch
 
 
@@ -127,6 +139,7 @@ def test_live_kosis_connector_fetches_macro_indicators_via_kpubdata_client() -> 
         {
             "start_date": START_DATE.isoformat(),
             "end_date": END_DATE.isoformat(),
+            "frequency": None,
         }
     ]
     assert [row.value_date for row in rows] == [date(2024, 1, 1), date(2024, 2, 1)]

--- a/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
+++ b/apps/kr-kospi/tests/contract/test_kosis_live_connector.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
 import hashlib
-import os
+from types import SimpleNamespace
+from typing import cast
 
-import httpx
 import pytest
+from kpubdata import Client
+from kpubdata.core.models import Query
+from kpubdata.exceptions import DatasetNotFoundError
 
-from kospi_decision_pipeline_app_kr_kospi.connectors._http import HttpRequestError
 from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import (
     LiveKosisConnector,
-    _default_sleep,
-    _format_period,
-    _utc_now,
+    UnsupportedDatasetError,
     parse_macro_indicator_rows,
 )
 
@@ -23,13 +25,63 @@ END_DATE = date(2024, 2, 29)
 FETCHED_AT = datetime(2024, 3, 1, tzinfo=timezone.utc)
 
 
-def _json_response(request: httpx.Request, payload: object) -> httpx.Response:
-    return httpx.Response(status_code=200, json=payload, request=request)
+@dataclass(frozen=True, slots=True)
+class _FakeRecordBatch:
+    items: tuple[Mapping[str, object], ...]
+
+
+class _FakeDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+        self.queries: list[Query] = []
+
+    def query_records(self, query: Query) -> _FakeRecordBatch:
+        self.queries.append(query)
+        return self._batch
+
+
+class _ListOnlyDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+        self.calls: list[dict[str, object]] = []
+
+    def list(self, **kwargs: object) -> _FakeRecordBatch:
+        self.calls.append(dict(kwargs))
+        return self._batch
+
+
+class _DatasetNotFoundClient:
+    def __init__(self) -> None:
+        self._config = SimpleNamespace(provider_keys={"kosis": "test-kosis-key"})
+
+    def dataset(self, dataset_id: str) -> _FakeDataset:
+        raise DatasetNotFoundError(dataset_id)
+
+
+class _FakeClient:
+    def __init__(self, provider_key: str, datasets: Mapping[str, _FakeDataset]) -> None:
+        self._config = SimpleNamespace(provider_keys={"kosis": provider_key})
+        self._datasets = dict(datasets)
+        self.dataset_calls: list[str] = []
+
+    def dataset(self, dataset_id: str) -> _FakeDataset:
+        self.dataset_calls.append(dataset_id)
+        return self._datasets[dataset_id]
+
+
+class _ConfigurableClient:
+    def __init__(self, dataset_id: str, dataset: object, config: object | None) -> None:
+        self._datasets = {dataset_id: dataset}
+        if config is not None:
+            self._config = config
+
+    def dataset(self, dataset_id: str) -> object:
+        return self._datasets[dataset_id]
 
 
 def test_parse_macro_indicator_rows_parses_verified_monthly_kosis_payload() -> None:
     rows = parse_macro_indicator_rows(
-        payload=[
+        payload=(
             {
                 "PRD_DE": "202402",
                 "DT": "101.2",
@@ -42,7 +94,7 @@ def test_parse_macro_indicator_rows_parses_verified_monthly_kosis_payload() -> N
                 "C1_OBJ_NM": "반도체",
                 "UNIT_NM": "2020=100",
             },
-        ],
+        ),
         dataset_name="macro_indicators",
         fetched_at_utc=FETCHED_AT.isoformat(),
         key_fingerprint_sha256="fingerprint123456",
@@ -58,94 +110,137 @@ def test_parse_macro_indicator_rows_parses_verified_monthly_kosis_payload() -> N
     assert rows[0].metadata.dataset_name == "macro_indicators"
 
 
-def test_live_kosis_connector_uses_explicit_api_key_over_environment() -> None:
-    expected_fingerprint = hashlib.sha256("explicit-kosis-key".encode("utf-8")).hexdigest()[:16]
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.params["apiKey"] == "explicit-kosis-key"
-        assert request.url.params["orgId"] == "101"
-        assert request.url.params["tblId"] == "DT_1J22003"
-        assert request.url.params["itmId"] == "T"
-        assert request.url.params["objL1"] == "T10"
-        assert request.url.params["prdSe"] == "M"
-        assert request.url.params["startPrdDe"] == "202401"
-        assert request.url.params["endPrdDe"] == "202402"
-        return _json_response(
-            request,
-            [
-                {
-                    "PRD_DE": "202401",
-                    "DT": "100.1",
-                    "C1_OBJ_NM": "반도체",
-                    "UNIT_NM": "2020=100",
-                }
-            ],
+def test_live_kosis_connector_fetches_macro_indicators_via_kpubdata_client() -> None:
+    dataset = _FakeDataset(
+        (
+            {
+                "PRD_DE": "202402",
+                "DT": "101.2",
+                "C1_OBJ_NM": "산업생산지수",
+                "UNIT_NM": "2020=100",
+            },
+            {
+                "PRD_DE": "202401",
+                "DT": "100.1",
+                "C1_OBJ_NM": "산업생산지수",
+                "UNIT_NM": "2020=100",
+            },
         )
-
-    connector = LiveKosisConnector(
-        api_key="explicit-kosis-key",
-        environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"},
-        transport=httpx.MockTransport(handler),
-        now=lambda: FETCHED_AT,
     )
+    client = _FakeClient("explicit-kosis-key", {"kosis.industrial_production": dataset})
+
+    connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
 
     rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
 
-    assert rows[0].metadata.key_fingerprint_sha256 == expected_fingerprint
-
-
-def test_live_kosis_connector_requires_api_key_when_no_auth_source_exists(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("KPUBDATA_KOSIS_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="KOSIS API key is required"):
-        LiveKosisConnector(environment={})
-
-
-@pytest.mark.parametrize("status_code", [401, 403])
-def test_live_kosis_connector_maps_http_auth_failure_to_permission_error(status_code: int) -> None:
-    connector = LiveKosisConnector(
-        api_key="test-kosis-key",
-        transport=httpx.MockTransport(
-            lambda request: httpx.Response(status_code=status_code, request=request)
-        ),
+    assert client.dataset_calls == ["kosis.industrial_production"]
+    assert dataset.queries == [
+        Query(start_date=START_DATE.isoformat(), end_date=END_DATE.isoformat())
+    ]
+    assert [row.value_date for row in rows] == [date(2024, 1, 1), date(2024, 2, 1)]
+    assert [row.indicator_value for row in rows] == [Decimal("100.1"), Decimal("101.2")]
+    assert (
+        rows[0].metadata.key_fingerprint_sha256
+        == hashlib.sha256("explicit-kosis-key".encode("utf-8")).hexdigest()[:16]
     )
 
-    with pytest.raises(PermissionError, match=f"HTTP {status_code}"):
-        connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+def test_live_kosis_connector_falls_back_to_dataset_list_when_query_records_is_unavailable() -> (
+    None
+):
+    dataset = _ListOnlyDataset(
+        (
+            {
+                "PRD_DE": "202401",
+                "DT": "100.1",
+                "C1_OBJ_NM": "산업생산지수",
+                "UNIT_NM": "2020=100",
+            },
+        )
+    )
+    client = _ConfigurableClient(
+        "kosis.industrial_production",
+        dataset,
+        SimpleNamespace(provider_keys={}),
+    )
+
+    connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
+
+    rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+    assert rows
+    assert dataset.calls == [
+        {
+            "start_date": START_DATE.isoformat(),
+            "end_date": END_DATE.isoformat(),
+        }
+    ]
 
 
 def test_live_kosis_connector_rejects_unsupported_live_dataset_shape() -> None:
-    connector = LiveKosisConnector(api_key="test-kosis-key")
+    connector = LiveKosisConnector(client=cast(Client, _FakeClient("test-kosis-key", {})))
 
-    with pytest.raises(ValueError, match="per_pbr_percentiles"):
+    with pytest.raises(UnsupportedDatasetError, match="per_pbr_percentiles"):
         connector.fetch_per_pbr_percentiles(START_DATE, END_DATE)
 
 
-def test_live_kosis_connector_reraises_non_auth_http_failures() -> None:
-    connector = LiveKosisConnector(
-        api_key="test-kosis-key",
-        transport=httpx.MockTransport(
-            lambda request: httpx.Response(status_code=500, request=request)
-        ),
-        sleep=lambda _seconds: None,
-    )
+def test_live_kosis_connector_translates_missing_kpubdata_dataset_to_existing_sentinel() -> None:
+    connector = LiveKosisConnector(client=cast(Client, _DatasetNotFoundClient()))
 
-    with pytest.raises(HttpRequestError, match="HTTP request failed after 3 attempts"):
+    with pytest.raises(UnsupportedDatasetError, match="industrial_production"):
         connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        None,
+        SimpleNamespace(provider_keys="bad"),
+        SimpleNamespace(provider_keys={1: "ignored", "kosis": 1}),
+    ],
+)
+def test_live_kosis_connector_leaves_fingerprint_empty_when_client_config_is_unusable(
+    config: object | None,
+) -> None:
+    dataset = _FakeDataset(({"PRD_DE": "202401", "DT": "100.1"},))
+    client = _ConfigurableClient("kosis.industrial_production", dataset, config)
+
+    connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
+
+    rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+    assert rows[0].metadata.key_fingerprint_sha256 is None
+
+
+def test_live_kosis_connector_raises_when_dataset_cannot_query_records() -> None:
+    client = _ConfigurableClient("kosis.industrial_production", object(), None)
+    connector = LiveKosisConnector(client=cast(Client, client), now=lambda: FETCHED_AT)
+
+    with pytest.raises(TypeError, match="query_records"):
+        connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+
+def test_live_kosis_connector_uses_default_utc_clock() -> None:
+    dataset = _FakeDataset(({"PRD_DE": "202401", "DT": "100.1"},))
+    client = _FakeClient("explicit-kosis-key", {"kosis.industrial_production": dataset})
+    connector = LiveKosisConnector(client=cast(Client, client))
+
+    rows = connector.fetch_macro_indicators(START_DATE, END_DATE)
+
+    assert rows[0].metadata.fetched_at_utc.endswith("+00:00")
 
 
 @pytest.mark.parametrize(
     ("payload", "message"),
     [
-        ({}, "JSON array"),
-        (["bad-row"], "JSON object"),
-        ([{"DT": "1.0"}], "PRD_DE"),
-        ([{"PRD_DE": 202401, "DT": "1.0"}], "PRD_DE"),
-        ([{"PRD_DE": "202401", "DT": 1.0}], "DT"),
-        ([{"PRD_DE": "202401", "DT": "1.0", "C1_OBJ_NM": 1}], "C1_OBJ_NM"),
-        ([{"PRD_DE": "202401", "DT": "1.0", "UNIT_NM": 1}], "UNIT_NM"),
-        ([{"PRD_DE": "2024", "DT": "1.0"}], "unsupported KOSIS period format"),
+        ({}, "record batch payload"),
+        (("bad-row",), "record payload"),
+        (({"DT": "1.0"},), "PRD_DE"),
+        (({"PRD_DE": 202401, "DT": "1.0"},), "PRD_DE"),
+        (({"PRD_DE": "202401", "DT": 1.0},), "DT"),
+        (({"PRD_DE": "202401", "DT": "1.0", "C1_OBJ_NM": 1},), "C1_OBJ_NM"),
+        (({"PRD_DE": "202401", "DT": "1.0", "UNIT_NM": 1},), "UNIT_NM"),
+        (({"PRD_DE": "2024", "DT": "1.0"},), "unsupported KOSIS period format"),
     ],
 )
 def test_parse_macro_indicator_rows_validates_payload_shape(payload: object, message: str) -> None:
@@ -162,7 +257,7 @@ def test_parse_macro_indicator_rows_validates_payload_shape(payload: object, mes
 
 def test_parse_macro_indicator_rows_uses_fallback_series_name_and_unit() -> None:
     rows = parse_macro_indicator_rows(
-        payload=[{"PRD_DE": "202401", "DT": "99.9"}],
+        payload=({"PRD_DE": "202401", "DT": "99.9"},),
         dataset_name="macro_indicators",
         fetched_at_utc=FETCHED_AT.isoformat(),
         key_fingerprint_sha256="fingerprint123456",
@@ -172,35 +267,3 @@ def test_parse_macro_indicator_rows_uses_fallback_series_name_and_unit() -> None
 
     assert rows[0].indicator_name == "verified-series"
     assert rows[0].unit == "index"
-
-
-def test_kosis_period_helpers_cover_supported_and_unsupported_paths(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    assert _format_period(date(2024, 2, 29), "M") == "202402"
-
-    with pytest.raises(ValueError, match="unsupported KOSIS period type"):
-        _format_period(date(2024, 2, 29), "D")
-
-    slept: list[float] = []
-    monkeypatch.setattr("time.sleep", slept.append)
-    _default_sleep(0.25)
-
-    assert slept == [0.25]
-    assert _utc_now().tzinfo == timezone.utc
-
-
-@pytest.mark.requires_network
-@pytest.mark.skipif(
-    os.getenv("KPUBDATA_KOSIS_API_KEY") is None,
-    reason="KPUBDATA_KOSIS_API_KEY not set",
-)
-def test_live_kosis_connector_smoke_fetches_verified_bronze_series() -> None:
-    connector = LiveKosisConnector(now=lambda: FETCHED_AT)
-
-    rows = connector.fetch_macro_indicators(date(2024, 1, 1), date(2024, 3, 31))
-
-    assert rows
-    assert rows[0].metadata.source_name == "kosis"
-    assert rows[0].metadata.dataset_name == "macro_indicators"
-    assert rows[0].indicator_name != ""

--- a/apps/kr-kospi/tests/contract/test_kpubdata_dataset_list_shape.py
+++ b/apps/kr-kospi/tests/contract/test_kpubdata_dataset_list_shape.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import pytest
+from kpubdata import Client
+from kpubdata.providers.bok import adapter as bok_adapter
+from kpubdata.providers.kosis import adapter as kosis_adapter
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeRecordBatch:
+    items: Sequence[object]
+    total_count: int | None = 0
+    next_page: int | None = None
+    next_cursor: str | None = None
+
+
+def test_bok_dataset_list_maps_top_level_kwargs_into_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KPUBDATA_BOK_API_KEY", "test-bok-api-key")
+    captured_queries: list[object] = []
+
+    def spy(self: object, dataset_ref: object, query: object) -> _FakeRecordBatch:
+        del self, dataset_ref
+        captured_queries.append(query)
+        return _FakeRecordBatch(())
+
+    monkeypatch.setattr(bok_adapter.BokAdapter, "query_records", spy)
+
+    client = Client.from_env()
+    batch = client.dataset("bok.base_rate").list(
+        start_date="2024-01-01",
+        end_date="2024-01-31",
+        frequency="D",
+    )
+
+    assert tuple(batch.items) == ()
+    assert len(captured_queries) == 1
+    query = captured_queries[0]
+    assert getattr(query, "start_date") == "2024-01-01"
+    assert getattr(query, "end_date") == "2024-01-31"
+    assert getattr(query, "filters") == {"frequency": "D"}
+    assert getattr(query, "extra") == {}
+
+
+def test_kosis_dataset_list_maps_top_level_kwargs_into_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-api-key")
+    captured_queries: list[object] = []
+
+    def spy(self: object, dataset_ref: object, query: object) -> _FakeRecordBatch:
+        del self, dataset_ref
+        captured_queries.append(query)
+        return _FakeRecordBatch(())
+
+    monkeypatch.setattr(kosis_adapter.KosisAdapter, "query_records", spy)
+
+    client = Client.from_env()
+    batch = client.dataset("kosis.industrial_production").list(
+        start_date="2024-01-01",
+        end_date="2024-03-31",
+    )
+
+    assert tuple(batch.items) == ()
+    assert len(captured_queries) == 1
+    query = captured_queries[0]
+    assert getattr(query, "start_date") == "2024-01-01"
+    assert getattr(query, "end_date") == "2024-03-31"
+    assert getattr(query, "filters") == {}
+    assert getattr(query, "extra") == {}

--- a/apps/kr-kospi/tests/contract/test_live_connector_registry.py
+++ b/apps/kr-kospi/tests/contract/test_live_connector_registry.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-
 import pytest
 
-from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import LiveEcosConnector
-from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import LiveKosisConnector
 from kospi_decision_pipeline_app_kr_kospi.connectors.krx import PykrxKrxConnector
-from kospi_decision_pipeline_app_kr_kospi.connectors.registry import (
-    LiveConnectorRegistry,
-    resolve_live_api_key,
-)
+from kospi_decision_pipeline_app_kr_kospi.connectors.registry import LiveConnectorRegistry
 
 
 def test_live_connector_registry_returns_pykrx_connector_for_krx() -> None:
@@ -19,76 +12,60 @@ def test_live_connector_registry_returns_pykrx_connector_for_krx() -> None:
     assert isinstance(registry.get_connector("krx"), PykrxKrxConnector)
 
 
-def test_live_connector_registry_returns_live_ecos_connector_with_explicit_api_key() -> None:
-    registry = LiveConnectorRegistry(environment={})
+def test_live_connector_registry_builds_client_for_ecos(monkeypatch: pytest.MonkeyPatch) -> None:
+    built_client = object()
+    observed: dict[str, object] = {}
 
-    connector = registry.get_connector("ecos", api_key="explicit-ecos-key")
-
-    assert isinstance(connector, LiveEcosConnector)
-
-
-def test_live_connector_registry_prefers_explicit_key_over_environment() -> None:
-    assert (
-        resolve_live_api_key(
-            source="ecos",
-            api_key="explicit-ecos-key",
-            environment={"KPUBDATA_BOK_API_KEY": "env-ecos-key"},
-        )
-        == "explicit-ecos-key"
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.client_factory.build_client",
+        lambda: built_client,
     )
 
+    class _FakeEcosConnector:
+        def __init__(self, *, client: object) -> None:
+            observed["client"] = client
 
-def test_live_connector_registry_reads_source_specific_environment_key() -> None:
-    assert (
-        resolve_live_api_key(
-            source="ecos",
-            api_key=None,
-            environment={"KPUBDATA_BOK_API_KEY": "env-ecos-key"},
-        )
-        == "env-ecos-key"
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.LiveEcosConnector",
+        _FakeEcosConnector,
     )
 
+    registry = LiveConnectorRegistry()
 
-def test_live_connector_registry_returns_none_for_sources_without_api_keys() -> None:
-    assert resolve_live_api_key(source="krx", api_key=None, environment={}) is None
+    connector = registry.get_connector("ecos")
 
-
-def test_live_connector_registry_rejects_missing_required_api_key() -> None:
-    with pytest.raises(ValueError, match="ECOS API key is required"):
-        _ = resolve_live_api_key(source="ecos", api_key=None, environment={})
+    assert isinstance(connector, _FakeEcosConnector)
+    assert observed == {"client": built_client}
 
 
-def test_live_connector_registry_returns_live_kosis_connector_with_explicit_api_key() -> None:
-    registry = LiveConnectorRegistry(environment={})
+def test_live_connector_registry_builds_client_for_kosis(monkeypatch: pytest.MonkeyPatch) -> None:
+    built_client = object()
+    observed: dict[str, object] = {}
 
-    connector = registry.get_connector("kosis", api_key="explicit-kosis-key")
-
-    assert isinstance(connector, LiveKosisConnector)
-
-
-def test_live_connector_registry_reads_kosis_environment_key() -> None:
-    assert (
-        resolve_live_api_key(
-            source="kosis",
-            api_key=None,
-            environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"},
-        )
-        == "env-kosis-key"
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.client_factory.build_client",
+        lambda: built_client,
     )
 
+    class _FakeKosisConnector:
+        def __init__(self, *, client: object) -> None:
+            observed["client"] = client
 
-def test_live_connector_registry_passes_environment_to_live_kosis_connector() -> None:
-    registry = LiveConnectorRegistry(environment={"KPUBDATA_KOSIS_API_KEY": "env-kosis-key"})
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.LiveKosisConnector",
+        _FakeKosisConnector,
+    )
+
+    registry = LiveConnectorRegistry()
 
     connector = registry.get_connector("kosis")
 
-    environment = getattr(connector, "_environment")
-    assert isinstance(environment, Mapping)
-    assert environment["KPUBDATA_KOSIS_API_KEY"] == "env-kosis-key"
+    assert isinstance(connector, _FakeKosisConnector)
+    assert observed == {"client": built_client}
 
 
 def test_live_connector_registry_rejects_unknown_source() -> None:
-    registry = LiveConnectorRegistry(environment={})
+    registry = LiveConnectorRegistry()
 
     with pytest.raises(ValueError, match="unsupported source"):
         registry.get_connector("missing")

--- a/apps/kr-kospi/tests/integration/test_ecos_live.py
+++ b/apps/kr-kospi/tests/integration/test_ecos_live.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import os
 
 import pytest
+from kpubdata import Client
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import (
     EcosBaseRateRow,
@@ -77,7 +78,7 @@ def test_live_ecos_connector_fetches_sorted_rows_for_all_series(
     fetcher: EcosFetcher,
     value_getter: Callable[[EcosBaseRateRow | EcosUsdKrwRow | EcosBondYieldRow], Decimal],
 ) -> None:
-    connector = LiveEcosConnector()
+    connector = LiveEcosConnector(client=Client.from_env())
 
     rows = fetcher(connector, date(2024, 1, 2), date(2024, 1, 5))
 

--- a/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
+++ b/apps/kr-kospi/tests/integration/test_live_ingest_cli.py
@@ -218,6 +218,7 @@ def test_cli_main_fails_clearly_for_unsupported_live_kosis_dataset(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setenv("KPUBDATA_BOK_API_KEY", "test-bok-api-key")
     monkeypatch.setenv("KPUBDATA_KOSIS_API_KEY", "test-kosis-api-key")
 
     assert (

--- a/apps/kr-kospi/tests/parity/test_v02_baseline.py
+++ b/apps/kr-kospi/tests/parity/test_v02_baseline.py
@@ -6,10 +6,11 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
 
-import httpx
 import pytest
+from kpubdata import Client
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.ecos import LiveEcosConnector
 from kospi_decision_pipeline_app_kr_kospi.connectors.kosis import LiveKosisConnector
@@ -18,6 +19,30 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.krx import PykrxKrxConnecto
 
 PARITY_FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "parity" / "v0.2"
 FETCHED_AT = datetime(2024, 2, 1, tzinfo=timezone.utc)
+PARITY_API_KEY = "parity-api-key"
+
+
+class _FakeRecordBatch:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self.items = items
+
+
+class _FakeDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+
+    def query_records(self, query: object) -> _FakeRecordBatch:
+        del query
+        return self._batch
+
+
+class _FakeClient:
+    def __init__(self, *, provider: str, datasets: Mapping[str, _FakeDataset]) -> None:
+        self._config = SimpleNamespace(provider_keys={provider: PARITY_API_KEY})
+        self._datasets = dict(datasets)
+
+    def dataset(self, dataset_id: str) -> _FakeDataset:
+        return self._datasets[dataset_id]
 
 
 class _FakeFrameIndex:
@@ -86,10 +111,6 @@ def _serialize(value: object) -> object:
     return value
 
 
-def _json_response(request: httpx.Request, payload: object) -> httpx.Response:
-    return httpx.Response(status_code=200, json=payload, request=request)
-
-
 def _frame_from_payload(payload: object) -> _FakeDataFrame:
     mapping = cast(dict[str, object], payload)
     raw_rows = cast(list[dict[str, object]], mapping["rows"])
@@ -109,6 +130,12 @@ def _extract_ohlcv_payload(payload: object) -> object:
             return ohlcv_payload
         return dict(mapping)
     return payload
+
+
+def _extract_ecos_records(payload: object) -> tuple[Mapping[str, object], ...]:
+    mapping = cast(Mapping[str, object], payload)
+    statistic_search = cast(Mapping[str, object], mapping["StatisticSearch"])
+    return tuple(cast(list[Mapping[str, object]], statistic_search.get("row", [])))
 
 
 class _ParityPykrxStockApi:
@@ -156,10 +183,17 @@ class _ParityPykrxStockApi:
 def _fetch_ecos_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
     snapshot = _load_snapshot(snapshot_name)
     start, end = _load_window(snapshot)
-    payload = snapshot["raw"]
+    dataset_name = {
+        "fetch_base_rate_series": "bok.base_rate",
+        "fetch_usd_krw_series": "bok.usd_krw",
+        "fetch_bond_yield_series": "bok.bond_yield_3y",
+    }[fetcher_name]
+    client = _FakeClient(
+        provider="bok",
+        datasets={dataset_name: _FakeDataset(_extract_ecos_records(snapshot["raw"]))},
+    )
     connector = LiveEcosConnector(
-        api_key="parity-api-key",
-        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+        client=cast(Client, client),
         now=lambda: FETCHED_AT,
     )
     return cast(list[object], list(getattr(connector, fetcher_name)(start, end)))
@@ -168,10 +202,13 @@ def _fetch_ecos_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
 def _fetch_kosis_rows(snapshot_name: str) -> list[object]:
     snapshot = _load_snapshot(snapshot_name)
     start, end = _load_window(snapshot)
-    payload = snapshot["raw"]
+    payload = tuple(cast(list[Mapping[str, object]], snapshot["raw"]))
+    client = _FakeClient(
+        provider="kosis",
+        datasets={"kosis.industrial_production": _FakeDataset(payload)},
+    )
     connector = LiveKosisConnector(
-        api_key="parity-api-key",
-        transport=httpx.MockTransport(lambda request: _json_response(request, payload)),
+        client=cast(Client, client),
         now=lambda: FETCHED_AT,
     )
     return list(connector.fetch_macro_indicators(start, end))

--- a/apps/kr-kospi/tests/parity/test_v02_baseline.py
+++ b/apps/kr-kospi/tests/parity/test_v02_baseline.py
@@ -31,8 +31,8 @@ class _FakeDataset:
     def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
         self._batch = _FakeRecordBatch(items)
 
-    def query_records(self, query: object) -> _FakeRecordBatch:
-        del query
+    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
+        del filters
         return self._batch
 
 

--- a/apps/kr-kospi/tests/parity/test_v02_baseline.py
+++ b/apps/kr-kospi/tests/parity/test_v02_baseline.py
@@ -31,8 +31,14 @@ class _FakeDataset:
     def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
         self._batch = _FakeRecordBatch(items)
 
-    def list(self, *, filters: Mapping[str, object]) -> _FakeRecordBatch:
-        del filters
+    def list(
+        self,
+        *,
+        start_date: object,
+        end_date: object,
+        frequency: object | None = None,
+    ) -> _FakeRecordBatch:
+        del start_date, end_date, frequency
         return self._batch
 
 


### PR DESCRIPTION
## Summary
- migrate the ECOS and KOSIS live connectors to injected `kpubdata.Client` datasets while preserving v0.2 normalized row output and unsupported-dataset semantics
- wire the live connector registry through `client_factory.build_client()`, update parity/live tests to mock `kpubdata.Client`, and restore coverage for retained `_http.py` / `_secrets.py` helpers
- align the live-smoke workflow with the shared kpubdata key requirements introduced by the registry migration

## Acceptance checklist
- [x] `ecos.py` rewritten to use injected `kpubdata.Client` datasets for `bok.base_rate`, `bok.usd_krw`, and `bok.bond_yield_3y`
- [x] `kosis.py` rewritten to use injected `kpubdata.Client` dataset `kosis.industrial_production` and preserve `UnsupportedDatasetError` semantics
- [x] `connectors/registry.py` now builds live connectors via `client_factory.build_client()`
- [x] parity baseline and connector tests pass with `kpubdata.Client` mocks while preserving v0.2 output
- [x] full local verification passed: pytest coverage, pytest `-m \"not integration\"`, ruff check, ruff format --check, mypy --strict

Closes #62