### PR TITLE
v0.3-4: Migrate KRX connector to kpubdata.Client (#63)

### DIFF
--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/client_factory.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/client_factory.py
@@ -12,16 +12,16 @@ def _env_var_name(provider: str) -> str:
     return f"KPUBDATA_{provider.upper()}_API_KEY"
 
 
-def _missing_providers() -> list[str]:
+def _missing_providers(required_providers: tuple[str, ...]) -> list[str]:
     missing: list[str] = []
-    for provider in REQUIRED_PROVIDERS:
+    for provider in required_providers:
         if not os.environ.get(_env_var_name(provider)):
             missing.append(provider)
     return missing
 
 
-def build_client() -> Client:
-    missing = _missing_providers()
+def build_client(*, required_providers: tuple[str, ...] = REQUIRED_PROVIDERS) -> Client:
+    missing = _missing_providers(required_providers)
     if missing:
         expected = ", ".join(_env_var_name(provider) for provider in missing)
         message = (

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/krx.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation
-import importlib
 from typing import Protocol, cast, final, runtime_checkable
+
+from kpubdata import Client
 
 from .base import ConnectorRowBase, SourceMetadata
 
@@ -45,92 +47,25 @@ class KrxConnector(Protocol):
     def fetch_market_valuation(self, start: date, end: date) -> tuple[MarketValuationRow, ...]: ...
 
 
-class PykrxStockApi(Protocol):
-    def get_index_ohlcv_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        freq: str = "d",
-        name_display: bool = True,
-    ) -> object: ...
-
-    def get_market_trading_value_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        etf: bool = False,
-        etn: bool = False,
-        elw: bool = False,
-        on: str = "순매수",
-        detail: bool = False,
-        freq: str = "d",
-    ) -> object: ...
-
-    def get_index_fundamental_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        prev: bool = True,
-    ) -> object: ...
-
-
-class _FrameIndex(Protocol):
-    def tolist(self) -> list[object]: ...
-
-
-class _FrameAtAccessor(Protocol):
-    def __getitem__(self, key: tuple[object, str]) -> object: ...
-
-
-class FrameLike(Protocol):
-    @property
-    def empty(self) -> bool: ...
-
-    @property
-    def index(self) -> _FrameIndex: ...
-
-    @property
-    def at(self) -> _FrameAtAccessor: ...
-
-    def sort_index(self) -> "FrameLike": ...
-
-
-class Sleep(Protocol):
-    def __call__(self, seconds: float, /) -> object: ...
-
-
-class Clock(Protocol):
-    def __call__(self) -> datetime: ...
+_KOSPI_INDEX_DATASET_ID = "krx.kospi_index"
+_INVESTOR_FLOW_DATASET_ID = "krx.investor_flow"
+_MARKET_VALUATION_DATASET_ID = "krx.market_valuation"
+_INDIVIDUAL_INVESTOR_TYPE = "개인"
+_FOREIGN_INVESTOR_TYPE = "외국인"
+_INSTITUTION_INVESTOR_TYPE = "기관"
 
 
 def _utc_now() -> datetime:
-    return datetime.now(timezone.utc).replace(microsecond=0)
-
-
-def _default_sleep(seconds: float) -> None:
-    from time import sleep
-
-    sleep(seconds)
-
-
-def _load_default_stock_api() -> PykrxStockApi:
-    return cast(PykrxStockApi, importlib.import_module("pykrx.stock"))
-
-
-def _format_date(value: date) -> str:
-    return value.strftime("%Y%m%d")
+    return datetime.now(timezone.utc)
 
 
 def _parse_decimal(value: object) -> Decimal:
     try:
         parsed = Decimal(str(value))
     except InvalidOperation as exc:
-        raise ValueError(f"invalid decimal value from pykrx: {value!r}") from exc
+        raise ValueError(f"invalid decimal value from kpubdata: {value!r}") from exc
     if not parsed.is_finite():
-        raise ValueError(f"non-finite decimal value from pykrx: {value!r}")
+        raise ValueError(f"non-finite decimal value from kpubdata: {value!r}")
     return parsed
 
 
@@ -145,235 +80,177 @@ def _row_date(value: object) -> date:
         return value.date()
     if isinstance(value, str):
         return date.fromisoformat(value[:10])
-    raise ValueError(f"unsupported row date value from pykrx: {value!r}")
+    raise ValueError(f"unsupported row date value from kpubdata: {value!r}")
 
 
-def _as_frame(frame: object) -> FrameLike:
-    return cast(FrameLike, frame)
+def _require_record_rows(payload: object) -> tuple[Mapping[str, object], ...]:
+    if not isinstance(payload, Sequence) or isinstance(payload, str | bytes | bytearray):
+        raise ValueError("KRX record batch payload must be a sequence")
+    raw_payload = cast(Sequence[object], payload)
+    rows: list[Mapping[str, object]] = []
+    for raw_row in raw_payload:
+        if not isinstance(raw_row, Mapping):
+            raise ValueError("KRX record payload must be an object")
+        rows.append(cast(Mapping[str, object], raw_row))
+    return tuple(rows)
 
 
-def _sorted_index_values(frame: FrameLike) -> tuple[object, ...]:
-    return tuple(frame.index.tolist())
+def _require_string(mapping: Mapping[str, object], key: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str):
+        raise ValueError(f"missing KRX string field: {key}")
+    return value
 
 
-def _frame_value(frame: FrameLike, index_value: object, column_name: str) -> object:
-    return frame.at[index_value, column_name]
-
-
-def _chunk_date_ranges(start: date, end: date, *, chunk_days: int) -> tuple[tuple[date, date], ...]:
-    chunks: list[tuple[date, date]] = []
-    current_start = start
-    while current_start <= end:
-        current_end = min(current_start + timedelta(days=chunk_days), end)
-        chunks.append((current_start, current_end))
-        current_start = current_end + timedelta(days=1)
-    return tuple(chunks)
+def _require_value(mapping: Mapping[str, object], key: str) -> object:
+    if key not in mapping:
+        raise ValueError(f"missing KRX field: {key}")
+    return mapping[key]
 
 
 @final
 class PykrxKrxConnector:
     SOURCE_NAME = "krx"
-    KOSPI_INDEX_TICKER = "1001"
-    MAX_CHUNK_DAYS = 730
 
-    _stock_api: PykrxStockApi | None
-    _clock: Clock
-    _sleep: Sleep
+    _client: Client
+    _clock: Callable[[], datetime]
 
-    def __init__(
-        self,
-        *,
-        stock_api: PykrxStockApi | None = None,
-        clock: Clock = _utc_now,
-        sleep: Sleep = _default_sleep,
-    ) -> None:
-        self._stock_api = stock_api
+    def __init__(self, *, client: Client, clock: Callable[[], datetime] = _utc_now) -> None:
+        self._client = client
         self._clock = clock
-        self._sleep = sleep
-
-    @property
-    def stock_api(self) -> PykrxStockApi:
-        if self._stock_api is None:
-            self._stock_api = _load_default_stock_api()
-        return self._stock_api
 
     def fetch_kospi_index(self, start: date, end: date) -> tuple[KospiIndexRow, ...]:
-        metadata = self._metadata(dataset_name="kospi_index")
-        rows: list[KospiIndexRow] = []
-        request = _ChunkedPykrxRequester(
-            sleep=self._sleep,
-            should_throttle=(end - start).days > self.MAX_CHUNK_DAYS,
+        return parse_kospi_index_rows(
+            payload=self._query_dataset(_KOSPI_INDEX_DATASET_ID, start, end),
+            fetched_at_utc=self._fetched_at_utc(),
+            connector_id=self._connector_id(),
         )
-        for chunk_start, chunk_end in _chunk_date_ranges(
-            start, end, chunk_days=self.MAX_CHUNK_DAYS
-        ):
-            frame = _as_frame(
-                request.call(
-                    self.stock_api.get_index_ohlcv_by_date,
-                    _format_date(chunk_start),
-                    _format_date(chunk_end),
-                    self.KOSPI_INDEX_TICKER,
-                    freq="d",
-                    name_display=False,
-                )
-            )
-            rows.extend(self._build_kospi_index_rows(frame, metadata))
-        return tuple(sorted(rows, key=lambda row: row.trade_date))
 
     def fetch_investor_flow(self, start: date, end: date) -> tuple[InvestorFlowRow, ...]:
-        metadata = self._metadata(dataset_name="investor_flow")
-        rows: list[InvestorFlowRow] = []
-        request = _ChunkedPykrxRequester(
-            sleep=self._sleep,
-            should_throttle=(end - start).days > self.MAX_CHUNK_DAYS,
+        return parse_investor_flow_rows(
+            payload=self._query_dataset(_INVESTOR_FLOW_DATASET_ID, start, end),
+            fetched_at_utc=self._fetched_at_utc(),
+            connector_id=self._connector_id(),
         )
-        for chunk_start, chunk_end in _chunk_date_ranges(
-            start, end, chunk_days=self.MAX_CHUNK_DAYS
-        ):
-            frame = _as_frame(
-                request.call(
-                    self.stock_api.get_market_trading_value_by_date,
-                    _format_date(chunk_start),
-                    _format_date(chunk_end),
-                    "KOSPI",
-                    etf=False,
-                    etn=False,
-                    elw=False,
-                    on="순매수",
-                    detail=False,
-                    freq="d",
-                )
-            )
-            rows.extend(self._build_investor_flow_rows(frame, metadata))
-        return tuple(sorted(rows, key=lambda row: row.trade_date))
 
     def fetch_market_valuation(self, start: date, end: date) -> tuple[MarketValuationRow, ...]:
-        metadata = self._metadata(dataset_name="market_valuation")
-        rows: list[MarketValuationRow] = []
-        request = _ChunkedPykrxRequester(
-            sleep=self._sleep,
-            should_throttle=(end - start).days > self.MAX_CHUNK_DAYS,
-        )
-        for chunk_start, chunk_end in _chunk_date_ranges(
-            start, end, chunk_days=self.MAX_CHUNK_DAYS
-        ):
-            ohlcv_frame = _as_frame(
-                request.call(
-                    self.stock_api.get_index_ohlcv_by_date,
-                    _format_date(chunk_start),
-                    _format_date(chunk_end),
-                    self.KOSPI_INDEX_TICKER,
-                    freq="d",
-                    name_display=False,
-                )
-            )
-            fundamental_frame = _as_frame(
-                request.call(
-                    self.stock_api.get_index_fundamental_by_date,
-                    _format_date(chunk_start),
-                    _format_date(chunk_end),
-                    self.KOSPI_INDEX_TICKER,
-                    prev=True,
-                )
-            )
-            rows.extend(self._build_market_valuation_rows(ohlcv_frame, fundamental_frame, metadata))
-        return tuple(sorted(rows, key=lambda row: row.trade_date))
-
-    def _metadata(self, *, dataset_name: str) -> SourceMetadata:
-        fetched_at_utc = self._clock().astimezone(timezone.utc).replace(microsecond=0).isoformat()
-        connector_type = type(self)
-
-        return SourceMetadata(
-            source_name=self.SOURCE_NAME,
-            dataset_name=dataset_name,
-            fetched_at_utc=fetched_at_utc,
-            connector_id=f"{connector_type.__module__}.{connector_type.__qualname__}",
+        return parse_market_valuation_rows(
+            payload=self._query_dataset(_MARKET_VALUATION_DATASET_ID, start, end),
+            market_caps_payload=self._query_dataset(_KOSPI_INDEX_DATASET_ID, start, end),
+            fetched_at_utc=self._fetched_at_utc(),
+            connector_id=self._connector_id(),
         )
 
-    def _build_kospi_index_rows(
-        self, frame: FrameLike, metadata: SourceMetadata
-    ) -> tuple[KospiIndexRow, ...]:
-        if frame.empty:
-            return ()
-        sorted_frame = frame.sort_index()
-        return tuple(
-            KospiIndexRow(
-                metadata=metadata,
-                trade_date=_row_date(index_value),
-                open_price=_parse_decimal(_frame_value(sorted_frame, index_value, "시가")),
-                high_price=_parse_decimal(_frame_value(sorted_frame, index_value, "고가")),
-                low_price=_parse_decimal(_frame_value(sorted_frame, index_value, "저가")),
-                close_price=_parse_decimal(_frame_value(sorted_frame, index_value, "종가")),
-                volume=_parse_int(_frame_value(sorted_frame, index_value, "거래량")),
-                turnover=_parse_decimal(_frame_value(sorted_frame, index_value, "거래대금")),
-            )
-            for index_value in _sorted_index_values(sorted_frame)
-        )
-
-    def _build_investor_flow_rows(
-        self, frame: FrameLike, metadata: SourceMetadata
-    ) -> tuple[InvestorFlowRow, ...]:
-        if frame.empty:
-            return ()
-        sorted_frame = frame.sort_index()
-        return tuple(
-            InvestorFlowRow(
-                metadata=metadata,
-                trade_date=_row_date(index_value),
-                individual_net_buy=_parse_decimal(_frame_value(sorted_frame, index_value, "개인")),
-                foreign_net_buy=_parse_decimal(
-                    _frame_value(sorted_frame, index_value, "외국인합계")
-                ),
-                institution_net_buy=_parse_decimal(
-                    _frame_value(sorted_frame, index_value, "기관합계")
-                ),
-            )
-            for index_value in _sorted_index_values(sorted_frame)
-        )
-
-    def _build_market_valuation_rows(
+    def _query_dataset(
         self,
-        ohlcv_frame: FrameLike,
-        fundamental_frame: FrameLike,
-        metadata: SourceMetadata,
-    ) -> tuple[MarketValuationRow, ...]:
-        if ohlcv_frame.empty or fundamental_frame.empty:
-            return ()
-        sorted_ohlcv = ohlcv_frame.sort_index()
-        sorted_fundamental = fundamental_frame.sort_index()
-        fundamental_index = frozenset(_sorted_index_values(sorted_fundamental))
-        joined_index = tuple(
-            index_value
-            for index_value in _sorted_index_values(sorted_ohlcv)
-            if index_value in fundamental_index
+        dataset_id: str,
+        start: date,
+        end: date,
+    ) -> tuple[Mapping[str, object], ...]:
+        batch = self._client.dataset(dataset_id).list(
+            start_date=start.isoformat(),
+            end_date=end.isoformat(),
         )
-        return tuple(
+        return _require_record_rows(batch.items)
+
+    def _connector_id(self) -> str:
+        connector_type = type(self)
+        return f"{connector_type.__module__}.{connector_type.__qualname__}"
+
+    def _fetched_at_utc(self) -> str:
+        return self._clock().astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def parse_kospi_index_rows(
+    *,
+    payload: object,
+    fetched_at_utc: str,
+    connector_id: str,
+) -> tuple[KospiIndexRow, ...]:
+    metadata = _source_metadata("kospi_index", fetched_at_utc, connector_id)
+    rows = _require_record_rows(payload)
+    return tuple(
+        sorted(
+            (
+                KospiIndexRow(
+                    metadata=metadata,
+                    trade_date=_row_date(_require_value(raw_row, "date")),
+                    open_price=_parse_decimal(_require_value(raw_row, "open")),
+                    high_price=_parse_decimal(_require_value(raw_row, "high")),
+                    low_price=_parse_decimal(_require_value(raw_row, "low")),
+                    close_price=_parse_decimal(_require_value(raw_row, "close")),
+                    volume=_parse_int(_require_value(raw_row, "volume")),
+                    turnover=_parse_decimal(_require_value(raw_row, "trading_value")),
+                )
+                for raw_row in rows
+            ),
+            key=lambda row: row.trade_date,
+        )
+    )
+
+
+def parse_investor_flow_rows(
+    *,
+    payload: object,
+    fetched_at_utc: str,
+    connector_id: str,
+) -> tuple[InvestorFlowRow, ...]:
+    metadata = _source_metadata("investor_flow", fetched_at_utc, connector_id)
+    aggregated: dict[date, dict[str, Decimal]] = {}
+    for raw_row in _require_record_rows(payload):
+        trade_date = _row_date(_require_value(raw_row, "date"))
+        investor_type = _require_string(raw_row, "investor_type")
+        totals = aggregated.setdefault(trade_date, {})
+        current_total = totals.get(investor_type, Decimal("0"))
+        totals[investor_type] = current_total + _parse_decimal(_require_value(raw_row, "net_value"))
+    return tuple(
+        InvestorFlowRow(
+            metadata=metadata,
+            trade_date=trade_date,
+            individual_net_buy=totals.get(_INDIVIDUAL_INVESTOR_TYPE, Decimal("0")),
+            foreign_net_buy=totals.get(_FOREIGN_INVESTOR_TYPE, Decimal("0")),
+            institution_net_buy=totals.get(_INSTITUTION_INVESTOR_TYPE, Decimal("0")),
+        )
+        for trade_date, totals in sorted(aggregated.items())
+    )
+
+
+def parse_market_valuation_rows(
+    *,
+    payload: object,
+    market_caps_payload: object,
+    fetched_at_utc: str,
+    connector_id: str,
+) -> tuple[MarketValuationRow, ...]:
+    metadata = _source_metadata("market_valuation", fetched_at_utc, connector_id)
+    market_caps = {
+        _row_date(_require_value(raw_row, "date")): _parse_decimal(
+            _require_value(raw_row, "market_cap")
+        )
+        for raw_row in _require_record_rows(market_caps_payload)
+    }
+    rows: list[MarketValuationRow] = []
+    for raw_row in _require_record_rows(payload):
+        trade_date = _row_date(_require_value(raw_row, "date"))
+        market_capitalization = market_caps.get(trade_date)
+        if market_capitalization is None:
+            continue
+        rows.append(
             MarketValuationRow(
                 metadata=metadata,
-                trade_date=_row_date(index_value),
-                market_capitalization=_parse_decimal(
-                    _frame_value(sorted_ohlcv, index_value, "상장시가총액")
-                ),
-                trailing_per=_parse_decimal(_frame_value(sorted_fundamental, index_value, "PER")),
-                trailing_pbr=_parse_decimal(_frame_value(sorted_fundamental, index_value, "PBR")),
+                trade_date=trade_date,
+                market_capitalization=market_capitalization,
+                trailing_per=_parse_decimal(_require_value(raw_row, "per")),
+                trailing_pbr=_parse_decimal(_require_value(raw_row, "pbr")),
             )
-            for index_value in joined_index
         )
+    return tuple(sorted(rows, key=lambda row: row.trade_date))
 
 
-class _PykrxOperation(Protocol):
-    def __call__(self, /, *args: object, **kwargs: object) -> object: ...
-
-
-@dataclass(slots=True)
-class _ChunkedPykrxRequester:
-    sleep: Sleep
-    should_throttle: bool
-    _call_count: int = 0
-
-    def call(self, operation: object, /, *args: object, **kwargs: object) -> object:
-        if self.should_throttle and self._call_count > 0:
-            _ = self.sleep(1.0)
-        self._call_count += 1
-        fetch = cast(_PykrxOperation, operation)
-        return fetch(*args, **kwargs)
+def _source_metadata(dataset_name: str, fetched_at_utc: str, connector_id: str) -> SourceMetadata:
+    return SourceMetadata(
+        source_name="krx",
+        dataset_name=dataset_name,
+        fetched_at_utc=fetched_at_utc,
+        connector_id=connector_id,
+    )

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
@@ -16,7 +16,7 @@ class LiveConnectorRegistry:
     def get_connector(self, source: str, *, api_key: str | None = None) -> object:
         del api_key
         if source == "krx":
-            return PykrxKrxConnector(client=client_factory.build_client())
+            return PykrxKrxConnector(client=client_factory.build_client(required_providers=()))
         if source == "ecos":
             return LiveEcosConnector(client=client_factory.build_client())
         if source == "kosis":

--- a/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
+++ b/apps/kr-kospi/src/kospi_decision_pipeline_app_kr_kospi/connectors/registry.py
@@ -16,7 +16,7 @@ class LiveConnectorRegistry:
     def get_connector(self, source: str, *, api_key: str | None = None) -> object:
         del api_key
         if source == "krx":
-            return PykrxKrxConnector()
+            return PykrxKrxConnector(client=client_factory.build_client())
         if source == "ecos":
             return LiveEcosConnector(client=client_factory.build_client())
         if source == "kosis":

--- a/apps/kr-kospi/tests/contract/test_kpubdata_krx_dataset_list_shape.py
+++ b/apps/kr-kospi/tests/contract/test_kpubdata_krx_dataset_list_shape.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import inspect
+
+import pytest
+from kpubdata import Client
+from kpubdata.providers.krx import adapter as krx_adapter
+
+
+@dataclass(frozen=True, slots=True)
+class _FakeRecordBatch:
+    items: tuple[object, ...]
+    total_count: int | None = 0
+    next_page: int | None = None
+    next_cursor: str | None = None
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    [
+        "krx.kospi_index",
+        "krx.investor_flow",
+        "krx.market_valuation",
+    ],
+)
+def test_krx_dataset_list_signature_accepts_top_level_kwargs(dataset_id: str) -> None:
+    signature = inspect.signature(Client.from_env().dataset(dataset_id).list)
+
+    assert len(signature.parameters) == 1
+    assert next(iter(signature.parameters.values())).kind is inspect.Parameter.VAR_KEYWORD
+
+
+@pytest.mark.parametrize(
+    "dataset_id",
+    [
+        "krx.kospi_index",
+        "krx.investor_flow",
+        "krx.market_valuation",
+    ],
+)
+def test_krx_dataset_list_maps_top_level_kwargs_into_query(
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_id: str,
+) -> None:
+    monkeypatch.setenv("KPUBDATA_KRX_INTEGRATION", "1")
+    captured_queries: list[object] = []
+
+    def spy(self: object, dataset_ref: object, query: object) -> _FakeRecordBatch:
+        del self, dataset_ref
+        captured_queries.append(query)
+        return _FakeRecordBatch(())
+
+    monkeypatch.setattr(krx_adapter.KrxAdapter, "query_records", spy)
+
+    batch = (
+        Client.from_env()
+        .dataset(dataset_id)
+        .list(
+            start_date="2024-01-02",
+            end_date="2024-01-05",
+        )
+    )
+
+    assert tuple(batch.items) == ()
+    assert len(captured_queries) == 1
+    query = captured_queries[0]
+    assert getattr(query, "start_date") == "2024-01-02"
+    assert getattr(query, "end_date") == "2024-01-05"
+    assert getattr(query, "filters") == {}
+    assert getattr(query, "extra") == {}

--- a/apps/kr-kospi/tests/contract/test_live_connector_registry.py
+++ b/apps/kr-kospi/tests/contract/test_live_connector_registry.py
@@ -2,14 +2,33 @@ from __future__ import annotations
 
 import pytest
 
-from kospi_decision_pipeline_app_kr_kospi.connectors.krx import PykrxKrxConnector
 from kospi_decision_pipeline_app_kr_kospi.connectors.registry import LiveConnectorRegistry
 
 
-def test_live_connector_registry_returns_pykrx_connector_for_krx() -> None:
+def test_live_connector_registry_builds_client_for_krx(monkeypatch: pytest.MonkeyPatch) -> None:
+    built_client = object()
+    observed: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.client_factory.build_client",
+        lambda: built_client,
+    )
+
+    class _FakeKrxConnector:
+        def __init__(self, *, client: object) -> None:
+            observed["client"] = client
+
+    monkeypatch.setattr(
+        "kospi_decision_pipeline_app_kr_kospi.connectors.registry.PykrxKrxConnector",
+        _FakeKrxConnector,
+    )
+
     registry = LiveConnectorRegistry()
 
-    assert isinstance(registry.get_connector("krx"), PykrxKrxConnector)
+    connector = registry.get_connector("krx")
+
+    assert isinstance(connector, _FakeKrxConnector)
+    assert observed == {"client": built_client}
 
 
 def test_live_connector_registry_builds_client_for_ecos(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/kr-kospi/tests/contract/test_live_connector_registry.py
+++ b/apps/kr-kospi/tests/contract/test_live_connector_registry.py
@@ -8,10 +8,15 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.registry import LiveConnect
 def test_live_connector_registry_builds_client_for_krx(monkeypatch: pytest.MonkeyPatch) -> None:
     built_client = object()
     observed: dict[str, object] = {}
+    build_client_calls: list[tuple[str, ...]] = []
+
+    def _fake_build_client(*, required_providers: tuple[str, ...] = ()) -> object:
+        build_client_calls.append(required_providers)
+        return built_client
 
     monkeypatch.setattr(
         "kospi_decision_pipeline_app_kr_kospi.connectors.registry.client_factory.build_client",
-        lambda: built_client,
+        _fake_build_client,
     )
 
     class _FakeKrxConnector:
@@ -29,6 +34,7 @@ def test_live_connector_registry_builds_client_for_krx(monkeypatch: pytest.Monke
 
     assert isinstance(connector, _FakeKrxConnector)
     assert observed == {"client": built_client}
+    assert build_client_calls == [()]
 
 
 def test_live_connector_registry_builds_client_for_ecos(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/kr-kospi/tests/contract/test_pykrx_krx_connector.py
+++ b/apps/kr-kospi/tests/contract/test_pykrx_krx_connector.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal
-import json
-import os
-from pathlib import Path
+from types import SimpleNamespace
 from typing import cast
+
 import pytest
+from kpubdata import Client
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
     InvestorFlowRow,
@@ -16,279 +18,114 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
 )
 
 
-FIXTURES_ROOT = Path(__file__).resolve().parents[1] / "fixtures" / "krx"
+START_DATE = date(2024, 1, 2)
+END_DATE = date(2024, 1, 3)
+FETCHED_AT = datetime(2024, 1, 10, 9, 0, tzinfo=timezone.utc)
 
 
-def _parse_pykrx_date(value: object) -> date:
-    return datetime.strptime(str(value), "%Y%m%d").date()
+@dataclass(frozen=True, slots=True)
+class _FakeRecordBatch:
+    items: tuple[Mapping[str, object], ...]
 
 
-class FakeFrameIndex:
-    def __init__(self, values: tuple[object, ...]) -> None:
-        self._values = values
+class _FakeDataset:
+    def __init__(self, items: tuple[Mapping[str, object], ...]) -> None:
+        self._batch = _FakeRecordBatch(items)
+        self.calls: list[dict[str, object]] = []
 
-    def tolist(self) -> list[object]:
-        return list(self._values)
-
-
-class FakeFrameAtAccessor:
-    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
-        self._rows = rows
-
-    def __getitem__(self, key: tuple[object, str]) -> object:
-        index_value, column_name = key
-        return self._rows[index_value][column_name]
-
-
-class FakeDataFrame:
-    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
-        self._rows = rows
-
-    @property
-    def empty(self) -> bool:
-        return not self._rows
-
-    @property
-    def index(self) -> FakeFrameIndex:
-        return FakeFrameIndex(tuple(self._rows))
-
-    @property
-    def at(self) -> FakeFrameAtAccessor:
-        return FakeFrameAtAccessor(self._rows)
-
-    def sort_index(self) -> FakeDataFrame:
-        return FakeDataFrame(dict(sorted(self._rows.items(), key=lambda item: str(item[0]))))
-
-
-def _load_frame_fixture(name: str) -> FakeDataFrame:
-    payload = cast(
-        dict[str, object], json.loads((FIXTURES_ROOT / name).read_text(encoding="utf-8"))
-    )
-    raw_rows = cast(list[dict[str, object]], payload["rows"])
-    rows: dict[object, dict[str, object]] = {}
-    for raw_row in raw_rows:
-        rows[datetime.fromisoformat(str(raw_row["index"]))] = cast(
-            dict[str, object], raw_row["values"]
-        )
-    return FakeDataFrame(rows)
-
-
-def _load_market_valuation_frames() -> tuple[FakeDataFrame, FakeDataFrame]:
-    payload = cast(
-        dict[str, object],
-        json.loads((FIXTURES_ROOT / "market_valuation_frames.json").read_text(encoding="utf-8")),
-    )
-
-    def _as_frame(frame_payload: object) -> FakeDataFrame:
-        mapping = cast(dict[str, object], frame_payload)
-        raw_rows = cast(list[dict[str, object]], mapping["rows"])
-        rows: dict[object, dict[str, object]] = {}
-        for raw_row in raw_rows:
-            rows[datetime.fromisoformat(str(raw_row["index"]))] = cast(
-                dict[str, object], raw_row["values"]
-            )
-        return FakeDataFrame(rows)
-
-    return (_as_frame(payload["ohlcv"]), _as_frame(payload["fundamental"]))
-
-
-class FakePykrxStockApi:
-    def __init__(self) -> None:
-        self.calls: list[tuple[str, tuple[object, ...], dict[str, object]]] = []
-        self._kospi_index_frame = _load_frame_fixture("kospi_index_frame.json")
-        self._investor_flow_frame = _load_frame_fixture("investor_flow_frame.json")
-        self._market_valuation_ohlcv_frame, self._market_valuation_fundamental_frame = (
-            _load_market_valuation_frames()
-        )
-
-    def get_index_ohlcv_by_date(
+    def list(
         self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        freq: str = "d",
-        name_display: bool = True,
-    ) -> FakeDataFrame:
+        *,
+        start_date: object,
+        end_date: object,
+        market: object | None = None,
+    ) -> _FakeRecordBatch:
         self.calls.append(
-            (
-                "get_index_ohlcv_by_date",
-                (fromdate, todate, ticker),
-                {"freq": freq, "name_display": name_display},
-            )
-        )
-        if fromdate == "20240106":
-            return FakeDataFrame({})
-        return (
-            self._market_valuation_ohlcv_frame
-            if fromdate == "20240102" and todate == "20240103"
-            else self._kospi_index_frame
-        )
-
-    def get_market_trading_value_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        etf: bool = False,
-        etn: bool = False,
-        elw: bool = False,
-        on: str = "순매수",
-        detail: bool = False,
-        freq: str = "d",
-    ) -> FakeDataFrame:
-        self.calls.append(
-            (
-                "get_market_trading_value_by_date",
-                (fromdate, todate, ticker),
-                {
-                    "etf": etf,
-                    "etn": etn,
-                    "elw": elw,
-                    "on": on,
-                    "detail": detail,
-                    "freq": freq,
-                },
-            )
-        )
-        if fromdate == "20240106":
-            return FakeDataFrame({})
-        return self._investor_flow_frame
-
-    def get_index_fundamental_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        prev: bool = True,
-    ) -> FakeDataFrame:
-        self.calls.append(
-            (
-                "get_index_fundamental_by_date",
-                (fromdate, todate, ticker),
-                {"prev": prev},
-            )
-        )
-        if fromdate == "20240106":
-            return FakeDataFrame({})
-        return self._market_valuation_fundamental_frame
-
-
-class InvalidDecimalStockApi(FakePykrxStockApi):
-    def get_index_ohlcv_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        freq: str = "d",
-        name_display: bool = True,
-    ) -> FakeDataFrame:
-        return FakeDataFrame(
             {
-                datetime(2024, 1, 2): {
-                    "시가": "bad-decimal",
-                    "고가": 1,
-                    "저가": 1,
-                    "종가": 1,
-                    "거래량": 1,
-                    "거래대금": 1,
-                    "상장시가총액": 1,
-                }
+                "start_date": start_date,
+                "end_date": end_date,
+                "market": market,
             }
         )
+        return self._batch
 
 
-class NonFiniteDecimalStockApi(FakePykrxStockApi):
-    def get_index_fundamental_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        prev: bool = True,
-    ) -> FakeDataFrame:
-        return FakeDataFrame({datetime(2024, 1, 2): {"PER": "NaN", "PBR": 0.93}})
+class _FakeClient:
+    def __init__(self, datasets: Mapping[str, object]) -> None:
+        self._config = SimpleNamespace(provider_keys={})
+        self._datasets = dict(datasets)
+        self.dataset_calls: list[str] = []
+
+    def dataset(self, dataset_id: str) -> object:
+        self.dataset_calls.append(dataset_id)
+        return self._datasets[dataset_id]
 
 
-class UnsupportedDateStockApi(FakePykrxStockApi):
-    def get_index_ohlcv_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        freq: str = "d",
-        name_display: bool = True,
-    ) -> FakeDataFrame:
-        return FakeDataFrame(
+class _ConfigurableClient:
+    def __init__(self, dataset_id: str, dataset: object) -> None:
+        self._datasets = {dataset_id: dataset}
+
+    def dataset(self, dataset_id: str) -> object:
+        return self._datasets[dataset_id]
+
+
+def _build_client(**datasets: object) -> _FakeClient:
+    return _FakeClient(datasets)
+
+
+def test_live_krx_connector_normalizes_kpubdata_record_batches_into_typed_rows() -> None:
+    kospi_dataset = _FakeDataset(
+        (
             {
-                cast(datetime, object()): {
-                    "시가": 1,
-                    "고가": 1,
-                    "저가": 1,
-                    "종가": 1,
-                    "거래량": 1,
-                    "거래대금": 1,
-                    "상장시가총액": 1,
-                }
-            }
-        )
-
-
-class NativeDateStockApi(FakePykrxStockApi):
-    def get_market_trading_value_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        etf: bool = False,
-        etn: bool = False,
-        elw: bool = False,
-        on: str = "순매수",
-        detail: bool = False,
-        freq: str = "d",
-    ) -> FakeDataFrame:
-        return FakeDataFrame(
+                "date": "2024-01-03",
+                "open": "2660.0",
+                "high": "2672.1",
+                "low": "2631.5",
+                "close": "2645.2",
+                "volume": 460000000,
+                "trading_value": "9100000000000",
+                "market_cap": "2100000000000000",
+            },
             {
-                datetime(2024, 1, 2).date(): {
-                    "개인": Decimal("1"),
-                    "외국인합계": Decimal("2"),
-                    "기관합계": Decimal("3"),
-                }
-            }
+                "date": "2024-01-02",
+                "open": "2640.5",
+                "high": "2655.0",
+                "low": "2621.0",
+                "close": "2651.8",
+                "volume": 470000000,
+                "trading_value": "9200000000000",
+                "market_cap": "2110000000000000",
+            },
         )
-
-
-class StringDateStockApi(FakePykrxStockApi):
-    def get_market_trading_value_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        etf: bool = False,
-        etn: bool = False,
-        elw: bool = False,
-        on: str = "순매수",
-        detail: bool = False,
-        freq: str = "d",
-    ) -> FakeDataFrame:
-        return FakeDataFrame(
-            {
-                "2024-01-02 00:00:00": {
-                    "개인": Decimal("1"),
-                    "외국인합계": Decimal("2"),
-                    "기관합계": Decimal("3"),
-                }
-            }
-        )
-
-
-def test_pykrx_krx_connector_normalizes_dataframes_into_typed_rows() -> None:
-    connector = PykrxKrxConnector(
-        stock_api=FakePykrxStockApi(),
-        clock=lambda: datetime(2024, 1, 10, 9, 0, tzinfo=timezone.utc),
     )
+    investor_dataset = _FakeDataset(
+        (
+            {"date": "2024-01-03", "investor_type": "외국인", "net_value": "150000000000"},
+            {"date": "2024-01-02", "investor_type": "기관", "net_value": "20000000000"},
+            {"date": "2024-01-02", "investor_type": "외국인", "net_value": "-120000000000"},
+            {"date": "2024-01-03", "investor_type": "개인", "net_value": "-200000000000"},
+            {"date": "2024-01-03", "investor_type": "기관", "net_value": "50000000000"},
+            {"date": "2024-01-02", "investor_type": "개인", "net_value": "100000000000"},
+        )
+    )
+    valuation_dataset = _FakeDataset(
+        (
+            {"date": "2024-01-03", "per": "12.5", "pbr": "0.95"},
+            {"date": "2024-01-02", "per": "12.2", "pbr": "0.93"},
+        )
+    )
+    client = _build_client(
+        **{
+            "krx.kospi_index": kospi_dataset,
+            "krx.investor_flow": investor_dataset,
+            "krx.market_valuation": valuation_dataset,
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client), clock=lambda: FETCHED_AT)
 
-    kospi_rows = connector.fetch_kospi_index(date(2024, 1, 2), date(2024, 1, 3))
-    investor_rows = connector.fetch_investor_flow(date(2024, 1, 2), date(2024, 1, 3))
-    valuation_rows = connector.fetch_market_valuation(date(2024, 1, 2), date(2024, 1, 3))
+    kospi_rows = connector.fetch_kospi_index(START_DATE, END_DATE)
+    investor_rows = connector.fetch_investor_flow(START_DATE, END_DATE)
+    valuation_rows = connector.fetch_market_valuation(START_DATE, END_DATE)
 
     assert kospi_rows == (
         KospiIndexRow(
@@ -347,138 +184,239 @@ def test_pykrx_krx_connector_normalizes_dataframes_into_typed_rows() -> None:
     assert kospi_rows[0].metadata.source_name == "krx"
     assert kospi_rows[0].metadata.dataset_name == "kospi_index"
     assert kospi_rows[0].metadata.connector_id.endswith("PykrxKrxConnector")
-    assert kospi_rows[0].metadata.fetched_at_utc == "2024-01-10T09:00:00+00:00"
+    assert kospi_rows[0].metadata.fetched_at_utc == FETCHED_AT.isoformat()
     assert investor_rows[0].metadata.dataset_name == "investor_flow"
     assert valuation_rows[0].metadata.dataset_name == "market_valuation"
+    assert client.dataset_calls == [
+        "krx.kospi_index",
+        "krx.investor_flow",
+        "krx.market_valuation",
+        "krx.kospi_index",
+    ]
+    assert kospi_dataset.calls == [
+        {"start_date": START_DATE.isoformat(), "end_date": END_DATE.isoformat(), "market": None},
+        {"start_date": START_DATE.isoformat(), "end_date": END_DATE.isoformat(), "market": None},
+    ]
+    assert investor_dataset.calls == [
+        {"start_date": START_DATE.isoformat(), "end_date": END_DATE.isoformat(), "market": None}
+    ]
+    assert valuation_dataset.calls == [
+        {"start_date": START_DATE.isoformat(), "end_date": END_DATE.isoformat(), "market": None}
+    ]
 
 
-def test_pykrx_krx_connector_returns_empty_rows_for_empty_window() -> None:
-    connector = PykrxKrxConnector(stock_api=FakePykrxStockApi())
+def test_live_krx_connector_returns_empty_rows_for_empty_record_batches() -> None:
+    empty_dataset = _FakeDataset(())
+    client = _build_client(
+        **{
+            "krx.kospi_index": empty_dataset,
+            "krx.investor_flow": empty_dataset,
+            "krx.market_valuation": empty_dataset,
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     assert connector.fetch_kospi_index(date(2024, 1, 6), date(2024, 1, 7)) == ()
     assert connector.fetch_investor_flow(date(2024, 1, 6), date(2024, 1, 7)) == ()
     assert connector.fetch_market_valuation(date(2024, 1, 6), date(2024, 1, 7)) == ()
 
 
-def test_pykrx_krx_connector_sleeps_between_chunked_pykrx_calls() -> None:
-    stock_api = FakePykrxStockApi()
-    sleep_calls: list[float] = []
-    connector = PykrxKrxConnector(stock_api=stock_api, sleep=sleep_calls.append)
-
-    _ = connector.fetch_kospi_index(date(2020, 1, 1), date(2024, 12, 31))
-
-    assert [call[0] for call in stock_api.calls] == [
-        "get_index_ohlcv_by_date",
-        "get_index_ohlcv_by_date",
-        "get_index_ohlcv_by_date",
-    ]
-    chunk_ranges = [
-        (_parse_pykrx_date(call[1][0]), _parse_pykrx_date(call[1][1])) for call in stock_api.calls
-    ]
-    assert chunk_ranges[0][0] == date(2020, 1, 1)
-    assert chunk_ranges[-1][1] == date(2024, 12, 31)
-    assert all((chunk_end - chunk_start).days <= 730 for chunk_start, chunk_end in chunk_ranges)
-    assert sleep_calls == [1.0, 1.0]
-
-
-def test_pykrx_krx_connector_lazy_loads_pykrx_and_uses_default_sleep(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    stock_api = FakePykrxStockApi()
-    sleep_calls: list[float] = []
-
-    def fake_import_module(name: str) -> FakePykrxStockApi:
-        assert name == "pykrx.stock"
-        return stock_api
-
-    def fake_sleep(seconds: float) -> None:
-        sleep_calls.append(seconds)
-
-    monkeypatch.setattr(
-        "kospi_decision_pipeline_app_kr_kospi.connectors.krx.importlib.import_module",
-        fake_import_module,
+def test_live_krx_connector_joins_market_caps_with_market_valuation_rows_by_trade_date() -> None:
+    kospi_dataset = _FakeDataset(
+        (
+            {"date": "2024-01-04", "market_cap": "999"},
+            {"date": "2024-01-02", "market_cap": "2110000000000000"},
+            {"date": "2024-01-03", "market_cap": "2100000000000000"},
+        )
     )
-    monkeypatch.setattr("time.sleep", fake_sleep)
+    valuation_dataset = _FakeDataset(
+        (
+            {"date": "2024-01-03", "per": "12.5", "pbr": "0.95"},
+            {"date": "2024-01-02", "per": "12.2", "pbr": "0.93"},
+        )
+    )
+    client = _build_client(
+        **{
+            "krx.kospi_index": kospi_dataset,
+            "krx.investor_flow": _FakeDataset(()),
+            "krx.market_valuation": valuation_dataset,
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client), clock=lambda: FETCHED_AT)
 
-    connector = PykrxKrxConnector()
+    rows = connector.fetch_market_valuation(START_DATE, END_DATE)
 
-    _ = connector.fetch_kospi_index(date(2020, 1, 1), date(2024, 12, 31))
+    assert [(row.trade_date, row.market_capitalization) for row in rows] == [
+        (date(2024, 1, 2), Decimal("2110000000000000")),
+        (date(2024, 1, 3), Decimal("2100000000000000")),
+    ]
 
-    assert sleep_calls == [1.0, 1.0]
-    assert len(stock_api.calls) == 3
 
-
-def test_pykrx_krx_connector_rejects_invalid_decimal_values() -> None:
-    connector = PykrxKrxConnector(stock_api=InvalidDecimalStockApi())
+def test_live_krx_connector_rejects_invalid_decimal_values() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(
+                (
+                    {
+                        "date": "2024-01-02",
+                        "open": "bad-decimal",
+                        "high": 1,
+                        "low": 1,
+                        "close": 1,
+                        "volume": 1,
+                        "trading_value": 1,
+                        "market_cap": 1,
+                    },
+                )
+            ),
+            "krx.investor_flow": _FakeDataset(()),
+            "krx.market_valuation": _FakeDataset(()),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     with pytest.raises(ValueError, match="invalid decimal value"):
         connector.fetch_kospi_index(date(2024, 1, 2), date(2024, 1, 2))
 
 
-def test_pykrx_krx_connector_rejects_non_finite_decimal_values() -> None:
-    connector = PykrxKrxConnector(stock_api=NonFiniteDecimalStockApi())
+def test_live_krx_connector_rejects_non_finite_decimal_values() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(({"date": "2024-01-02", "market_cap": 1},)),
+            "krx.investor_flow": _FakeDataset(()),
+            "krx.market_valuation": _FakeDataset(
+                ({"date": "2024-01-02", "per": "NaN", "pbr": "0.93"},)
+            ),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     with pytest.raises(ValueError, match="non-finite decimal value"):
         connector.fetch_market_valuation(date(2024, 1, 2), date(2024, 1, 2))
 
 
-def test_pykrx_krx_connector_rejects_unsupported_row_dates() -> None:
-    connector = PykrxKrxConnector(stock_api=UnsupportedDateStockApi())
+def test_live_krx_connector_rejects_unsupported_row_dates() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(
+                (
+                    {
+                        "date": cast(object, object()),
+                        "open": 1,
+                        "high": 1,
+                        "low": 1,
+                        "close": 1,
+                        "volume": 1,
+                        "trading_value": 1,
+                        "market_cap": 1,
+                    },
+                )
+            ),
+            "krx.investor_flow": _FakeDataset(()),
+            "krx.market_valuation": _FakeDataset(()),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     with pytest.raises(ValueError, match="unsupported row date value"):
         connector.fetch_kospi_index(date(2024, 1, 2), date(2024, 1, 2))
 
 
-def test_pykrx_krx_connector_accepts_native_date_index_values() -> None:
-    connector = PykrxKrxConnector(stock_api=NativeDateStockApi())
+def test_live_krx_connector_accepts_native_date_values() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(()),
+            "krx.investor_flow": _FakeDataset(
+                ({"date": date(2024, 1, 2), "investor_type": "개인", "net_value": Decimal("1")},)
+            ),
+            "krx.market_valuation": _FakeDataset(()),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     rows = connector.fetch_investor_flow(date(2024, 1, 2), date(2024, 1, 2))
 
     assert rows[0].trade_date == date(2024, 1, 2)
 
 
-def test_pykrx_krx_connector_accepts_string_date_index_values() -> None:
-    connector = PykrxKrxConnector(stock_api=StringDateStockApi())
+def test_live_krx_connector_accepts_string_datetime_values() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(()),
+            "krx.investor_flow": _FakeDataset(
+                (
+                    {
+                        "date": "2024-01-02 00:00:00",
+                        "investor_type": "개인",
+                        "net_value": Decimal("1"),
+                    },
+                )
+            ),
+            "krx.market_valuation": _FakeDataset(()),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
     rows = connector.fetch_investor_flow(date(2024, 1, 2), date(2024, 1, 2))
 
     assert rows[0].trade_date == date(2024, 1, 2)
 
 
-def test_pykrx_krx_connector_frame_fixtures_capture_expected_adapter_shapes() -> None:
-    kospi_frame = _load_frame_fixture("kospi_index_frame.json")
-    investor_frame = _load_frame_fixture("investor_flow_frame.json")
-    valuation_ohlcv_frame, valuation_fundamental_frame = _load_market_valuation_frames()
+def test_live_krx_connector_sorts_rows_deterministically() -> None:
+    client = _build_client(
+        **{
+            "krx.kospi_index": _FakeDataset(
+                (
+                    {
+                        "date": "2024-01-03",
+                        "open": 2,
+                        "high": 2,
+                        "low": 2,
+                        "close": 2,
+                        "volume": 2,
+                        "trading_value": 2,
+                        "market_cap": 20,
+                    },
+                    {
+                        "date": "2024-01-02",
+                        "open": 1,
+                        "high": 1,
+                        "low": 1,
+                        "close": 1,
+                        "volume": 1,
+                        "trading_value": 1,
+                        "market_cap": 10,
+                    },
+                )
+            ),
+            "krx.investor_flow": _FakeDataset(
+                (
+                    {"date": "2024-01-03", "investor_type": "개인", "net_value": 2},
+                    {"date": "2024-01-02", "investor_type": "개인", "net_value": 1},
+                )
+            ),
+            "krx.market_valuation": _FakeDataset(
+                (
+                    {"date": "2024-01-03", "per": 2, "pbr": 2},
+                    {"date": "2024-01-02", "per": 1, "pbr": 1},
+                )
+            ),
+        }
+    )
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
-    assert kospi_frame.index.tolist() == [datetime(2024, 1, 3), datetime(2024, 1, 2)]
-    assert kospi_frame.at[datetime(2024, 1, 3), "시가"] == "2660.0"
-    assert investor_frame.at[datetime(2024, 1, 2), "외국인합계"] == "-120000000000"
-    assert valuation_ohlcv_frame.at[datetime(2024, 1, 2), "상장시가총액"] == "2110000000000000"
-    assert valuation_fundamental_frame.at[datetime(2024, 1, 3), "PER"] == "12.5"
-
-
-def test_pykrx_krx_connector_sorts_fixture_backed_rows_deterministically() -> None:
-    connector = PykrxKrxConnector(stock_api=FakePykrxStockApi())
-
-    kospi_rows = connector.fetch_kospi_index(date(2024, 1, 2), date(2024, 1, 3))
-    investor_rows = connector.fetch_investor_flow(date(2024, 1, 2), date(2024, 1, 3))
-    valuation_rows = connector.fetch_market_valuation(date(2024, 1, 2), date(2024, 1, 3))
+    kospi_rows = connector.fetch_kospi_index(START_DATE, END_DATE)
+    investor_rows = connector.fetch_investor_flow(START_DATE, END_DATE)
+    valuation_rows = connector.fetch_market_valuation(START_DATE, END_DATE)
 
     assert tuple(row.trade_date for row in kospi_rows) == (date(2024, 1, 2), date(2024, 1, 3))
     assert tuple(row.trade_date for row in investor_rows) == (date(2024, 1, 2), date(2024, 1, 3))
     assert tuple(row.trade_date for row in valuation_rows) == (date(2024, 1, 2), date(2024, 1, 3))
 
 
-@pytest.mark.requires_network
-@pytest.mark.skipif(
-    os.getenv("KOSPI_PIPELINE_LIVE_KRX") != "1",
-    reason="set KOSPI_PIPELINE_LIVE_KRX=1 to run live KRX smoke test",
-)
-def test_pykrx_krx_connector_live_smoke() -> None:
-    connector = PykrxKrxConnector()
+def test_live_krx_connector_raises_when_dataset_cannot_list_records() -> None:
+    client = _ConfigurableClient("krx.kospi_index", object())
+    connector = PykrxKrxConnector(client=cast(Client, client))
 
-    rows = connector.fetch_kospi_index(date(2024, 1, 2), date(2024, 1, 5))
-
-    assert rows
-    assert rows == tuple(sorted(rows, key=lambda row: row.trade_date))
-    assert all(row.metadata.connector_id.endswith("PykrxKrxConnector") for row in rows)
+    with pytest.raises(AttributeError, match="list"):
+        connector.fetch_kospi_index(START_DATE, END_DATE)

--- a/apps/kr-kospi/tests/contract/test_pykrx_krx_connector.py
+++ b/apps/kr-kospi/tests/contract/test_pykrx_krx_connector.py
@@ -15,6 +15,9 @@ from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
     KospiIndexRow,
     MarketValuationRow,
     PykrxKrxConnector,
+    parse_investor_flow_rows,
+    parse_kospi_index_rows,
+    parse_market_valuation_rows,
 )
 
 
@@ -301,7 +304,7 @@ def test_live_krx_connector_rejects_unsupported_row_dates() -> None:
             "krx.kospi_index": _FakeDataset(
                 (
                     {
-                        "date": cast(object, object()),
+                        "date": object(),
                         "open": 1,
                         "high": 1,
                         "low": 1,
@@ -420,3 +423,66 @@ def test_live_krx_connector_raises_when_dataset_cannot_list_records() -> None:
 
     with pytest.raises(AttributeError, match="list"):
         connector.fetch_kospi_index(START_DATE, END_DATE)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({}, "record batch payload"),
+        (("bad-row",), "record payload"),
+        (({"open": 1},), "date"),
+        (({"date": "2024-01-02"},), "open"),
+    ],
+)
+def test_parse_kospi_index_rows_validate_payload_shape(payload: object, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        parse_kospi_index_rows(
+            payload=payload,
+            fetched_at_utc=FETCHED_AT.isoformat(),
+            connector_id="test.connector",
+        )
+
+
+def test_parse_investor_flow_rows_requires_string_investor_type() -> None:
+    with pytest.raises(ValueError, match="investor_type"):
+        parse_investor_flow_rows(
+            payload=({"date": "2024-01-02", "investor_type": 1, "net_value": "1"},),
+            fetched_at_utc=FETCHED_AT.isoformat(),
+            connector_id="test.connector",
+        )
+
+
+def test_parse_kospi_index_rows_accept_datetime_values() -> None:
+    rows = parse_kospi_index_rows(
+        payload=(
+            {
+                "date": datetime(2024, 1, 2, tzinfo=timezone.utc),
+                "open": "1",
+                "high": "2",
+                "low": "0",
+                "close": "1.5",
+                "volume": 10,
+                "trading_value": "100",
+            },
+        ),
+        fetched_at_utc=FETCHED_AT.isoformat(),
+        connector_id="test.connector",
+    )
+
+    assert rows[0].trade_date == date(2024, 1, 2)
+
+
+def test_parse_market_valuation_rows_skips_dates_missing_market_cap_match() -> None:
+    rows = parse_market_valuation_rows(
+        payload=(
+            {"date": "2024-01-03", "per": "12.5", "pbr": "0.95"},
+            {"date": "2024-01-02", "per": "12.2", "pbr": "0.93"},
+        ),
+        market_caps_payload=({"date": "2024-01-02", "market_cap": "2110000000000000"},),
+        fetched_at_utc=FETCHED_AT.isoformat(),
+        connector_id="test.connector",
+    )
+
+    assert [(row.trade_date, row.market_capitalization) for row in rows] == [
+        (date(2024, 1, 2), Decimal("2110000000000000"))
+    ]

--- a/apps/kr-kospi/tests/integration/test_krx_live.py
+++ b/apps/kr-kospi/tests/integration/test_krx_live.py
@@ -5,6 +5,7 @@ from datetime import date
 import os
 
 import pytest
+from kpubdata import Client
 
 from kospi_decision_pipeline_app_kr_kospi.connectors.krx import (
     InvestorFlowRow,
@@ -66,7 +67,7 @@ def test_pykrx_krx_connector_live_fetch_methods_return_sorted_rows(
     fetcher: KrxFetcher,
     date_getter: Callable[[KospiIndexRow | InvestorFlowRow | MarketValuationRow], date],
 ) -> None:
-    connector = PykrxKrxConnector()
+    connector = PykrxKrxConnector(client=Client.from_env())
 
     rows = fetcher(connector, date(2024, 1, 2), date(2024, 1, 5))
 

--- a/apps/kr-kospi/tests/parity/test_v02_baseline.py
+++ b/apps/kr-kospi/tests/parity/test_v02_baseline.py
@@ -37,8 +37,9 @@ class _FakeDataset:
         start_date: object,
         end_date: object,
         frequency: object | None = None,
+        market: object | None = None,
     ) -> _FakeRecordBatch:
-        del start_date, end_date, frequency
+        del start_date, end_date, frequency, market
         return self._batch
 
 
@@ -49,43 +50,6 @@ class _FakeClient:
 
     def dataset(self, dataset_id: str) -> _FakeDataset:
         return self._datasets[dataset_id]
-
-
-class _FakeFrameIndex:
-    def __init__(self, values: tuple[object, ...]) -> None:
-        self._values = values
-
-    def tolist(self) -> list[object]:
-        return list(self._values)
-
-
-class _FakeFrameAtAccessor:
-    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
-        self._rows = rows
-
-    def __getitem__(self, key: tuple[object, str]) -> object:
-        index_value, column_name = key
-        return self._rows[index_value][column_name]
-
-
-class _FakeDataFrame:
-    def __init__(self, rows: dict[object, dict[str, object]]) -> None:
-        self._rows = rows
-
-    @property
-    def empty(self) -> bool:
-        return not self._rows
-
-    @property
-    def index(self) -> _FakeFrameIndex:
-        return _FakeFrameIndex(tuple(self._rows))
-
-    @property
-    def at(self) -> _FakeFrameAtAccessor:
-        return _FakeFrameAtAccessor(self._rows)
-
-    def sort_index(self) -> _FakeDataFrame:
-        return _FakeDataFrame(dict(sorted(self._rows.items(), key=lambda item: str(item[0]))))
 
 
 def _load_snapshot(name: str) -> dict[str, object]:
@@ -117,73 +81,70 @@ def _serialize(value: object) -> object:
     return value
 
 
-def _frame_from_payload(payload: object) -> _FakeDataFrame:
-    mapping = cast(dict[str, object], payload)
-    raw_rows = cast(list[dict[str, object]], mapping["rows"])
-    rows: dict[object, dict[str, object]] = {}
-    for raw_row in raw_rows:
-        rows[datetime.fromisoformat(str(raw_row["index"]))] = cast(
-            dict[str, object], raw_row["values"]
-        )
-    return _FakeDataFrame(rows)
-
-
-def _extract_ohlcv_payload(payload: object) -> object:
-    if isinstance(payload, Mapping):
-        mapping = cast(Mapping[str, object], payload)
-        ohlcv_payload = mapping.get("ohlcv")
-        if ohlcv_payload is not None:
-            return ohlcv_payload
-        return dict(mapping)
-    return payload
-
-
 def _extract_ecos_records(payload: object) -> tuple[Mapping[str, object], ...]:
     mapping = cast(Mapping[str, object], payload)
     statistic_search = cast(Mapping[str, object], mapping["StatisticSearch"])
     return tuple(cast(list[Mapping[str, object]], statistic_search.get("row", [])))
 
 
-class _ParityPykrxStockApi:
-    def __init__(self, payload: dict[str, object]) -> None:
-        self._payload = payload
+def _krx_row_date(raw_row: Mapping[str, object]) -> str:
+    return str(raw_row["index"])[:10]
 
-    def get_index_ohlcv_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        freq: str = "d",
-        name_display: bool = True,
-    ) -> _FakeDataFrame:
-        del fromdate, todate, ticker, freq, name_display
-        return _frame_from_payload(_extract_ohlcv_payload(self._payload["raw"]))
 
-    def get_market_trading_value_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        etf: bool = False,
-        etn: bool = False,
-        elw: bool = False,
-        on: str = "순매수",
-        detail: bool = False,
-        freq: str = "d",
-    ) -> _FakeDataFrame:
-        del fromdate, todate, ticker, etf, etn, elw, on, detail, freq
-        return _frame_from_payload(self._payload["raw"])
+def _extract_krx_kospi_items(snapshot: dict[str, object]) -> tuple[Mapping[str, object], ...]:
+    raw = cast(Mapping[str, object], snapshot["raw"])
+    rows_payload = raw.get("ohlcv", raw)
+    raw_rows = cast(list[Mapping[str, object]], cast(Mapping[str, object], rows_payload)["rows"])
+    return tuple(
+        {
+            "date": _krx_row_date(raw_row),
+            "open": cast(Mapping[str, object], raw_row["values"])["시가"],
+            "high": cast(Mapping[str, object], raw_row["values"])["고가"],
+            "low": cast(Mapping[str, object], raw_row["values"])["저가"],
+            "close": cast(Mapping[str, object], raw_row["values"])["종가"],
+            "volume": cast(Mapping[str, object], raw_row["values"])["거래량"],
+            "trading_value": cast(Mapping[str, object], raw_row["values"])["거래대금"],
+            "market_cap": cast(Mapping[str, object], raw_row["values"])["상장시가총액"],
+        }
+        for raw_row in raw_rows
+    )
 
-    def get_index_fundamental_by_date(
-        self,
-        fromdate: str,
-        todate: str,
-        ticker: str,
-        prev: bool = True,
-    ) -> _FakeDataFrame:
-        del fromdate, todate, ticker, prev
-        raw = cast(dict[str, object], self._payload["raw"])
-        return _frame_from_payload(raw["fundamental"])
+
+def _extract_krx_investor_items(snapshot: dict[str, object]) -> tuple[Mapping[str, object], ...]:
+    raw = cast(Mapping[str, object], snapshot["raw"])
+    raw_rows = cast(list[Mapping[str, object]], raw["rows"])
+    labels = (
+        ("개인", "개인"),
+        ("외국인합계", "외국인"),
+        ("기관합계", "기관"),
+    )
+    return tuple(
+        {
+            "date": _krx_row_date(raw_row),
+            "market": "KOSPI",
+            "investor_type": investor_type,
+            "net_value": cast(Mapping[str, object], raw_row["values"])[column_name],
+        }
+        for raw_row in raw_rows
+        for column_name, investor_type in labels
+    )
+
+
+def _extract_krx_market_valuation_items(
+    snapshot: dict[str, object],
+) -> tuple[Mapping[str, object], ...]:
+    raw = cast(Mapping[str, object], snapshot["raw"])
+    fundamental = cast(Mapping[str, object], raw["fundamental"])
+    raw_rows = cast(list[Mapping[str, object]], fundamental["rows"])
+    return tuple(
+        {
+            "date": _krx_row_date(raw_row),
+            "market": "KOSPI",
+            "per": cast(Mapping[str, object], raw_row["values"])["PER"],
+            "pbr": cast(Mapping[str, object], raw_row["values"])["PBR"],
+        }
+        for raw_row in raw_rows
+    )
 
 
 def _fetch_ecos_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
@@ -223,10 +184,25 @@ def _fetch_kosis_rows(snapshot_name: str) -> list[object]:
 def _fetch_krx_rows(snapshot_name: str, fetcher_name: str) -> list[object]:
     snapshot = _load_snapshot(snapshot_name)
     start, end = _load_window(snapshot)
-    connector = PykrxKrxConnector(
-        stock_api=_ParityPykrxStockApi(snapshot),
-        clock=lambda: FETCHED_AT,
+    datasets: dict[str, _FakeDataset] = {
+        "krx.kospi_index": _FakeDataset(()),
+        "krx.investor_flow": _FakeDataset(()),
+        "krx.market_valuation": _FakeDataset(()),
+    }
+    if fetcher_name == "fetch_kospi_index":
+        datasets["krx.kospi_index"] = _FakeDataset(_extract_krx_kospi_items(snapshot))
+    elif fetcher_name == "fetch_investor_flow":
+        datasets["krx.investor_flow"] = _FakeDataset(_extract_krx_investor_items(snapshot))
+    else:
+        datasets["krx.kospi_index"] = _FakeDataset(_extract_krx_kospi_items(snapshot))
+        datasets["krx.market_valuation"] = _FakeDataset(
+            _extract_krx_market_valuation_items(snapshot)
+        )
+    client = _FakeClient(
+        provider="krx",
+        datasets=datasets,
     )
+    connector = PykrxKrxConnector(client=cast(Client, client), clock=lambda: FETCHED_AT)
     return cast(list[object], list(getattr(connector, fetcher_name)(start, end)))
 
 
@@ -255,7 +231,7 @@ def test_v02_ecos_parity_snapshots_match_live_connector_normalization(
         ("krx_market_valuation.json", "fetch_market_valuation"),
     ],
 )
-def test_v02_krx_parity_snapshots_match_pykrx_connector_normalization(
+def test_v02_krx_parity_snapshots_match_live_connector_normalization(
     snapshot_name: str,
     fetcher_name: str,
 ) -> None:

--- a/apps/kr-kospi/tests/unit/test_client_factory.py
+++ b/apps/kr-kospi/tests/unit/test_client_factory.py
@@ -74,3 +74,11 @@ def test_returned_client_is_kpubdata_client(monkeypatch: pytest.MonkeyPatch) -> 
     client = build_client()
 
     assert isinstance(client, Client)
+
+
+def test_build_client_allows_authless_provider_sets(monkeypatch: pytest.MonkeyPatch) -> None:
+    _clear_auth_env(monkeypatch)
+
+    client = build_client(required_providers=())
+
+    assert isinstance(client, Client)


### PR DESCRIPTION
Closes #63

## Summary
- migrate the KRX connector to injected `kpubdata.Client` datasets for `krx.kospi_index`, `krx.investor_flow`, and `krx.market_valuation` while preserving normalized row parity
- rewrite KRX contract/parity/live tests around `client.dataset(...).list(...)` and add a regression test that locks the KRX `Dataset.list(**kwargs)` query shape
- scope auth requirements so KRX stays authless while ECOS/KOSIS still enforce their required kpubdata provider keys

## Verification
- `uv run --python 3.12 --extra dev pytest --cov=core/src --cov=apps/kr-kospi/src --cov-branch --cov-fail-under=100`
- `uv run --python 3.12 --extra dev pytest -m "not integration"`
- `uv run --python 3.12 --extra dev ruff check .`
- `uv run --python 3.12 --extra dev ruff format --check .`
- `uv run --python 3.12 --extra dev mypy --strict core/src apps/kr-kospi/src`